### PR TITLE
Grant workflows read-only repo contents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}-ci
     cancel-in-progress: true
 
+permissions:
+    contents: read
+
 jobs:
     linux:
         runs-on: ubuntu-latest

--- a/Sources/Strand/DB/Queries.swift
+++ b/Sources/Strand/DB/Queries.swift
@@ -168,7 +168,7 @@ enum Queries {
                 VALUES (\(namespaceID), \(taskID), \(queue), \(taskName), \(paramsBuffer),
                         \(headersBuffer), \(retryStrategyBuffer), \(maxAttempts),
                         \(timeoutSeconds), \(cancellationBuffer), \(idempotencyKey), \(priority),
-                        \(fairnessKey), \(fairnessWeight), 'PENDING',
+                        \(fairnessKey), \(fairnessWeight), \(TaskState.pending),
                         \(kind), \(parentTaskID), \(deadlineAt))
                 ON CONFLICT (namespace_id, queue, idempotency_key) DO NOTHING
                 """,
@@ -183,7 +183,7 @@ enum Queries {
                     """
                     INSERT INTO strand.runs (namespace_id, id, task_id, queue, attempt, state, available_at, priority,
                                            fairness_key, fairness_weight, kind)
-                    VALUES (\(namespaceID), \(runID), \(taskID), \(queue), 1, 'PENDING',
+                    VALUES (\(namespaceID), \(runID), \(taskID), \(queue), 1, \(TaskState.pending),
                             COALESCE(\(scheduledAt), NOW()), \(priority),
                             \(fairnessKey), \(fairnessWeight), \(kind))
                     """,
@@ -254,7 +254,7 @@ enum Queries {
                 JOIN strand.tasks t ON t.id = r.task_id
                 WHERE r.queue = \(queue)
                   AND r.namespace_id = \(namespaceID)
-                  AND r.state IN ('PENDING', 'SLEEPING')
+                  AND r.state IN (\(TaskState.pending), \(TaskState.sleeping))
                   AND r.available_at <= NOW()
                   AND (t.deadline_at IS NULL OR t.deadline_at > NOW())
                   AND (
@@ -264,7 +264,7 @@ enum Queries {
                           WHERE r2.queue        = r.queue
                             AND r2.namespace_id = r.namespace_id
                             AND r2.fairness_key = r.fairness_key
-                            AND r2.state IN ('PENDING', 'SLEEPING')
+                            AND r2.state IN (\(TaskState.pending), \(TaskState.sleeping))
                             AND r2.available_at <= NOW()
                             AND (
                                 r2.priority < r.priority
@@ -283,7 +283,7 @@ enum Queries {
             ),
             claimed AS (
                 UPDATE strand.runs r
-                SET state            = 'RUNNING',
+                SET state            = \(TaskState.running),
                     worker_id        = \(workerID),
                     lease_expires_at = NOW() + COALESCE(NULLIF(c.timeout_seconds, 0), \(claimTimeoutSeconds)) * INTERVAL '1 second',
                     started_at       = COALESCE(r.started_at, NOW())
@@ -292,7 +292,7 @@ enum Queries {
             ),
             task_upd AS (
                 UPDATE strand.tasks t
-                SET state        = 'RUNNING',
+                SET state        = \(TaskState.running),
                     attempt      = GREATEST(t.attempt, c.attempt),
                     first_run_at = COALESCE(t.first_run_at, NOW())
                 FROM claimed c WHERE t.id = c.task_id
@@ -337,22 +337,25 @@ enum Queries {
             if taskState == .cancelled { throw InternalError.cancelled }
 
             // CAS on version — if another worker already wrote a completion, bail out.
+            // The tasks update is gated on the runs CAS via the CTE: if r is empty
+            // (CAS failed), the WHERE subquery returns NULL and no task row is touched.
             let casStream = try await conn.query(
                 """
-                UPDATE strand.runs
-                SET state = 'COMPLETED', finished_at = NOW(), version = version + 1
-                WHERE id = \(runID) AND state = 'RUNNING' AND version = \(version)
-                  AND namespace_id = \(namespaceID)
+                WITH r AS (
+                    UPDATE strand.runs
+                    SET state = \(TaskState.completed), finished_at = NOW(), version = version + 1
+                    WHERE id = \(runID) AND state = \(TaskState.running) AND version = \(version)
+                      AND namespace_id = \(namespaceID)
+                    RETURNING task_id
+                )
+                UPDATE strand.tasks
+                SET state = \(TaskState.completed), completed_at = NOW(), result = \(resultBuffer)
+                WHERE id = (SELECT task_id FROM r)
                 RETURNING id
                 """,
                 logger: logger
             )
             guard try await casStream.first(where: { _ in true }) != nil else { return }
-
-            try await conn.query(
-                "UPDATE strand.tasks SET state = 'COMPLETED', completed_at = NOW(), result = \(resultBuffer) WHERE id = \(taskID)",
-                logger: logger
-            )
             try await conn.query(
                 "DELETE FROM strand.event_waits WHERE run_id = \(runID)",
                 logger: logger
@@ -396,7 +399,7 @@ enum Queries {
             // Guard: only fail if this run is still running.
             // If another worker already processed it, bail out silently.
             let failStream = try await conn.query(
-                "UPDATE strand.runs SET state = 'FAILED', failure_reason = \(reasonBuffer), finished_at = NOW() WHERE id = \(runID) AND state = 'RUNNING' RETURNING id",
+                "UPDATE strand.runs SET state = \(TaskState.failed), failure_reason = \(reasonBuffer), finished_at = NOW() WHERE id = \(runID) AND state = \(TaskState.running) RETURNING id",
                 logger: logger
             )
             guard try await failStream.first(where: { _ in true }) != nil else { return }
@@ -421,7 +424,7 @@ enum Queries {
                 if !nret.isEmpty && nret.contains(errorType) {
                     // Non-retryable error type — fail permanently, no retry
                     try await conn.query(
-                        "UPDATE strand.tasks SET state = 'FAILED', attempt = \(attempt) WHERE id = \(taskID) AND namespace_id = \(namespaceID)",
+                        "UPDATE strand.tasks SET state = \(TaskState.failed), attempt = \(attempt) WHERE id = \(taskID) AND namespace_id = \(namespaceID)",
                         logger: logger
                     )
                     try await emitTaskCompletionSignal(
@@ -440,7 +443,7 @@ enum Queries {
             if let deadline = deadlineAt, Date.now >= deadline {
                 // Total wall-clock budget exhausted — fail permanently
                 try await conn.query(
-                    "UPDATE strand.tasks SET state = 'FAILED', attempt = \(attempt) WHERE id = \(taskID) AND namespace_id = \(namespaceID)",
+                    "UPDATE strand.tasks SET state = \(TaskState.failed), attempt = \(attempt) WHERE id = \(taskID) AND namespace_id = \(namespaceID)",
                     logger: logger
                 )
                 try await emitTaskCompletionSignal(
@@ -457,7 +460,7 @@ enum Queries {
             let nextAttempt = attempt + 1
             guard maxAttempts == nil || nextAttempt <= maxAttempts! else {
                 try await conn.query(
-                    "UPDATE strand.tasks SET state = 'FAILED', attempt = \(attempt) WHERE id = \(taskID)",
+                    "UPDATE strand.tasks SET state = \(TaskState.failed), attempt = \(attempt) WHERE id = \(taskID)",
                     logger: logger
                 )
                 // Wake any awaitTaskResult callers.
@@ -502,11 +505,17 @@ enum Queries {
         logger: Logger
     ) async throws {
         try await client.query(
-            "UPDATE strand.runs SET state = 'SLEEPING', available_at = \(wakeAt), worker_id = NULL, lease_expires_at = NULL WHERE id = \(runID) AND namespace_id = \(namespaceID)",
-            logger: logger
-        )
-        try await client.query(
-            "UPDATE strand.tasks SET state = 'SLEEPING' WHERE id = \(taskID) AND namespace_id = \(namespaceID)",
+            """
+            WITH r AS (
+                UPDATE strand.runs
+                SET state = \(TaskState.sleeping), available_at = \(wakeAt),
+                    worker_id = NULL, lease_expires_at = NULL
+                WHERE id = \(runID) AND namespace_id = \(namespaceID)
+                RETURNING id
+            )
+            UPDATE strand.tasks SET state = \(TaskState.sleeping)
+            WHERE id = \(taskID) AND namespace_id = \(namespaceID)
+            """,
             logger: logger
         )
     }
@@ -521,7 +530,7 @@ enum Queries {
         logger: Logger
     ) async throws {
         let stream = try await client.query(
-            "UPDATE strand.runs SET lease_expires_at = NOW() + \(extendBySeconds) * INTERVAL '1 second' WHERE id = \(runID) AND state = 'RUNNING' AND namespace_id = \(namespaceID) RETURNING id",
+            "UPDATE strand.runs SET lease_expires_at = NOW() + \(extendBySeconds) * INTERVAL '1 second' WHERE id = \(runID) AND state = \(TaskState.running) AND namespace_id = \(namespaceID) RETURNING id",
             logger: logger
         )
         if try await stream.first(where: { _ in true }) == nil {
@@ -539,7 +548,7 @@ enum Queries {
         logger: Logger
     ) async throws {
         let stream = try await conn.query(
-            "UPDATE strand.runs SET lease_expires_at = NOW() + \(extendBySeconds) * INTERVAL '1 second' WHERE id = \(runID) AND state = 'RUNNING' AND namespace_id = \(namespaceID) RETURNING id",
+            "UPDATE strand.runs SET lease_expires_at = NOW() + \(extendBySeconds) * INTERVAL '1 second' WHERE id = \(runID) AND state = \(TaskState.running) AND namespace_id = \(namespaceID) RETURNING id",
             logger: logger
         )
         if try await stream.first(where: { _ in true }) == nil {
@@ -560,10 +569,10 @@ enum Queries {
             try await conn.query(
                 """
                 UPDATE strand.tasks
-                SET state = 'CANCELLED', cancelled_at = NOW()
+                SET state = \(TaskState.cancelled), cancelled_at = NOW()
                 WHERE id = \(taskID)
                   AND namespace_id = \(namespaceID)
-                  AND state NOT IN ('COMPLETED', 'FAILED', 'CANCELLED')
+                  AND state NOT IN (\(TaskState.completed), \(TaskState.failed), \(TaskState.cancelled))
                 """,
                 logger: logger
             )
@@ -576,10 +585,10 @@ enum Queries {
             try await conn.query(
                 """
                 UPDATE strand.runs
-                SET state = 'CANCELLED'
+                SET state = \(TaskState.cancelled)
                 WHERE task_id = \(taskID)
                   AND namespace_id = \(namespaceID)
-                  AND state IN ('PENDING', 'SLEEPING', 'WAITING', 'RUNNING')
+                  AND state IN (\(TaskState.pending), \(TaskState.sleeping), \(TaskState.waiting), \(TaskState.running))
                 """,
                 logger: logger
             )
@@ -601,9 +610,9 @@ enum Queries {
                     WHERE t.namespace_id = \(namespaceID)
                 )
                 UPDATE strand.tasks
-                SET state = 'CANCELLED', cancelled_at = NOW()
+                SET state = \(TaskState.cancelled), cancelled_at = NOW()
                 WHERE id IN (SELECT id FROM descendants)
-                  AND state NOT IN ('COMPLETED', 'FAILED', 'CANCELLED')
+                  AND state NOT IN (\(TaskState.completed), \(TaskState.failed), \(TaskState.cancelled))
                 """,
                 logger: logger
             )
@@ -622,10 +631,10 @@ enum Queries {
                     WHERE t.namespace_id = \(namespaceID)
                 )
                 UPDATE strand.runs
-                SET state = 'CANCELLED'
+                SET state = \(TaskState.cancelled)
                 WHERE task_id IN (SELECT id FROM descendants)
                   AND namespace_id = \(namespaceID)
-                  AND state IN ('PENDING', 'SLEEPING', 'WAITING', 'RUNNING')
+                  AND state IN (\(TaskState.pending), \(TaskState.sleeping), \(TaskState.waiting), \(TaskState.running))
                 """,
                 logger: logger
             )
@@ -840,31 +849,31 @@ enum Queries {
             if let timeoutAt {
                 try await conn.query(
                     """
-                    UPDATE strand.runs
-                    SET state = 'SLEEPING', available_at = \(timeoutAt),
-                        wake_event = \(eventName), event_payload = NULL,
-                        worker_id = NULL, lease_expires_at = NULL
-                    WHERE id = \(runID)
+                    WITH r AS (
+                        UPDATE strand.runs
+                        SET state = \(TaskState.sleeping), available_at = \(timeoutAt),
+                            wake_event = \(eventName), event_payload = NULL,
+                            worker_id = NULL, lease_expires_at = NULL
+                        WHERE id = \(runID)
+                        RETURNING id
+                    )
+                    UPDATE strand.tasks SET state = \(TaskState.sleeping) WHERE id = \(taskID)
                     """,
-                    logger: logger
-                )
-                try await conn.query(
-                    "UPDATE strand.tasks SET state = 'SLEEPING' WHERE id = \(taskID)",
                     logger: logger
                 )
             } else {
                 try await conn.query(
                     """
-                    UPDATE strand.runs
-                    SET state = 'WAITING',
-                        wake_event = \(eventName), event_payload = NULL,
-                        worker_id = NULL, lease_expires_at = NULL
-                    WHERE id = \(runID)
+                    WITH r AS (
+                        UPDATE strand.runs
+                        SET state = \(TaskState.waiting),
+                            wake_event = \(eventName), event_payload = NULL,
+                            worker_id = NULL, lease_expires_at = NULL
+                        WHERE id = \(runID)
+                        RETURNING id
+                    )
+                    UPDATE strand.tasks SET state = \(TaskState.waiting) WHERE id = \(taskID)
                     """,
-                    logger: logger
-                )
-                try await conn.query(
-                    "UPDATE strand.tasks SET state = 'WAITING' WHERE id = \(taskID)",
                     logger: logger
                 )
             }
@@ -910,11 +919,11 @@ enum Queries {
             }
             for wait in waits {
                 try await conn.query(
-                    "UPDATE strand.runs SET state = 'PENDING', available_at = NOW(), event_payload = \(payloadBuffer), wake_event = \(eventName), lease_expires_at = NULL WHERE id = \(wait.runID) AND state IN ('SLEEPING', 'WAITING') AND namespace_id = \(namespaceID)",
+                    "UPDATE strand.runs SET state = \(TaskState.pending), available_at = NOW(), event_payload = \(payloadBuffer), wake_event = \(eventName), lease_expires_at = NULL WHERE id = \(wait.runID) AND state IN (\(TaskState.sleeping), \(TaskState.waiting)) AND namespace_id = \(namespaceID)",
                     logger: logger
                 )
                 try await conn.query(
-                    "UPDATE strand.tasks SET state = 'PENDING' WHERE id = \(wait.taskID) AND namespace_id = \(namespaceID)",
+                    "UPDATE strand.tasks SET state = \(TaskState.pending) WHERE id = \(wait.taskID) AND namespace_id = \(namespaceID)",
                     logger: logger
                 )
             }
@@ -945,7 +954,7 @@ enum Queries {
             SELECT id FROM strand.runs
             WHERE namespace_id = \(namespaceID)
               AND queue        = \(queue)
-              AND state        = 'RUNNING'
+              AND state        = \(TaskState.running)
               AND lease_expires_at <= NOW()
             ORDER BY lease_expires_at, id
             LIMIT 50
@@ -996,7 +1005,7 @@ enum Queries {
             let stream = try await conn.query(
                 """
                 SELECT attempt, max_attempts FROM strand.tasks
-                WHERE id = \(taskID) AND state IN ('FAILED', 'CANCELLED')
+                WHERE id = \(taskID) AND state IN (\(TaskState.failed), \(TaskState.cancelled))
                   AND namespace_id = \(namespaceID)
                 FOR UPDATE
                 """,
@@ -1029,7 +1038,7 @@ enum Queries {
                 INSERT INTO strand.runs (namespace_id, id, task_id, queue, attempt, state, available_at,
                                        priority, fairness_key, fairness_weight,
                                        kind, parent_task_id)
-                SELECT namespace_id, \(newRunID), id, queue, \(nextAttempt), 'PENDING', NOW(),
+                SELECT namespace_id, \(newRunID), id, queue, \(nextAttempt), \(TaskState.pending), NOW(),
                        priority, fairness_key, fairness_weight,
                        kind, parent_task_id
                 FROM strand.tasks WHERE id = \(taskID) AND namespace_id = \(namespaceID)
@@ -1039,7 +1048,7 @@ enum Queries {
             try await conn.query(
                 """
                 UPDATE strand.tasks
-                SET state = 'PENDING', attempt = \(nextAttempt), max_attempts = \(newMaxAttempts)
+                SET state = \(TaskState.pending), attempt = \(nextAttempt), max_attempts = \(newMaxAttempts)
                 WHERE id = \(taskID)
                 """,
                 logger: logger
@@ -1050,7 +1059,7 @@ enum Queries {
                     """
                     UPDATE strand.runs
                     SET failure_reason = NULL
-                    WHERE task_id = \(taskID) AND state IN ('FAILED', 'CANCELLED')
+                    WHERE task_id = \(taskID) AND state IN (\(TaskState.failed), \(TaskState.cancelled))
                     """,
                     logger: logger
                 )
@@ -1076,7 +1085,7 @@ enum Queries {
                 """
                 SELECT name, queue, params, headers, retry_strategy, max_attempts,
                        cancellation, priority, fairness_key, fairness_weight, kind
-                FROM strand.tasks WHERE id = \(taskID) AND state = 'COMPLETED'
+                FROM strand.tasks WHERE id = \(taskID) AND state = \(TaskState.completed)
                   AND namespace_id = \(namespaceID)
                 FOR UPDATE
                 """,
@@ -1117,7 +1126,7 @@ enum Queries {
                      kind, state)
                 VALUES (\(newTaskID), \(namespaceID), \(queue), \(name), \(params),
                         \(headers), \(retryStrategy), \(maxAttempts), \(cancellation),
-                        \(priority), \(fairnessKey), \(fairnessWeight), \(kind), 'PENDING')
+                        \(priority), \(fairnessKey), \(fairnessWeight), \(kind), \(TaskState.pending))
                 """,
                 logger: logger
             )
