### PR TITLE
Add LISTEN/NOTIFY wakeups and notify jitter

### DIFF
--- a/Examples/Sources/DevServer/DevServer.swift
+++ b/Examples/Sources/DevServer/DevServer.swift
@@ -131,17 +131,26 @@ struct GreetUserWorkflow: Workflow {
 
 private func makePostgres(logger: Logger) -> PostgresClient {
     let env = ProcessInfo.processInfo.environment
-    return PostgresClient(
-        configuration: .init(
-            host: env["POSTGRES_HOST"] ?? "localhost",
-            port: Int(env["POSTGRES_PORT"] ?? "5499") ?? 5499,
-            username: env["POSTGRES_USER"] ?? "strand",
-            password: env["POSTGRES_PASSWORD"] ?? "strand",
-            database: env["POSTGRES_DB"] ?? "strand_dev",
-            tls: .disable
-        ),
-        backgroundLogger: logger
+    let host = env["POSTGRES_HOST"] ?? "localhost"
+    let port = Int(env["POSTGRES_PORT"] ?? "5499") ?? 5499
+    let user = env["POSTGRES_USER"] ?? "strand"
+    let pass = env["POSTGRES_PASSWORD"] ?? "strand"
+    let db = env["POSTGRES_DB"] ?? "strand_dev"
+
+    var config = PostgresClient.Configuration(
+        host: host,
+        port: port,
+        username: user,
+        password: pass,
+        database: db,
+        tls: .disable
     )
+    // Pool sizing: Σ(activityConcurrency) + Σ(workflowConcurrency)
+    //            + N workers × 3 (listenLoop + poll + lease)
+    //            + headroom for HTTP handlers
+    // ordersWorker (16+8) + reportsWorker (8+4) + 2×3 + 8 HTTP = 50
+    config.options.maximumConnections = 50
+    return PostgresClient(configuration: config, backgroundLogger: logger)
 }
 
 // MARK: - Seeder
@@ -303,9 +312,13 @@ private func seedOne(orders: StrandClient, logger: Logger) async {
                 queue: "orders",
                 workflowConcurrency: 8,
                 activityConcurrency: 16,
-                pollInterval: .milliseconds(100),
+                // pollInterval is a fallback for LISTEN/NOTIFY misses (timer fires,
+                // brief reconnect window). 5 s is plenty — NOTIFY handles the fast path.
+                pollInterval: .seconds(5),
                 claimTimeout: .seconds(60),
-                leaseExpiryInterval: .seconds(5)
+                leaseExpiryInterval: .seconds(5),
+                // Only 2 workers on this server — no thundering herd, no jitter needed.
+                notifyJitter: .zero
             ),
             workflows: [
                 ProcessOrderWorkflow.self,
@@ -321,9 +334,10 @@ private func seedOne(orders: StrandClient, logger: Logger) async {
                 queue: "reports",
                 workflowConcurrency: 4,
                 activityConcurrency: 8,
-                pollInterval: .milliseconds(250),
+                pollInterval: .seconds(5),
                 claimTimeout: .seconds(120),
-                leaseExpiryInterval: .seconds(5)
+                leaseExpiryInterval: .seconds(5),
+                notifyJitter: .zero
             ),
             workflows: [GenerateReportWorkflow.self],
             logger: logger

--- a/Sources/Strand/DB/Queries.swift
+++ b/Sources/Strand/DB/Queries.swift
@@ -202,6 +202,14 @@ enum Queries {
                         "strand.kind": .string(kind.rawValue),
                     ]
                 )
+                // Notify any listening workers that a new task is available for this queue.
+                // pg_notify is transactional — the notification is only delivered after this
+                // transaction commits, so listeners always see a task that can be claimed.
+                let notification = StrandChannels.Notification(namespace: namespaceID, queue: queue)
+                try await conn.query(
+                    "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
+                    logger: logger
+                )
                 return EnqueueRow(taskID: taskID, runID: runID, attempt: 1, created: true)
             } else {
                 let existStream = try await conn.query(
@@ -516,6 +524,22 @@ enum Queries {
                 "UPDATE strand.tasks SET state = \(newState), attempt = \(nextAttempt) WHERE id = \(taskID)",
                 logger: logger
             )
+            // Only notify when the retry is immediately runnable (no sleep delay).
+            if newState == .pending {
+                let qStream = try await conn.query(
+                    "SELECT queue FROM strand.runs WHERE id = \(runID)",
+                    logger: logger
+                )
+                if let qRow = try await qStream.first(where: { _ in true }) {
+                    var qCol = qRow.makeIterator()
+                    let q = try qCol.next()!.decode(String.self, context: .default)
+                    let notification = StrandChannels.Notification(namespace: namespaceID, queue: q)
+                    try await conn.query(
+                        "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
+                        logger: logger
+                    )
+                }
+            }
         }
     }
 
@@ -955,6 +979,14 @@ enum Queries {
                 "DELETE FROM strand.event_waits WHERE queue = \(queue) AND event_name = \(eventName)",
                 logger: logger
             )
+            if !waits.isEmpty {
+                // Wake workers: runs transitioned to PENDING above.
+                let notification = StrandChannels.Notification(namespace: namespaceID, queue: queue)
+                try await conn.query(
+                    "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
+                    logger: logger
+                )
+            }
         }
     }
 
