### PR TITLE
Fix cancellation race in _SlotSignal wait path

### DIFF
--- a/Sources/Strand/Worker.swift
+++ b/Sources/Strand/Worker.swift
@@ -988,20 +988,30 @@ private final class _SlotSignal: Sendable {
         // Slow path: park the continuation until signal() or cancellation.
         await withTaskCancellationHandler {
             await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-                // Race between signal() arriving after fast-path check and now.
-                let raced = _mutex.withLock { s -> Bool in
+                // Three-way check inside the lock:
+                //  1. A signal arrived after the fast-path check above       → resume now
+                //  2. Cancellation arrived before onCancel could see the     → resume now
+                //     continuation (the narrow window between registering the
+                //     onCancel handler and this closure running): onCancel
+                //     fired, read continuation = nil, did nothing. Without
+                //     this check the continuation would be stored and leaked.
+                //  3. Neither → store the continuation for signal()/onCancel.
+                var shouldResume = false
+                _mutex.withLock { s in
                     if s.pending {
                         s.pending = false
-                        return true  // signal already here — resume immediately
+                        shouldResume = true
+                    } else if Task.isCancelled {
+                        shouldResume = true  // onCancel already missed us
+                    } else {
+                        s.continuation = cont
                     }
-                    s.continuation = cont
-                    return false
                 }
-                if raced { cont.resume() }
+                if shouldResume { cont.resume() }
             }
         } onCancel: {
-            // Resume synchronously from the canceller’s thread so the
-            // dispatcher unblocks and can call Task.checkCancellation().
+            // Resume synchronously from the canceller's thread so the
+            // dispatcher unblocks and can propagate CancellationError.
             let cont = _mutex.withLock { s -> CheckedContinuation<Void, Never>? in
                 let c = s.continuation
                 s.continuation = nil


### PR DESCRIPTION
## Summary

Address a race between signal delivery and task cancellation in _SlotSignal's slow path. Introduce a three-way check inside the lock to: 1) resume immediately if a pending signal is present, 2) resume if cancellation already occurred (preventing a leaked continuation), or 3) store the continuation for later. Refactor from a returned Bool to a local shouldResume flag and adjust the onCancel comment to note propagation of CancellationError.

## Changes

- Fixed race condition in Slot signal wait

## Testing

<!-- How did you verify this works? Did you run `swift test`? -->

- [x] `swift test` passes locally

## AI Disclosure

<!--
  REQUIRED if any AI assistance was used — see CONTRIBUTING.md.
  Delete this section entirely if no AI was involved.
-->

- [ ] I used AI assistance while working on this PR

**Tool(s) used:** <!-- e.g. Claude, Copilot, ChatGPT -->

**Extent of use:**
<!-- Describe honestly. Examples:
  - Generated first draft of WorkflowDag.tsx, reviewed and edited manually.
  - Used for commit message suggestions only.
  - Pair-programmed the entire feature; all output was reviewed.
-->

**Was the PR description itself AI-generated?** No