@@ -1126,7 +1135,7 @@ enum Queries {
                 """
                 INSERT INTO strand.runs (namespace_id, id, task_id, queue, attempt, state, available_at,
                                         priority, fairness_key, fairness_weight, kind)
-                VALUES (\(namespaceID), \(newRunID), \(newTaskID), \(queue), 1, 'PENDING', NOW(),
+                VALUES (\(namespaceID), \(newRunID), \(newTaskID), \(queue), 1, \(TaskState.pending), NOW(),
                         \(priority), \(fairnessKey), \(fairnessWeight), \(kind))
                 """,
                 logger: logger
@@ -1203,20 +1212,22 @@ enum Queries {
                 """,
                 logger: logger
             )
-            // Wake the suspended run.
+            // Wake the suspended run and its parent task in one round trip.
             try await conn.query(
                 """
-                UPDATE strand.runs
-                SET state = 'PENDING', available_at = NOW(),
-                    event_payload = \(payloadBuf), wake_event = NULL,
-                    lease_expires_at = NULL
-                WHERE id = \(wait.runID) AND state IN ('SLEEPING', 'WAITING')
+                WITH r AS (
+                    UPDATE strand.runs
+                    SET state = \(TaskState.pending), available_at = NOW(),
+                        event_payload = \(payloadBuf), wake_event = NULL,
+                        lease_expires_at = NULL
+                    WHERE id = \(wait.runID) AND state IN (\(TaskState.sleeping), \(TaskState.waiting))
+                      AND namespace_id = \(namespaceID)
+                    RETURNING id
+                )
+                UPDATE strand.tasks SET state = \(TaskState.pending)
+                WHERE id = \(wait.taskID) AND state IN (\(TaskState.sleeping), \(TaskState.waiting))
                   AND namespace_id = \(namespaceID)
                 """,
-                logger: logger
-            )
-            try await conn.query(
-                "UPDATE strand.tasks SET state = 'PENDING' WHERE id = \(wait.taskID) AND state IN ('SLEEPING', 'WAITING') AND namespace_id = \(namespaceID)",
                 logger: logger
             )
         }

--- a/Sources/Strand/Worker.swift
+++ b/Sources/Strand/Worker.swift
@@ -89,7 +89,7 @@ public struct WorkerOptions: Sendable {
     public var fatalOnLeaseTimeout: Bool
 
     /// How long the worker waits for in-flight tasks to finish after receiving a
-    /// graceful-shutdown signal. Default: `.seconds(30)`.
+    /// graceful-shutdown signal. Default: `.seconds(10)`.
     public var gracefulShutdownTimeout: Duration
 
     /// Interval between expired-lease sweep passes. Default: `.seconds(5)`.
@@ -108,7 +108,7 @@ public struct WorkerOptions: Sendable {
         claimTimeout: Duration = .seconds(120),
         batchSize: Int? = nil,
         fatalOnLeaseTimeout: Bool = true,
-        gracefulShutdownTimeout: Duration = .seconds(30),
+        gracefulShutdownTimeout: Duration = .seconds(10),
         leaseExpiryInterval: Duration = .seconds(5),
         onError: (@Sendable (any Error) async -> Void)? = nil
     ) {
@@ -541,20 +541,21 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
 
                 case .startTimer(let wakeAt, _):
                     // Sleep: transition run to SLEEPING with available_at = wakeAt.
-                    try await exec.postgres.withTransaction(logger: exec.logger) { conn in
-                        try await conn.query(
-                            """
-                            UPDATE strand.runs SET state = 'SLEEPING', available_at = \(wakeAt),
+                    // Single CTE statement is atomic — no explicit transaction needed.
+                    try await exec.postgres.query(
+                        """
+                        WITH r AS (
+                            UPDATE strand.runs
+                            SET state = \(TaskState.sleeping), available_at = \(wakeAt),
                                 worker_id = NULL, lease_expires_at = NULL
                             WHERE id = \(claimed.runID)
-                            """,
-                            logger: exec.logger
+                            RETURNING id
                         )
-                        try await conn.query(
-                            "UPDATE strand.tasks SET state = 'SLEEPING' WHERE id = \(claimed.taskID)",
-                            logger: exec.logger
-                        )
-                    }
+                        UPDATE strand.tasks SET state = \(TaskState.sleeping)
+                        WHERE id = \(claimed.taskID)
+                        """,
+                        logger: exec.logger
+                    )
                     let timerData = try? JSON.encode([
                         "duration_ms": Int(wakeAt.timeIntervalSinceNow * 1000)
                     ])
@@ -570,18 +571,17 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
                     historySeq += 1
 
                 case .awaitEvent(let eventName, let seqNum, let timeoutAt):
-                    // Atomic check-or-wait: prevents a race where the event fires
-                    // between drain() returning and this transaction registering
-                    // the event_wait row.
+                    // Atomic check-or-wait: prevents the lost-wakeup race where the
+                    // event fires between drain() returning and this transaction committing.
                     //
-                    // Race being prevented:
-                    //   1. drain() finishes — handler suspended, emitted .awaitEvent command
-                    //   2. client.emitEvent(eventName) fires — finds NO event_wait yet — no run woken
-                    //   3. worker registers event_wait — run goes WAITING and stays there forever
+                    // Without this check:
+                    //   1. drain() returns — handler suspended, .awaitEvent command emitted
+                    //   2. client.emitEvent fires — finds no event_wait yet — run not woken
+                    //   3. worker inserts event_wait — run goes WAITING and stalls forever
                     //
-                    // Fix: inside ONE transaction, check strand.events first. If the event is
-                    // already there, set the run to PENDING immediately (not WAITING) with
-                    // wake_event=eventName. The next activation fast-paths through waitForEvent.
+                    // Both operations live in the same transaction: insert the event_wait
+                    // and check strand.events. If the event is already there, go PENDING
+                    // immediately so the next activation fast-paths through waitForEvent.
                     let taskID = claimed.taskID
                     let runID = claimed.runID
                     let queueName = exec.queue
@@ -621,11 +621,11 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
                             )
 
                             // Transition to PENDING with the event payload so the next
-                            // activation’s waitForEvent fast-path (wakeEvent == name) fires.
+                            // activation's waitForEvent fast-path (wakeEvent == name) fires.
                             try await conn.query(
                                 """
                                 UPDATE strand.runs
-                                SET state        = 'PENDING',
+                                SET state        = \(TaskState.pending),
                                     available_at  = NOW(),
                                     wake_event    = \(eventName),
                                     event_payload = \(existingPayload),
@@ -636,14 +636,14 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
                                 logger: exec.logger
                             )
                             try await conn.query(
-                                "UPDATE strand.tasks SET state = 'PENDING' WHERE id = \(taskID)",
+                                "UPDATE strand.tasks SET state = \(TaskState.pending) WHERE id = \(taskID)",
                                 logger: exec.logger
                             )
                         } else {
                             // Event not yet emitted — set run to WAITING (or SLEEPING for timed waits).
                             let availableAt =
                                 timeoutAt ?? Date(timeIntervalSince1970: 32_503_680_000)
-                            let runState = timeoutAt != nil ? "SLEEPING" : "WAITING"
+                            let runState: TaskState = timeoutAt != nil ? .sleeping : .waiting
                             try await conn.query(
                                 """
                                 UPDATE strand.runs
@@ -727,6 +727,20 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
 
             // Register event_waits for all enqueued activities / child workflows,
             // then transition the run to WAITING (event-driven, no timer).
+            //
+            // Atomic check-or-wait: prevents the lost-wakeup race where a child
+            // task completes between enqueueTask() committing and this transaction
+            // committing.
+            //
+            // Without this check:
+            //   1. enqueueTask() commits — child task visible to activity workers
+            //   2. Activity worker claims, runs, and completes it immediately
+            //   3. emitTaskCompletionSignal finds no event_wait — parent not woken
+            //   4. This transaction commits — run goes WAITING and stalls forever
+            //
+            // Both the event_wait inserts and a task_completions count live in the
+            // same transaction. If all children are already done, go PENDING immediately;
+            // the next poll re-activates the workflow. Remaining event_waits fire normally.
             if !enqueued.isEmpty {
                 try await exec.postgres.withTransaction(logger: exec.logger) { conn in
                     for item in enqueued {
@@ -741,18 +755,56 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
                             logger: exec.logger
                         )
                     }
-                    try await conn.query(
+
+                    // Atomically check whether any child tasks already completed
+                    // (i.e. are present in task_completions) before we park the run.
+                    let childTaskIDs = enqueued.map { $0.taskID }
+                    let completedStream = try await conn.query(
                         """
-                        UPDATE strand.runs
-                        SET state = 'WAITING', worker_id = NULL, lease_expires_at = NULL
-                        WHERE id = \(claimed.runID)
+                        SELECT COUNT(*) FROM strand.task_completions
+                        WHERE task_id = ANY(\(childTaskIDs))
                         """,
                         logger: exec.logger
                     )
-                    try await conn.query(
-                        "UPDATE strand.tasks SET state = 'WAITING' WHERE id = \(claimed.taskID)",
-                        logger: exec.logger
-                    )
+                    var completedCount = 0
+                    for try await row in completedStream {
+                        var col = row.makeIterator()
+                        completedCount = try col.next()!.decode(Int.self, context: .default)
+                    }
+
+                    if completedCount == enqueued.count {
+                        // All children already finished — go PENDING so the next poll
+                        // re-activates immediately rather than waiting for events that
+                        // already fired and were missed.
+                        try await conn.query(
+                            """
+                            WITH r AS (
+                                UPDATE strand.runs
+                                SET state = \(TaskState.pending), available_at = NOW(),
+                                    worker_id = NULL, lease_expires_at = NULL
+                                WHERE id = \(claimed.runID)
+                                RETURNING id
+                            )
+                            UPDATE strand.tasks SET state = \(TaskState.pending)
+                            WHERE id = \(claimed.taskID)
+                            """,
+                            logger: exec.logger
+                        )
+                    } else {
+                        try await conn.query(
+                            """
+                            WITH r AS (
+                                UPDATE strand.runs
+                                SET state = \(TaskState.waiting), worker_id = NULL, lease_expires_at = NULL
+                                WHERE id = \(claimed.runID)
+                                RETURNING id
+                            )
+                            UPDATE strand.tasks SET state = \(TaskState.waiting)
+                            WHERE id = \(claimed.taskID)
+                            """,
+                            logger: exec.logger
+                        )
+                    }
                 }
             }
         }
@@ -773,14 +825,14 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
                     try await conn.query(
                         """
                         UPDATE strand.runs
-                        SET state = 'SLEEPING', available_at = \(wakeAt),
+                        SET state = \(TaskState.sleeping), available_at = \(wakeAt),
                             worker_id = NULL, lease_expires_at = NULL
                         WHERE id = \(condRunID)
                         """,
                         logger: exec.logger
                     )
                     try await conn.query(
-                        "UPDATE strand.tasks SET state = 'SLEEPING' WHERE id = \(condTaskID)",
+                        "UPDATE strand.tasks SET state = \(TaskState.sleeping) WHERE id = \(condTaskID)",
                         logger: exec.logger
                     )
                 }
@@ -790,13 +842,13 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
                     try await conn.query(
                         """
                         UPDATE strand.runs
-                        SET state = 'WAITING', worker_id = NULL, lease_expires_at = NULL
+                        SET state = \(TaskState.waiting), worker_id = NULL, lease_expires_at = NULL
                         WHERE id = \(condRunID)
                         """,
                         logger: exec.logger
                     )
                     try await conn.query(
-                        "UPDATE strand.tasks SET state = 'WAITING' WHERE id = \(condTaskID)",
+                        "UPDATE strand.tasks SET state = \(TaskState.waiting) WHERE id = \(condTaskID)",
                         logger: exec.logger
                     )
                 }
@@ -815,10 +867,13 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
         // No else branch: if scheduleCommands is empty and no conditions remain,
         // suspension came from sleep/waitForEvent which already wrote their own DB updates.
 
-        // ── 8. Cancel continuations + flush ─────────────────────────────────────────────
-        // Resume all parked continuations with StrandError.cancelled. This unblocks the
-        // handler task (which catches the error and sets handlerResult). Drain once more
-        // to run those cleanup jobs, then discard the task.
+        // ── 8. Signal handler exit ───────────────────────────────────────────────────────
+        // cancelPending() resumes every parked continuation with StrandError.cancelled.
+        // Each suspended runActivity / sleep / waitForEvent call receives that error,
+        // allowing the handler Task to finish and record its result in handlerResult.
+        // drain() flushes any final jobs the handler emits during that teardown.
+        // handlerTask.cancel() is a safety net for the (unreachable in practice) path
+        // where the handler didn't park any continuation and exited before this point.
         executor.cancelPending()
         executor.drain()
         handlerTask.cancel()
@@ -1032,7 +1087,7 @@ public struct StrandWorker: Service {
                             SET lease_expires_at = NOW()
                             WHERE worker_id     = \(workerID)
                               AND namespace_id  = \(self.namespace)
-                              AND state         = 'RUNNING'
+                              AND state         = \(TaskState.running)
                             """,
                             logger: self.logger
                         )
@@ -1053,20 +1108,14 @@ public struct StrandWorker: Service {
 
     /// Continuously claims and executes tasks using a slot-aware dispatch loop.
     ///
-    /// ## Architecture: continuous-fill vs batch-and-wait
+    /// The loop runs as the body of a `withThrowingDiscardingTaskGroup`. On each
+    /// iteration it claims up to `free = maxConcurrency - running` tasks and starts
+    /// each as an independent group child. When a child finishes it decrements the
+    /// counter and signals `_SlotSignal`, waking the loop to claim the next batch
+    /// without waiting for other in-flight tasks to complete.
     ///
-    /// The previous implementation used `await withTaskGroup { … }` which blocked
-    /// until ALL claimed tasks finished before claiming more. If 149 tasks completed
-    /// in 1 second but one workflow was sleeping for an hour, 149 slots sat idle.
-    ///
-    /// The new design uses `withThrowingDiscardingTaskGroup` — the dispatch loop runs as the group body
-    /// and claims up to `freeSlots` tasks on each iteration. Each execution task
-    /// decrements the running counter and signals `SlotSignal` when it finishes,
-    /// waking the dispatcher to claim more work immediately.
-    ///
-    /// `SlotSignal` is a `Mutex`-backed async wakeup. It uses
-    /// `withTaskCancellationHandler` + explicit `onCancel` resume,
-    /// so it never leaks a `_runTimer` continuation.
+    /// When all slots are occupied the loop parks on `_SlotSignal` — a
+    /// `Mutex`-backed async wakeup that resumes as soon as any slot is freed.
     private func pollLoop(workerID: String) async throws {
         let queueName = options.queue
         let maxConcurrency =
@@ -1152,7 +1201,10 @@ public struct StrandWorker: Service {
                         await self.runTask(claimedTask)
                     }
                 }
-                // Immediately re-check: there may be slots left if claimed < free.
+                // No explicit sleep: fall through to re-poll immediately.
+                // If claimed.count < free there is still open capacity for another
+                // batch. If claimed.count == free the next iteration finds free == 0
+                // and blocks on slotFreeSignal until a running task finishes.
             }
         }
     }