@@ -1025,6 +1057,11 @@ enum Queries {
             logger.warning(
                 "re-queued \(count) run(s) with expired lease—worker was likely restarted",
                 metadata: ["queue": "\(queue)"]
+            )
+            let notification = StrandChannels.Notification(namespace: namespaceID, queue: queue)
+            try await client.query(
+                "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
+                logger: logger
             )
         }
     }
@@ -1097,18 +1134,23 @@ enum Queries {
                   AND namespace_id = \(namespaceID)
             ),
             del_event_waits AS (
-                -- Remove the child’s OWN event_waits (activities / timers it was
-                -- waiting for). The parent’s event_wait is on the parent’s run_id
+                -- Remove the child's OWN event_waits (activities / timers it was
+                -- waiting for). The parent's event_wait is on the parent's run_id
                 -- and is not touched.
                 DELETE FROM strand.event_waits
                 WHERE task_id = (SELECT task_id FROM complete_run)
+            ),
+            new_run AS (
+                INSERT INTO strand.runs
+                    (id, namespace_id, task_id, queue, attempt, state,
+                     available_at, created_at, priority, fairness_key, fairness_weight, kind)
+                SELECT \(newRunID), \(namespaceID), id, queue, 1, 'PENDING',
+                       NOW(), NOW(), priority, fairness_key, fairness_weight, kind
+                FROM reset_task
+                RETURNING namespace_id, queue
             )
-            INSERT INTO strand.runs
-                (id, namespace_id, task_id, queue, attempt, state,
-                 available_at, created_at, priority, fairness_key, fairness_weight, kind)
-            SELECT \(newRunID), \(namespaceID), id, queue, 1, 'PENDING',
-                   NOW(), NOW(), priority, fairness_key, fairness_weight, kind
-            FROM reset_task
+            SELECT pg_notify(\(StrandChannels.tasks), namespace_id || '/' || queue)
+            FROM new_run
             """,
             logger: logger
         )
@@ -1186,6 +1228,19 @@ enum Queries {
                     SET failure_reason = NULL
                     WHERE task_id = \(taskID) AND state IN (\(TaskState.failed), \(TaskState.cancelled))
                     """,
+                    logger: logger
+                )
+            }
+            let qStream = try await conn.query(
+                "SELECT queue FROM strand.tasks WHERE id = \(taskID) AND namespace_id = \(namespaceID)",
+                logger: logger
+            )
+            if let qRow = try await qStream.first(where: { _ in true }) {
+                var qCol = qRow.makeIterator()
+                let q = try qCol.next()!.decode(String.self, context: .default)
+                let notification = StrandChannels.Notification(namespace: namespaceID, queue: q)
+                try await conn.query(
+                    "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
                     logger: logger
                 )
             }
@@ -1267,7 +1322,11 @@ enum Queries {
                 """,
                 logger: logger
             )
-
+            let notification = StrandChannels.Notification(namespace: namespaceID, queue: queue)
+            try await conn.query(
+                "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
+                logger: logger
+            )
             return EnqueueRow(taskID: newTaskID, runID: newRunID, attempt: 1, created: true)
         }
     }
@@ -1329,13 +1388,18 @@ enum Queries {
                 USING  woken k
                 WHERE  ew.child_task_id = \(taskID)
                   AND  ew.run_id        = k.run_id
+            ),
+            task_upd AS (
+                UPDATE strand.tasks t SET state = \(TaskState.pending)
+                FROM   woken k
+                JOIN   waits w ON w.run_id = k.run_id
+                WHERE  t.id           = w.parent_task_id
+                  AND  t.state        IN (\(TaskState.sleeping), \(TaskState.waiting))
+                  AND  t.namespace_id = \(namespaceID)
+                RETURNING t.namespace_id, t.queue
             )
-            UPDATE strand.tasks t SET state = \(TaskState.pending)
-            FROM   woken k
-            JOIN   waits w ON w.run_id = k.run_id
-            WHERE  t.id           = w.parent_task_id
-              AND  t.state        IN (\(TaskState.sleeping), \(TaskState.waiting))
-              AND  t.namespace_id = \(namespaceID)
+            SELECT pg_notify(\(StrandChannels.tasks), namespace_id || '/' || queue)
+            FROM task_upd
             """,
             logger: logger
         )