@@ -1224,9 +1276,9 @@ public struct StrandWorker: Service {
             ("queue", options.queue),
         ]
 
-        // ── Race execution against 2× timeout ─────────────────
-        // Both run as structured children — cancellation propagates cleanly when
-        // the first finishes, with no exit(1) and no leaked continuations.
+        // ── Race execution against 2× timeout ─────────────────────────
+        // Execution and deadline enforcement run as structured children of the
+        // same group — whichever finishes first cancels the other cleanly.
         do {
             let resultBuf: ByteBuffer? = try await withThrowingTaskGroup(of: ByteBuffer?.self) {
                 group in
@@ -1262,10 +1314,7 @@ public struct StrandWorker: Service {
                     }
                 }
 
-                // Task 2: deadline poller — two thresholds, both pure Swift concurrency.
-                // No GCD, no LeaseWatchdog, no Task.sleep-based continuations outside
-                // structured concurrency.
-                //
+                // Task 2: deadline poller — two escalating thresholds:
                 //   1× claimTimeout → log a warning (task is running long)
                 //   2× claimTimeout → cancel execution (fatalDeadline expired)
                 group.addTask {
@@ -1331,9 +1380,9 @@ public struct StrandWorker: Service {
                 label: StrandMetrics.tasksContinuedAsNew,
                 dimensions: taskDims
             ).increment(by: 1)
-            // Workflow called context.continueAsNew(input:). Enqueue a fresh task with the
-            // new input, then complete the current run cleanly. The old task's checkpoints
-            // and history are retained until client.cleanup() prunes them.
+            // context.continueAsNew(input:): enqueue a fresh task with the new input
+            // and complete the current run. The old task's checkpoints and history
+            // are retained until client.cleanup() prunes them.
             do {
                 _ = try await Queries.enqueueTask(
                     on: postgres,

--- a/Tests/StrandTests/IntegrationTests.swift
+++ b/Tests/StrandTests/IntegrationTests.swift
@@ -825,17 +825,7 @@ struct ParallelActivityTests {
                 options: .init(),
                 input: "hello"
             )
-            // Use awaitTerminal (fixed 80 ms poll, no exponential backoff) so that
-            // a slow CI runner doesn't hit a 2-second polling gap after the workflow
-            // completes. handle.result backs off to 2 s which makes the test fragile
-            // under load. 60 s is an ample ceiling for the actual work (~200 ms).
-            let snap = try await awaitTerminal(
-                client: client,
-                taskID: handle.taskID,
-                timeout: .seconds(60)
-            )
-            #expect(snap.state == .completed)
-            let result = try snap.decodeResult(as: [String].self)
+            let result = try await handle.result(timeout: .seconds(10))
 
             // Both activities ran exactly once
             #expect(DoubleActivity.counter.value == 1)


### PR DESCRIPTION
## Summary

Add explicit permissions block to CI workflow giving GITHUB_TOKEN read access to repository contents. This reduces token privileges to follow least-privilege practices while allowing actions that need to read repo files; no write permissions are granted.

## Changes

None

## Testing

<!-- How did you verify this works? Did you run `swift test`? -->

- [ ] `swift test` passes locally

## AI Disclosure

<!--
  REQUIRED if any AI assistance was used — see CONTRIBUTING.md.
  Delete this section entirely if no AI was involved.
-->

- [ ] I used AI assistance while working on this PR

**Tool(s) used:** <!-- e.g. Claude, Copilot, ChatGPT -->

**Extent of use:**
<!-- Describe honestly. Examples:
  - Generated first draft of WorkflowDag.tsx, reviewed and edited manually.
  - Used for commit message suggestions only.
  - Pair-programmed the entire feature; all output was reviewed.
-->

**Was the PR description itself AI-generated?** 
No