--- a/Sources/Strand/Internal/StrandMetrics.swift
+++ b/Sources/Strand/Internal/StrandMetrics.swift
@@ -48,6 +48,45 @@ public enum StrandMetrics {
     public static let tasksContinuedAsNew = "strand.tasks.continued_as_new"
 }
 
+// MARK: - LISTEN/NOTIFY channel names
+
+/// Internal PostgreSQL channel names and payload type for LISTEN/NOTIFY wakeups.
+enum StrandChannels {
+    /// Channel on which workers LISTEN and `enqueueTask` sends NOTIFY.
+    static let tasks = "strand_tasks"
+
+    // MARK: - Payload type
+
+    /// A typed NOTIFY payload carrying a `(namespace, queue)` pair.
+    ///
+    /// Wire format: `"<namespace>/<queue>"`. Splitting on the first `/` allows
+    /// a queue name that contains `/` as long as the namespace does not
+    /// (namespace IDs are plain identifiers validated by a Postgres FK).
+    struct Notification: Sendable {
+        let namespace: String
+        let queue: String
+
+        /// Creates a notification for the given namespace and queue.
+        init(namespace: String, queue: String) {
+            self.namespace = namespace
+            self.queue = queue
+        }
+
+        /// Parses a raw NOTIFY payload. Returns `nil` if the format is unrecognised.
+        init?(payload: String) {
+            guard let slash = payload.firstIndex(of: "/") else { return nil }
+            let ns = String(payload[..<slash])
+            let q = String(payload[payload.index(after: slash)...])
+            guard !ns.isEmpty, !q.isEmpty else { return nil }
+            self.namespace = ns
+            self.queue = q
+        }
+
+        /// The encoded string passed as the `pg_notify` payload.
+        var payload: String { "\(namespace)/\(queue)" }
+    }
+}
+
 // MARK: - Helpers
 
 extension Duration {

--- a/Sources/Strand/Internal/WorkflowScheduling.swift
+++ b/Sources/Strand/Internal/WorkflowScheduling.swift
@@ -324,6 +324,12 @@ extension WorkflowRegistration {
                                 """,
                                 logger: exec.logger
                             )
+                            // Run is PENDING — notify workers to claim immediately.
+                            let notification = StrandChannels.Notification(namespace: exec.namespace, queue: queueName)
+                            try await conn.query(
+                                "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
+                                logger: exec.logger
+                            )
                         } else {
                             // Event not yet emitted — set run to WAITING (or SLEEPING for timed waits).
                             let availableAt =
@@ -473,6 +479,12 @@ extension WorkflowRegistration {
                             """,
                             logger: exec.logger
                         )
+                        // Run is PENDING — notify workers immediately.
+                        let notification = StrandChannels.Notification(namespace: exec.namespace, queue: exec.queue)
+                        try await conn.query(
+                            "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
+                            logger: exec.logger
+                        )
                     } else {
                         try await conn.query(
                             """
@@ -591,6 +603,14 @@ extension WorkflowRegistration {
                 WHERE id = \(claimed.taskID)
                   AND namespace_id = \(exec.namespace)
                 """,
+                logger: exec.logger
+            )
+            // Notify speculatively: if the run went PENDING (missed > 0) workers should
+            // claim it immediately. If it went WAITING the notification is a spurious
+            // wakeup that costs at most one empty poll — acceptable.
+            let notification = StrandChannels.Notification(namespace: exec.namespace, queue: exec.queue)
+            try await exec.postgres.query(
+                "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
                 logger: exec.logger
             )
         }

--- a/Sources/Strand/Strand.docc/WorkerTuning.md
+++ b/Sources/Strand/Strand.docc/WorkerTuning.md
@@ -173,31 +173,48 @@ try await context.runActivity(
 
 ---
 
-## Poll interval
+## LISTEN/NOTIFY and the poll interval
 
-`pollInterval` controls how long the worker sleeps between claim attempts when
-the queue is empty.
+Workers hold a dedicated PostgreSQL `LISTEN` connection and wake up the
+moment a task becomes `PENDING`. Every path that creates a pending run —
+`enqueueTask`, `emitTaskCompletionSignal`, `emitEvent`, `retryTask`, and
+others — sends `pg_notify('strand_tasks', '<namespace>/<queue>')` inside its
+transaction. The notification is only delivered after the transaction commits,
+so the worker always sees a claimable row.
 
-```swift
-WorkerOptions(pollInterval: .milliseconds(100))  // default
-```
+### `pollInterval` — safety-net fallback only
 
-**Tradeoffs:**
+With LISTEN/NOTIFY active, `pollInterval` (default: `5 s`) fires only for
+two edge cases:
+- The LISTEN connection was briefly down during the 1-second reconnect
+  back-off.
+- A `SLEEPING` task's `available_at` fired (timer expiry). Timer wakeups
+  are driven by `available_at <= NOW()` in `claimTasks` — no `NOTIFY` is
+  sent for this transition, so the fallback poll catches them.
 
-| Value | Latency | Postgres load |
-|---|---|---|
-| 50 ms | Very low | Higher (~20 req/s per worker) |
-| 100 ms | Low (default) | Moderate (~10 req/s) |
-| 500 ms | Acceptable for batch | Low |
-| 1 s | Background jobs only | Minimal |
+Keep `pollInterval` at a few seconds. Sub-100 ms values add unnecessary DB
+load without reducing task-pickup latency — NOTIFY handles the fast path.
 
-With the **continuous-fill** dispatch loop, `pollInterval` only fires when the
-queue returns empty. When work is available, polling is continuous — a freed
-slot triggers an immediate re-claim without sleeping. The interval therefore
-only affects **latency for newly-arrived tasks on an otherwise idle worker**.
+### `notifyJitter` — thundering-herd mitigation
 
-Future: LISTEN/NOTIFY will make this sleep unnecessary for the common case
-(new task arrives while worker is idle) — see ``BootOrder``.
+`NOTIFY` is broadcast: every worker on the queue wakes simultaneously. With
+hundreds of workers, a single enqueue can trigger hundreds of concurrent
+`claimTasks` queries. `notifyJitter` (default: `50 ms`) applies a random
+delay drawn from `[0, notifyJitter]` **only on NOTIFY wakeups** so claims
+spread across the window instead of hitting Postgres all at once.
+
+Tuning formula: keep `N / W_ms ≈ 2–5` concurrent claims.
+
+| Workers | `notifyJitter` |
+|---------|----------------|
+| 1 | `.zero` |
+| ≤ 10 | `.milliseconds(20)` |
+| ≤ 100 | `.milliseconds(100)` |
+| 300+ | `.milliseconds(300)` |
+
+`FOR UPDATE SKIP LOCKED` guarantees correctness regardless of jitter — each
+row is claimed by exactly one worker. Jitter is a load knob, not a
+correctness requirement.
 
 ---
 
@@ -304,8 +321,9 @@ WorkerOptions(
     queue:                "api",
     workflowConcurrency:  16,
     activityConcurrency:  64,
-    claimTimeout:         .seconds(15),
-    pollInterval:         .milliseconds(50)
+    claimTimeout:         .seconds(15)
+    // pollInterval left at default (5 s) — LISTEN/NOTIFY handles fast wakeup;
+    // tune notifyJitter based on how many workers share this queue.
 )
 ```
 

--- a/Sources/Strand/Worker.swift
+++ b/Sources/Strand/Worker.swift
@@ -112,11 +112,17 @@ public struct WorkerOptions: Sendable {
     /// resources. Jitter spreads the herd across a window so only the first few
     /// workers to fire actually find tasks, and the rest skip the round-trip.
     ///
-    /// Tuning guidance:
-    /// - 0 workers / single worker: `.zero` (no overhead)
-    /// - ~10 workers: `.milliseconds(20)` — 2‐3 concurrent claims on average
-    /// - ~100 workers: `.milliseconds(100)` — a few concurrent claims
-    /// - 300+ workers: `.milliseconds(300)`
+    /// With a jitter window of W ms and N workers, the average number of
+    /// concurrent claims after one notification is:
+    ///
+    ///     concurrent_claims ≈ N / W_ms
+    ///
+    /// Keep this around 2–5 to avoid unnecessary DB load:
+    ///
+    /// - 1 worker: `.zero` (no overhead)
+    /// - ~10 workers: `.milliseconds(20)` — ~2–3 concurrent claims
+    /// - ~100 workers: `.milliseconds(100)` — ~2–3 concurrent claims
+    /// - 300+ workers: `.milliseconds(300)` — ~2–3 concurrent claims
     ///
     /// Jitter is **not** applied to the fallback `pollInterval` wakeup — those
     /// are already staggered naturally because workers start at different times.
@@ -343,20 +349,17 @@ public struct StrandWorker: Service {
         )
 
         let (stream, cont) = AsyncStream.makeStream(of: Void.self)
-        // Buffer capacity 1: all notifications mean the same thing ("there might be
-        // work"). A second signal while the worker is busy processing tasks is
-        // redundant — drop it. Without this bound the buffer grows without limit
-        // while the worker is at capacity, then drains in a tight loop (100 % CPU).
-        let (wakeStream, wakeCont) = AsyncStream.makeStream(
-            of: Void.self,
-            bufferingPolicy: .bufferingNewest(1)
-        )
+        // Signal shared between listenLoop (producer) and pollLoop (consumer).
+        // _SlotSignal (Mutex + CheckedContinuation) has buffer-of-1 semantics:
+        // a notification that arrives while the worker is busy is stored and
+        // consumed on the next idle check with no allocation or task creation.
+        let notifySignal = _SlotSignal()
 
         try await withTaskCancellationOrGracefulShutdownHandler {
             do {
                 try await withThrowingTaskGroup(of: Void.self) { group in
-                    group.addTask { try await self.pollLoop(workerID: workerID, wakeStream: wakeStream) }
-                    group.addTask { try await self.listenLoop(wakeSignal: wakeCont) }
+                    group.addTask { try await self.pollLoop(workerID: workerID, notifySignal: notifySignal) }
+                    group.addTask { try await self.listenLoop(notifySignal: notifySignal) }
                     group.addTask { try await self.leaseExpiryLoop() }
                     group.addTask {
                         // Wait for shutdown signal.
@@ -402,7 +405,7 @@ public struct StrandWorker: Service {
     ///
     /// When all slots are occupied the loop parks on `_SlotSignal` — a
     /// `Mutex`-backed async wakeup that resumes as soon as any slot is freed.
-    private func pollLoop(workerID: String, wakeStream: AsyncStream<Void>) async throws {
+    private func pollLoop(workerID: String, notifySignal: _SlotSignal) async throws {
         let queueName = options.queue
         let maxConcurrency =
             options.batchSize ?? (options.workflowConcurrency + options.activityConcurrency)
@@ -456,19 +459,17 @@ public struct StrandWorker: Service {
                 }
 
                 if claimed.isEmpty {
-                    // No runnable tasks — park until a LISTEN/NOTIFY wakeup or the
-                    // fallback poll interval fires (whichever comes first).
+                    // No runnable tasks — park until listenLoop signals a new
+                    // PENDING task or the fallback interval fires.
                     try Task.checkCancellation()
-                    enum _WakeSource { case notification, fallback }
-                    let source = await withTaskGroup(of: _WakeSource.self) { sleepGroup in
+                    let wasNotified = await withTaskGroup(of: Bool.self) { sleepGroup in
                         sleepGroup.addTask {
-                            var iter = wakeStream.makeAsyncIterator()
-                            _ = await iter.next()
-                            return .notification
+                            try? await notifySignal.wait()  // returns on signal or cancellation
+                            return true
                         }
                         sleepGroup.addTask {
                             try? await Task.sleep(for: self.options.pollInterval)
-                            return .fallback
+                            return false
                         }
                         let first = await sleepGroup.next()!
                         sleepGroup.cancelAll()
@@ -477,10 +478,7 @@ public struct StrandWorker: Service {
                     // Apply jitter only to NOTIFY wakeups.
                     // Fallback polls are already staggered because workers start at
                     // different times; adding jitter there would only hurt latency.
-                    // Jitter spreads the thundering herd: with N workers and a
-                    // jitter window W, only ~1/(W_ms) workers claim per millisecond
-                    // rather than all N hitting Postgres simultaneously.
-                    if source == .notification {
+                    if wasNotified {
                         let jitter = options.notifyJitter
                         if jitter > .zero {
                             let maxMs =
@@ -558,7 +556,7 @@ public struct StrandWorker: Service {
     /// Reconnects automatically on connection loss (network hiccup, Postgres
     /// restart). Cancellation tears down the connection cleanly via the
     /// structured-concurrency cancel path.
-    private func listenLoop(wakeSignal: AsyncStream<Void>.Continuation) async throws {
+    private func listenLoop(notifySignal: _SlotSignal) async throws {
         let channel = StrandChannels.tasks
         let myNotification = StrandChannels.Notification(namespace: namespace, queue: options.queue)
 
@@ -569,7 +567,7 @@ public struct StrandWorker: Service {
                     try await conn.listen(on: channel) { notifications in
                         for try await note in notifications {
                             if note.payload == myNotification.payload {
-                                wakeSignal.yield(())
+                                notifySignal.signal()
                             }
                         }
                     }
@@ -578,7 +576,7 @@ public struct StrandWorker: Service {
                 return
             } catch {
                 logger.warning(
-                    "LISTEN connection lost \u{2014} reconnecting",
+                    "LISTEN connection lost — reconnecting",
                     metadata: .forError(error)
                 )
                 try await Task.sleep(for: .seconds(1))

--- a/Sources/Strand/Worker.swift
+++ b/Sources/Strand/Worker.swift
@@ -65,8 +65,16 @@ public struct WorkerOptions: Sendable {
     /// Default: `8`.
     public var activityConcurrency: Int
 
-    /// How long the worker sleeps between poll cycles when the queue is empty.
-    /// Default: `.milliseconds(250)`.
+    /// Fallback poll interval used when the LISTEN/NOTIFY connection is briefly down
+    /// (e.g. during the 1-second reconnect back-off in `listenLoop`), and for tasks
+    /// that become PENDING via paths that do not send NOTIFY — SLEEPING timer fires
+    /// and lease-expiry re-queues.
+    ///
+    /// With LISTEN/NOTIFY active this is a safety net, not the primary wakeup mechanism.
+    /// Keeping it at a few seconds (rather than sub-100 ms) avoids unnecessary polling
+    /// when the queue is genuinely idle.
+    ///
+    /// Default: `.seconds(5)` (matches `leaseExpiryInterval`).
     public var pollInterval: Duration
 
     /// Maximum time a claimed task may run per attempt before the in-process
@@ -95,6 +103,28 @@ public struct WorkerOptions: Sendable {
     /// Interval between expired-lease sweep passes. Default: `.seconds(5)`.
     public var leaseExpiryInterval: Duration
 
+    /// Maximum random delay applied **only** to NOTIFY wakeups before the worker
+    /// issues a `claimTasks` query.
+    ///
+    /// When many workers share a queue, a single `pg_notify` wakes all of them
+    /// simultaneously. Without jitter they all hit Postgres at once; `FOR UPDATE
+    /// SKIP LOCKED` keeps correctness but the concurrent empty claims waste DB
+    /// resources. Jitter spreads the herd across a window so only the first few
+    /// workers to fire actually find tasks, and the rest skip the round-trip.
+    ///
+    /// Tuning guidance:
+    /// - 0 workers / single worker: `.zero` (no overhead)
+    /// - ~10 workers: `.milliseconds(20)` — 2‐3 concurrent claims on average
+    /// - ~100 workers: `.milliseconds(100)` — a few concurrent claims
+    /// - 300+ workers: `.milliseconds(300)`
+    ///
+    /// Jitter is **not** applied to the fallback `pollInterval` wakeup — those
+    /// are already staggered naturally because workers start at different times.
+    ///
+    /// Default: `.milliseconds(50)` — a safe default for most SaaS deployments;
+    /// set to `.zero` for development or single-worker setups.
+    public var notifyJitter: Duration
+
     /// Called on every poll error. When `nil`, errors are logged at `.error` level.
     public var onError: (@Sendable (any Error) async -> Void)?
 
@@ -104,12 +134,13 @@ public struct WorkerOptions: Sendable {
         workerID: String? = nil,
         workflowConcurrency: Int = 4,
         activityConcurrency: Int = 8,
-        pollInterval: Duration = .milliseconds(250),
+        pollInterval: Duration = .seconds(5),
         claimTimeout: Duration = .seconds(120),
         batchSize: Int? = nil,
         fatalOnLeaseTimeout: Bool = true,
         gracefulShutdownTimeout: Duration = .seconds(10),
         leaseExpiryInterval: Duration = .seconds(5),
+        notifyJitter: Duration = .milliseconds(50),
         onError: (@Sendable (any Error) async -> Void)? = nil
     ) {
         self.queue = queue
@@ -123,6 +154,7 @@ public struct WorkerOptions: Sendable {
         self.fatalOnLeaseTimeout = fatalOnLeaseTimeout
         self.gracefulShutdownTimeout = gracefulShutdownTimeout
         self.leaseExpiryInterval = leaseExpiryInterval
+        self.notifyJitter = notifyJitter
         self.onError = onError
     }
 }
@@ -311,11 +343,20 @@ public struct StrandWorker: Service {
         )
 
         let (stream, cont) = AsyncStream.makeStream(of: Void.self)
+        // Buffer capacity 1: all notifications mean the same thing ("there might be
+        // work"). A second signal while the worker is busy processing tasks is
+        // redundant — drop it. Without this bound the buffer grows without limit
+        // while the worker is at capacity, then drains in a tight loop (100 % CPU).
+        let (wakeStream, wakeCont) = AsyncStream.makeStream(
+            of: Void.self,
+            bufferingPolicy: .bufferingNewest(1)
+        )
 
         try await withTaskCancellationOrGracefulShutdownHandler {
             do {
                 try await withThrowingTaskGroup(of: Void.self) { group in
-                    group.addTask { try await self.pollLoop(workerID: workerID) }
+                    group.addTask { try await self.pollLoop(workerID: workerID, wakeStream: wakeStream) }
+                    group.addTask { try await self.listenLoop(wakeSignal: wakeCont) }
                     group.addTask { try await self.leaseExpiryLoop() }
                     group.addTask {
                         // Wait for shutdown signal.
@@ -361,7 +402,7 @@ public struct StrandWorker: Service {
     ///
     /// When all slots are occupied the loop parks on `_SlotSignal` — a
     /// `Mutex`-backed async wakeup that resumes as soon as any slot is freed.
-    private func pollLoop(workerID: String) async throws {
+    private func pollLoop(workerID: String, wakeStream: AsyncStream<Void>) async throws {
         let queueName = options.queue
         let maxConcurrency =
             options.batchSize ?? (options.workflowConcurrency + options.activityConcurrency)
@@ -415,10 +456,39 @@ public struct StrandWorker: Service {
                 }
 
                 if claimed.isEmpty {
-                    // No runnable tasks — sleep until next poll tick.
-                    // LISTEN/NOTIFY wakeup would eliminate this sleep on the busy path.
+                    // No runnable tasks — park until a LISTEN/NOTIFY wakeup or the
+                    // fallback poll interval fires (whichever comes first).
                     try Task.checkCancellation()
-                    try await Task.sleep(for: options.pollInterval)
+                    enum _WakeSource { case notification, fallback }
+                    let source = await withTaskGroup(of: _WakeSource.self) { sleepGroup in
+                        sleepGroup.addTask {
+                            var iter = wakeStream.makeAsyncIterator()
+                            _ = await iter.next()
+                            return .notification
+                        }
+                        sleepGroup.addTask {
+                            try? await Task.sleep(for: self.options.pollInterval)
+                            return .fallback
+                        }
+                        let first = await sleepGroup.next()!
+                        sleepGroup.cancelAll()
+                        return first
+                    }
+                    // Apply jitter only to NOTIFY wakeups.
+                    // Fallback polls are already staggered because workers start at
+                    // different times; adding jitter there would only hurt latency.
+                    // Jitter spreads the thundering herd: with N workers and a
+                    // jitter window W, only ~1/(W_ms) workers claim per millisecond
+                    // rather than all N hitting Postgres simultaneously.
+                    if source == .notification {
+                        let jitter = options.notifyJitter
+                        if jitter > .zero {
+                            let maxMs =
+                                jitter.components.seconds * 1_000
+                                + jitter.components.attoseconds / 1_000_000_000_000_000
+                            try await Task.sleep(for: .milliseconds(Int64.random(in: 0...maxMs)))
+                        }
+                    }
                     continue
                 }
 
@@ -474,6 +544,44 @@ public struct StrandWorker: Service {
                     "lease sweep error",
                     metadata: .forError(error) + ["strand.queue": .string(queueName)]
                 )
+            }
+        }
+    }
+
+    // MARK: - LISTEN/NOTIFY loop
+
+    /// Holds one dedicated Postgres connection and listens on `strand_tasks`.
+    /// Whenever a notification arrives with our namespace/queue as payload,
+    /// it signals `wakeSignal` so the poll loop claims immediately instead of
+    /// sleeping the full poll interval.
+    ///
+    /// Reconnects automatically on connection loss (network hiccup, Postgres
+    /// restart). Cancellation tears down the connection cleanly via the
+    /// structured-concurrency cancel path.
+    private func listenLoop(wakeSignal: AsyncStream<Void>.Continuation) async throws {
+        let channel = StrandChannels.tasks
+        let myNotification = StrandChannels.Notification(namespace: namespace, queue: options.queue)
+
+        while true {
+            try Task.checkCancellation()
+            do {
+                try await postgres.withConnection { conn in
+                    try await conn.listen(on: channel) { notifications in
+                        for try await note in notifications {
+                            if note.payload == myNotification.payload {
+                                wakeSignal.yield(())
+                            }
+                        }
+                    }
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                logger.warning(
+                    "LISTEN connection lost \u{2014} reconnecting",
+                    metadata: .forError(error)
+                )
+                try await Task.sleep(for: .seconds(1))
             }
         }
     }

--- a/Tests/StrandTests/TestHelpers.swift
+++ b/Tests/StrandTests/TestHelpers.swift
@@ -143,33 +143,38 @@ func withTestEnvironment<T: Sendable>(
     try await client.verifySchema()
     try await client.createQueue(queueName)
 
-    // Shared teardown: remove all test artefacts so they don't appear in the
-    // dev dashboard when the DB is shared between tests and DevServer.
+    // Shared teardown: remove all test artefacts so they don't accumulate in
+    // the dev DB and confuse the dashboard or DevServer.
     //
-    // Cascade coverage via ON DELETE CASCADE:
-    //   tasks → runs, checkpoints, workflow_history, workflow_state,
-    //           workflow_signals, task_completions
-    //
-    // Explicit deletes (not FK-linked to tasks):
-    //   events, event_waits, schedules
+    // Schedules are deleted first — a live schedule can fire new tasks while
+    // older tasks are still being deleted. Errors are thrown, not swallowed:
+    // a silently-failed cleanup leaves active schedules that StrandScheduler
+    // will keep firing long after the test has finished.
     func cleanup() async {
-        _ = try? await postgres.query(
-            "DELETE FROM strand.tasks       WHERE queue = \(queueName)",
-            logger: logger
-        )
-        _ = try? await postgres.query(
-            "DELETE FROM strand.events      WHERE queue = \(queueName)",
-            logger: logger
-        )
-        _ = try? await postgres.query(
-            "DELETE FROM strand.event_waits WHERE queue = \(queueName)",
-            logger: logger
-        )
-        _ = try? await postgres.query(
-            "DELETE FROM strand.schedules   WHERE queue = \(queueName)",
-            logger: logger
-        )
-        try? await client.dropQueue(queueName)
+        do {
+            try await postgres.query(
+                "DELETE FROM strand.schedules   WHERE queue = \(queueName)",
+                logger: logger
+            )
+            try await postgres.query(
+                "DELETE FROM strand.events      WHERE queue = \(queueName)",
+                logger: logger
+            )
+            try await postgres.query(
+                "DELETE FROM strand.event_waits WHERE queue = \(queueName)",
+                logger: logger
+            )
+            try await postgres.query(
+                "DELETE FROM strand.tasks       WHERE queue = \(queueName)",
+                logger: logger
+            )
+            try await client.dropQueue(queueName)
+        } catch {
+            logger.error(
+                "[TestHelpers] cleanup failed — manually run: DELETE FROM strand.schedules WHERE queue = '\(queueName)'",
+                metadata: .forError(error)
+            )
+        }
     }
 
     do {
@@ -202,7 +207,10 @@ func startWorker(
             workflowConcurrency: concurrency,
             activityConcurrency: concurrency * 2,
             pollInterval: .milliseconds(20),
-            fatalOnLeaseTimeout: false
+            fatalOnLeaseTimeout: false,
+            // No jitter in tests: single worker per queue, no thundering herd,
+            // and jitter would add up to 50 ms latency per task step.
+            notifyJitter: .zero
         ),
         workflows: workflows,
         activityContainers: activityContainers,


### PR DESCRIPTION
## Summary

Introduce Postgres LISTEN/NOTIFY based wakeups and related tuning.

## Changes

- Add internal StrandChannels and typed Notification payload for "<namespace>/<queue>".
- Send pg_notify("strand_tasks", payload) from multiple DB code paths (enqueue, retry, event wait handling, lease requeue, workflow scheduling) so workers wake immediately when runs go PENDING.
- Add a dedicated listenLoop in Worker that holds a LISTEN connection and signals the poll loop via a bounded wake stream. Prevent unbounded wake buffering.
- Add notifyJitter option (default 50 ms) to spread thundering-herd claims; apply jitter only to NOTIFY wakeups. Make pollInterval a safety-net (default 5 s) rather than the primary wake mechanism.
- Update Worker internals to wait on either a NOTIFY signal or the fallback poll tick, and apply jitter for notifications.
- Update docs (WorkerTuning) with LISTEN/NOTIFY details and guidance for pollInterval and notifyJitter.
- Tweak DevServer Postgres config: expose env vars into config, set pool maximumConnections = 50 and adjust worker defaults (larger pollInterval, zero notifyJitter for small setups).
- Tests: improve cleanup ordering/robustness and disable notify jitter in test workers.

These changes reduce unnecessary polling, improve task pickup latency on notify, and provide a knob to mitigate thundering-herd load on Postgres.

## Testing

<!-- How did you verify this works? Did you run `swift test`? -->

- [ ] `swift test` passes locally

## AI Disclosure

<!--
  REQUIRED if any AI assistance was used — see CONTRIBUTING.md.
  Delete this section entirely if no AI was involved.
-->

- [ ] I used AI assistance while working on this PR

**Tool(s) used:** <!-- e.g. Claude, Copilot, ChatGPT -->

**Extent of use:**
<!-- Describe honestly. Examples:
  - Generated first draft of WorkflowDag.tsx, reviewed and edited manually.
  - Used for commit message suggestions only.
  - Pair-programmed the entire feature; all output was reviewed.
-->

**Was the PR description itself AI-generated?** NO

Closes #3 
