### PR TITLE
Scheduler service registration

### DIFF
--- a/Examples/Sources/HackerNewsSummary/HackerNewsSummaryExample.swift
+++ b/Examples/Sources/HackerNewsSummary/HackerNewsSummaryExample.swift
@@ -80,38 +80,25 @@ import Foundation
             logger: logger
         )
 
+        var estCal = Calendar(identifier: .gregorian)
+        estCal.timeZone = TimeZone(identifier: "America/New_York")!
+        let may1est = estCal.date(
+            from: DateComponents(
+                year: 2026,
+                month: 5,
+                day: 1,
+                hour: 0,
+                minute: 0,
+                second: 0
+            )
+        )!
+
         let scheduler = StrandScheduler(
             client: client,
-            options: SchedulerOptions(sleepCap: .seconds(30))
-        )
-
-        // Register a daily schedule — fires at 09:00 EST (America/New_York) on weekdays.
-        //
-        // startsAt = 2026-05-01 so catch-up recovery applies from that date:
-        // if the scheduler was offline over a long weekend, .last(3) fires the
-        // three most recent missed weekday briefings in order rather than all of them.
-        //
-        // Workaround: wait for Postgres before registering (see BootOrder.md)
-        Task {
-            do {
-                try await Task.sleep(for: .milliseconds(500))
-
-                var estCal = Calendar(identifier: .gregorian)
-                estCal.timeZone = TimeZone(identifier: "America/New_York")!
-                let may1est = estCal.date(
-                    from: DateComponents(
-                        year: 2026,
-                        month: 5,
-                        day: 1,
-                        hour: 0,
-                        minute: 0,
-                        second: 0
-                    )
-                )!
-
-                try await client.schedule(
-                    name: "hn-daily-briefing",
-                    // 09:00 every weekday, interpreted in Eastern Time
+            options: SchedulerOptions(sleepCap: .seconds(30)),
+            schedules: [
+                .workflow(
+                    "hn-daily-briefing",
                     pattern: .cron(
                         "0 9 * * 1-5",
                         timezone: TimeZone(identifier: "America/New_York")!
@@ -119,14 +106,11 @@ import Foundation
                     workflowType: HackerNewsSummaryWorkflow.self,
                     input: HNInput(storyCount: 5, jobID: "daily"),
                     startsAt: may1est,
-                    // Fire the last 3 missed briefings on restart, skip older stale ones
                     options: ScheduleOptions(accuracy: .last(3))
                 )
-                print(
-                    "✅ hn-daily-briefing  cron 0 9 * * 1-5 EST  (09:00 ET weekdays, from 2026-05-01)"
-                )
-            } catch { print("Schedule setup error:", error) }
-        }
+            ]
+        )
+        print("✅ hn-daily-briefing  cron 0 9 * * 1-5 EST  (09:00 ET weekdays, from 2026-05-01)")
 
         // Trigger an immediate run for demo purposes
         // Task {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,10 @@ let package = Package(
         .library(name: "StrandServer", targets: ["StrandServer"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.32.2"),
+        // Pinned to commit 820771e which includes the runTimer continuation leak fix
+        // (PR #641: pool idle-timer reschedule dropped CheckedContinuation).
+        // Revert to `from: "1.x.x"` once a release including that patch is cut.
+        .package(url: "https://github.com/vapor/postgres-nio.git", revision: "820771e"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.99.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.12.0"),
         .package(

--- a/README.md
+++ b/README.md
@@ -107,6 +107,49 @@ let handle = try await client.startWorkflow(
 try await group.run()
 ```
 
+## Scheduling
+
+Declare recurring schedules directly on ``StrandScheduler`` — they are upserted
+to the database when the service starts:
+
+```swift
+let scheduler = StrandScheduler(
+    client: client,
+    schedules: [
+        .workflow(
+            "daily-report",
+            pattern: .daily(offset: "PT9H"),          // 09:00 UTC every day
+            workflowType: DailyReportWorkflow.self,
+            input: ReportInput()
+        ),
+        .workflow(
+            "market-open",
+            pattern: .cron("30 8 * * 1-5",
+                           timezone: TimeZone(identifier: "America/New_York")!),
+            workflowType: MarketOpenWorkflow.self,
+            input: StrandVoid()
+        ),
+    ]
+)
+
+let group = ServiceGroup(configuration: .init(
+    services: [
+        .init(service: postgres),
+        .init(service: worker),
+        .init(service: scheduler),
+    ],
+    gracefulShutdownSignals: [.sigterm, .sigint]
+))
+try await group.run()
+```
+
+For schedules created at runtime (e.g. from an HTTP API), call
+`client.schedule(name:pattern:workflowType:input:)` directly — it is always a
+live database write.
+
+See **[Scheduling](Sources/Strand/Strand.docc/Scheduling.md)** for patterns,
+catch-up behaviour, time zones, and runtime management.
+
 ## Examples
 
 See [`Examples/`](Examples/) for complete runnable examples:

--- a/Sources/Strand/Client.swift
+++ b/Sources/Strand/Client.swift
@@ -697,6 +697,10 @@ public struct StrandClient: Sendable {
     /// The workflow type provides the registered task name — no strings needed.
     /// On name conflict within the queue the schedule is updated in place.
     ///
+    /// Use this for **runtime schedule creation** (e.g. from an HTTP API or
+    /// a workflow).  For schedules known at startup, declare them on
+    /// ``StrandScheduler`` instead so they are upserted before the first poll.
+    ///
     /// ```swift
     /// // 9 AM UTC every day
     /// try await client.schedule(
@@ -725,8 +729,8 @@ public struct StrandClient: Sendable {
     /// missed run. Subsequent fires resume on the normal cadence.
     ///
     /// Example: `.daily(offset: "PT15M")` + `startsAt` = yesterday, registered
-    /// at 23:20 UTC today. Without recovery, yesterday's 00:15 slot would fire
-    /// and today's would be lost. With recovery, `nextRunAt` advances to today
+    /// at 23:20 UTC today. Without recovery, yesterday’s 00:15 slot would fire
+    /// and today’s would be lost. With recovery, `nextRunAt` advances to today
     /// 00:15 — the scheduler fires it on the next poll, then schedules
     /// tomorrow 00:15.
     ///
@@ -736,8 +740,7 @@ public struct StrandClient: Sendable {
     /// - Parameters:
     ///   - name: Stable human-readable name, unique within the queue.
     ///   - pattern: When to fire — `.cron`, `.interval`, `.daily`, `.weekly`, `.monthly`, or `.once`.
-    ///   - workflowType: The ``Workflow`` type to enqueue. The registered name is derived
-    ///     from ``WorkflowRegistrable/workflowName``.
+    ///   - workflowType: The ``Workflow`` type to enqueue on each fire.
     ///   - input: Input forwarded to the workflow on each fire.
     ///   - queue: Target queue. `nil` inherits this client's default queue.
     ///   - startsAt: First eligible fire date. `nil` means active from creation.
@@ -769,12 +772,10 @@ public struct StrandClient: Sendable {
         )
     }
 
-    /// Schedules an `ActivityDefinition`-conforming activity on a recurring pattern.
+    /// Schedules an ``ActivityDefinition``-conforming activity on a recurring pattern.
     ///
     /// The activity fires directly — no wrapping workflow is created.
-    /// Use this for fire-and-forget work where durable orchestration is not needed.
-    /// For retries, error recovery, or multi-step logic, wrap the activity in a
-    /// ``WorkflowDefinition`` and use ``schedule(_:workflowType:input:queue:startsAt:endsAt:options:)`` instead.
+    /// Buffering / lifecycle semantics are identical to the workflow overload.
     @discardableResult
     public func schedule<A: ActivityDefinition>(
         name: String,
@@ -799,9 +800,10 @@ public struct StrandClient: Sendable {
         )
     }
 
-    /// Schedules an `Activity<P, R>` instance on a recurring pattern.
+    /// Schedules an ``Activity`` instance on a recurring pattern.
     ///
     /// The activity fires directly — no wrapping workflow is created.
+    /// Buffering / lifecycle semantics are identical to the workflow overload.
     @discardableResult
     public func schedule<P: Codable & Sendable, R: Codable & Sendable>(
         name scheduleName: String,
@@ -826,8 +828,8 @@ public struct StrandClient: Sendable {
         )
     }
 
-    // Private implementation — not public API.
-    // The typed `schedule(workflowType:input:)` overload is the only public entry point.
+    // MARK: - Schedule implementation
+
     @discardableResult
     private func _schedule<P: Codable & Sendable>(
         name: String,

--- a/Sources/Strand/DB/ScheduleQueries.swift
+++ b/Sources/Strand/DB/ScheduleQueries.swift
@@ -208,8 +208,15 @@ package enum ScheduleQueries {
                 kind            = EXCLUDED.kind,
                 starts_at       = EXCLUDED.starts_at,
                 ends_at         = EXCLUDED.ends_at,
-                next_run_at     = EXCLUDED.next_run_at,
-                is_active       = EXCLUDED.is_active,
+                -- GREATEST preserves whichever date is further ahead.
+                -- On a scheduler restart the freshly-computed next_run_at
+                -- (from catch-up recovery) can be earlier than what the DB
+                -- already has, which would reset the schedule backwards and
+                -- cause spurious re-fires (idempotent but inflates run_count
+                -- and corrupts last_run_at).  PostgreSQL GREATEST ignores
+                -- NULLs, so a fresh insert still gets EXCLUDED.next_run_at.
+                next_run_at     = GREATEST(strand.schedules.next_run_at, EXCLUDED.next_run_at),
+                is_active       = (GREATEST(strand.schedules.next_run_at, EXCLUDED.next_run_at) IS NOT NULL),
                 updated_at      = NOW()
             RETURNING id
             """,

--- a/Sources/Strand/Schedule/StrandScheduler.swift
+++ b/Sources/Strand/Schedule/StrandScheduler.swift
@@ -3,10 +3,117 @@ import NIOCore
 public import ServiceLifecycle
 
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
+
+// MARK: - StrandSchedule
+
+/// A static schedule definition passed to ``StrandScheduler`` at construction
+/// time and upserted to the database when the scheduler starts.
+///
+/// Use the static factory methods to build schedules fluently:
+///
+/// ```swift
+/// let scheduler = StrandScheduler(
+///     client: client,
+///     schedules: [
+///         .workflow(
+///             "daily-report",
+///             pattern: .daily(offset: "PT9H"),
+///             workflowType: DailyReportWorkflow.self,
+///             input: ReportInput()
+///         ),
+///         .activity(
+///             "hourly-cleanup",
+///             pattern: .interval(.seconds(3600)),
+///             activityType: CleanupActivity.self,
+///             input: CleanupInput()
+///         ),
+///     ]
+/// )
+/// ```
+///
+/// For schedules created at runtime (e.g. from an HTTP API), use
+/// ``StrandClient/schedule(name:pattern:workflowType:input:queue:startsAt:endsAt:options:)``
+/// directly — it is always a live database call.
+public struct StrandSchedule: Sendable {
+
+    // Type erasure: captures the generic W/A parameters so the schedule
+    // can be stored in a homogeneous [StrandSchedule] array.
+    // Private — callers only see the factory methods.
+    private let _body: @Sendable (StrandClient) async throws -> Void
+
+    private init(_ body: @escaping @Sendable (StrandClient) async throws -> Void) {
+        self._body = body
+    }
+
+    /// Applies this schedule to the database using `client`.
+    /// Called by ``StrandScheduler/run()`` at startup.
+    func _apply(to client: StrandClient) async throws {
+        try await _body(client)
+    }
+
+    // MARK: Workflow
+
+    /// Declares a recurring workflow schedule.
+    ///
+    /// The schedule is upserted to the database when ``StrandScheduler/run()``
+    /// is called.  On a name conflict the existing row is updated in place.
+    public static func workflow<W: Workflow>(
+        _ name: String,
+        pattern: SchedulePattern,
+        workflowType: W.Type = W.self,
+        input: W.Input,
+        queue: String? = nil,
+        startsAt: Date? = nil,
+        endsAt: Date? = nil,
+        options: ScheduleOptions = .init()
+    ) -> StrandSchedule {
+        StrandSchedule { client in
+            _ = try await client.schedule(
+                name: name,
+                pattern: pattern,
+                workflowType: workflowType,
+                input: input,
+                queue: queue,
+                startsAt: startsAt,
+                endsAt: endsAt,
+                options: options
+            )
+        }
+    }
+
+    // MARK: ActivityDefinition
+
+    /// Declares a recurring activity schedule.
+    ///
+    /// The activity fires directly — no wrapping workflow is created.
+    public static func activity<A: ActivityDefinition>(
+        _ name: String,
+        pattern: SchedulePattern,
+        activityType: A.Type,
+        input: A.Input,
+        queue: String? = nil,
+        startsAt: Date? = nil,
+        endsAt: Date? = nil,
+        options: ScheduleOptions = .init()
+    ) -> StrandSchedule {
+        StrandSchedule { client in
+            _ = try await client.schedule(
+                name: name,
+                pattern: pattern,
+                activityType: activityType,
+                input: input,
+                queue: queue,
+                startsAt: startsAt,
+                endsAt: endsAt,
+                options: options
+            )
+        }
+    }
+}
 
 /// A `Service`-conformant scheduler that fires durable workflow tasks on a
 /// configurable ``SchedulePattern`` (cron, interval, daily, weekly, monthly,
@@ -16,16 +123,17 @@ import Foundation
 /// and `StrandWorker` instances:
 ///
 /// ```swift
-/// // Define a schedule
-/// try await client.schedule(
-///     name: "nightly-report",
-///     pattern: .daily(offset: "PT9H"),   // 9 AM UTC every day
-///     taskName: "generate-report",
-///     params: ReportParams(kind: "daily")
+/// let scheduler = StrandScheduler(
+///     client: client,
+///     schedules: [
+///         .workflow(
+///             "nightly-report",
+///             pattern: .daily(offset: "PT9H"),
+///             workflowType: NightlyReportWorkflow.self,
+///             input: ReportInput()
+///         )
+///     ]
 /// )
-///
-/// // Run the scheduler as a Service
-/// let scheduler = StrandScheduler(client: client)
 /// ```
 ///
 /// When a schedule fires, Strand injects these headers into the task:
@@ -43,16 +151,32 @@ import Foundation
 public struct StrandScheduler: Service {
     private let client: StrandClient
     private let options: SchedulerOptions
+    /// Static schedules upserted to the database at startup.
+    private let schedules: [StrandSchedule]
 
-    public init(client: StrandClient, options: SchedulerOptions = .init()) {
+    public init(
+        client: StrandClient,
+        options: SchedulerOptions = .init(),
+        schedules: [StrandSchedule] = []
+    ) {
         self.client = client
         self.options = options
+        self.schedules = schedules
     }
 
     public func run() async throws {
         let logger = client.logger
         logger.info("scheduler starting")
         defer { logger.info("scheduler stopped") }
+
+        // Upsert all statically-declared schedules before the poll loop starts.
+        // Any failure is propagated immediately — a bad schedule definition is
+        // a programming error (wrong pattern, invalid input encoding, DB schema
+        // mismatch) that should surface loudly at startup rather than silently
+        // skipping a schedule and causing confusing production behaviour.
+        for declaration in schedules {
+            try await declaration._apply(to: client)
+        }
 
         let (stream, cont) = AsyncStream.makeStream(of: Void.self)
 
@@ -67,6 +191,7 @@ public struct StrandScheduler: Service {
                 }
             } catch is CancellationError {}
         } onCancelOrGracefulShutdown: {
+            logger.info("scheduler shutting down")
             cont.finish()
         }
     }
@@ -222,7 +347,13 @@ public struct StrandScheduler: Service {
             on: postgres,
             namespaceID: client.namespaceID,
             id: row.id,
-            firedAt: now,
+            // Use the scheduled slot time, not the wall-clock fire time.
+            // When the scheduler catches up a missed slot, `now` is the
+            // catch-up time (e.g. 12:19 UTC) while the slot was due at
+            // 13:00 UTC the previous day — using `now` makes last_run_at
+            // misleading and inconsistent with nextRunAt (which already
+            // anchors to row.scheduledAt to prevent drift).
+            firedAt: row.scheduledAt,
             nextRunAt: nextRunAt,
             logger: logger
         )

--- a/Sources/Strand/Schedule/StrandScheduler.swift
+++ b/Sources/Strand/Schedule/StrandScheduler.swift
@@ -109,8 +109,11 @@ public struct StrandScheduler: Service {
                 sleepFor = options.sleepCap
             }
 
-            try Task.checkCancellation()
-            try await Task.sleep(for: sleepFor)
+            // cancelWhenGracefulShutdown exits early on both task cancellation
+            // and graceful shutdown.
+            try await cancelWhenGracefulShutdown {
+                try await Task.sleep(for: sleepFor)
+            }
         }
     }
 

--- a/Sources/Strand/Strand.docc/Scheduling.md
+++ b/Sources/Strand/Strand.docc/Scheduling.md
@@ -1,60 +1,91 @@
 # Scheduling recurring tasks
 
-``StrandScheduler`` fires workflow or activity tasks on a repeating pattern.
+``StrandScheduler`` fires workflow or activity tasks on a repeating pattern and
+runs as a `Service` in your `ServiceGroup`.
 
-## Start the scheduler
+## Two modes: static declarations vs. runtime calls
 
-Add ``StrandScheduler`` alongside your worker in the `ServiceGroup`:
+Strand distinguishes between two kinds of schedule registration:
+
+| Mode | When to use | API |
+|---|---|---|
+| **Static declaration** | Schedules known at compile time (boot-time setup) | `StrandScheduler(schedules:)` |
+| **Runtime call** | Schedules created dynamically (HTTP API, user action) | `client.schedule(...)` |
+
+## Static declarations (boot-time)
+
+Pass schedule definitions directly to ``StrandScheduler`` at construction time.
+The scheduler upserts them to the database as the very first step of `run()` —
+Postgres is guaranteed to be live at that point because the `ServiceGroup` starts
+``PostgresClient`` before any other service.
 
 ```swift
-let scheduler = StrandScheduler(client: client)
+let scheduler = StrandScheduler(
+    client: client,
+    schedules: [
+        // Workflow schedule — every hour on the hour
+        .workflow(
+            "hourly-sync",
+            pattern: .interval(.hours(1)),
+            workflowType: DataSyncWorkflow.self,
+            input: SyncInput()
+        ),
+
+        // Daily at 09:00 UTC
+        .workflow(
+            "daily-report",
+            pattern: .daily(offset: "PT9H"),
+            workflowType: DailyReportWorkflow.self,
+            input: ReportInput()
+        ),
+
+        // Weekdays at 08:30 US Eastern via cron
+        .workflow(
+            "market-open",
+            pattern: .cron("30 8 * * 1-5",
+                           timezone: TimeZone(identifier: "America/New_York")!),
+            workflowType: MarketOpenWorkflow.self,
+            input: StrandVoid()
+        ),
+
+        // Activity fired directly — no wrapping workflow
+        .activity(
+            "cleanup-old-files",
+            pattern: .daily(offset: "PT2H"),
+            activityType: CleanupActivity.self,
+            input: CleanupInput(olderThanDays: 30)
+        ),
+    ]
+)
 
 let group = ServiceGroup(configuration: .init(
     services: [
         .init(service: postgres),
         .init(service: worker),
-        .init(service: scheduler),
+        .init(service: scheduler),   // ← schedules are upserted here
     ],
     gracefulShutdownSignals: [.sigterm, .sigint]
 ))
+try await group.run()
 ```
 
-## Register schedules
+Registering the same name twice upserts the pattern — existing in-flight tasks
+are unaffected.
 
-Schedules are registered at startup (or any time). Registering the same name
-twice upserts the pattern — existing in-flight tasks are unaffected.
+## Runtime calls (dynamic)
+
+For schedules created in response to an external event (an HTTP request, a user
+action, a Strand workflow itself), call ``StrandClient/schedule(name:pattern:workflowType:input:queue:startsAt:endsAt:options:)``
+directly from wherever the event is handled.  Postgres is always live at that
+point, so the call is a straightforward database write:
 
 ```swift
-// Every hour on the hour
+// Inside a Hummingbird route handler, a workflow activity, etc.
 try await client.schedule(
-    name: "hourly-sync",
-    pattern: .interval(.hours(1)),
-    workflowType: DataSyncWorkflow.self,
-    input: SyncInput()
-)
-
-// Daily at 09:00 UTC
-try await client.schedule(
-    name: "daily-report",
-    pattern: .daily(offset: "PT9H"),
-    workflowType: DailyReportWorkflow.self,
-    input: ReportInput()
-)
-
-// Every weekday at 08:30 UTC via cron
-try await client.schedule(
-    name: "market-open",
-    pattern: .cron("30 8 * * 1-5"),
-    workflowType: MarketOpenWorkflow.self,
-    input: StrandVoid()
-)
-
-// One-time future execution
-try await client.schedule(
-    name: "launch-day",
-    pattern: .once(at: launchDate),
-    workflowType: LaunchWorkflow.self,
-    input: LaunchInput()
+    name: "send-invoice-\(orderID)",
+    pattern: .once(at: invoiceDate),
+    workflowType: InvoiceWorkflow.self,
+    input: InvoiceInput(orderID: orderID)
 )
 ```
 
@@ -69,40 +100,42 @@ try await client.schedule(
 | `.monthly(offset:)` | `.monthly(offset: "P14DT9H")` | Monthly on a day-of-month + time |
 | `.once(at:)` | `.once(at: someDate)` | Fire exactly once at the given `Date` |
 
-## Scheduling activities directly
-
-For fire-and-forget work that doesn't need durable orchestration history:
-
-```swift
-try await client.schedule(
-    name: "cleanup-old-files",
-    pattern: .daily(offset: "PT2H"),
-    activityType: CleanupActivity.self,
-    input: CleanupInput(olderThanDays: 30)
-)
-```
-
 ## Catch-up behaviour
 
-``ScheduleAccuracy`` controls what happens when the scheduler starts after being
-offline:
+``ScheduleAccuracy`` controls what happens when the scheduler restarts after an
+outage:
 
 ```swift
 // Default: fire only the most-recent missed slot (avoids flooding the queue)
 options: ScheduleOptions(accuracy: .latest)
 
-// Fire all missed slots in order (for financial reconciliation etc.)
+// Fire all missed slots in order (e.g. financial reconciliation)
 options: ScheduleOptions(accuracy: .all)
 
 // Fire only the last 3 missed slots
 options: ScheduleOptions(accuracy: .last(3))
 ```
 
-## Time zones
+A past `startsAt` date triggers catch-up recovery automatically:
 
 ```swift
-try await client.schedule(
-    name: "new-york-open",
+.workflow(
+    "iss-telemetry",
+    pattern: .interval(.seconds(90 * 60)),
+    workflowType: TelemetryWorkflow.self,
+    input: TelemetryInput(),
+    startsAt: Date(timeIntervalSince1970: 0),   // active since epoch
+    options: ScheduleOptions(accuracy: .last(3)) // recover last 3 slots
+)
+```
+
+## Time zones
+
+Pass a `timezone:` argument to `.cron` or any pattern that accepts one:
+
+```swift
+.workflow(
+    "new-york-open",
     pattern: .cron("30 9 * * 1-5",
                    timezone: TimeZone(identifier: "America/New_York")!),
     workflowType: MarketOpenWorkflow.self,
@@ -113,10 +146,10 @@ try await client.schedule(
 ## Manage schedules at runtime
 
 ```swift
-// List all schedules in the default queue
+// List all schedules
 let schedules = try await client.listSchedules()
 
-// Pause / resume / delete by ID
+// Pause / resume / delete by UUID
 try await client.pauseSchedule(id: scheduleID)
 try await client.resumeSchedule(id: scheduleID)
 try await client.deleteSchedule(id: scheduleID)
@@ -125,15 +158,30 @@ try await client.deleteSchedule(id: scheduleID)
 ## Reading schedule metadata inside a workflow
 
 When a workflow is triggered by a schedule, ``SchedulingMetadata`` is available
-in the context:
+via the context:
 
 ```swift
 mutating func run(context: WorkflowContext<Self>, input: ReportInput) async throws -> ReportResult {
     if let meta = context.schedulingMetadata {
-        // meta.scheduleName  — e.g. "daily-report"
+        // meta.scheduleName  — "daily-report"
         // meta.scheduledAt   — wall-clock time the slot was due
         // meta.executionTime — time the task was actually dispatched
     }
     // ...
 }
 ```
+
+## Scheduler options
+
+```swift
+let scheduler = StrandScheduler(
+    client: client,
+    options: SchedulerOptions(
+        sleepCap: .seconds(60)   // max sleep between polls; default 60 s
+    ),
+    schedules: [ ... ]
+)
+```
+
+The scheduler sleeps precisely until the next known fire time, but wakes at
+least every `sleepCap` seconds to detect newly-added schedules.

--- a/Sources/Strand/Worker.swift
+++ b/Sources/Strand/Worker.swift
@@ -360,6 +360,7 @@ public struct StrandWorker: Service {
                 try await withThrowingTaskGroup(of: Void.self) { group in
                     group.addTask { try await self.pollLoop(workerID: workerID, notifySignal: notifySignal) }
                     group.addTask { try await self.listenLoop(notifySignal: notifySignal) }
+                    group.addTask { try await self.heartbeatLoop(notifySignal: notifySignal) }
                     group.addTask { try await self.leaseExpiryLoop() }
                     group.addTask {
                         // Wait for shutdown signal.
@@ -459,33 +460,21 @@ public struct StrandWorker: Service {
                 }
 
                 if claimed.isEmpty {
-                    // No runnable tasks — park until listenLoop signals a new
-                    // PENDING task or the fallback interval fires.
-                    try Task.checkCancellation()
-                    let wasNotified = await withTaskGroup(of: Bool.self) { sleepGroup in
-                        sleepGroup.addTask {
-                            try? await notifySignal.wait()  // returns on signal or cancellation
-                            return true
-                        }
-                        sleepGroup.addTask {
-                            try? await Task.sleep(for: self.options.pollInterval)
-                            return false
-                        }
-                        let first = await sleepGroup.next()!
-                        sleepGroup.cancelAll()
-                        return first
-                    }
-                    // Apply jitter only to NOTIFY wakeups.
-                    // Fallback polls are already staggered because workers start at
-                    // different times; adding jitter there would only hurt latency.
-                    if wasNotified {
-                        let jitter = options.notifyJitter
-                        if jitter > .zero {
-                            let maxMs =
-                                jitter.components.seconds * 1_000
-                                + jitter.components.attoseconds / 1_000_000_000_000_000
-                            try await Task.sleep(for: .milliseconds(Int64.random(in: 0...maxMs)))
-                        }
+                    // Park until either listenLoop (NOTIFY) or heartbeatLoop
+                    // (periodic fallback) signals. Both are structured siblings
+                    // in the same task group — no sibling-cancel of Task.sleep,
+                    // no unstructured tasks, no runTimer leak.
+                    try await notifySignal.wait()
+                    // Apply jitter on every wakeup to spread thundering herd.
+                    // Heartbeat wakeups are naturally staggered (each worker's
+                    // timer starts when it first goes idle, so different workers
+                    // fire at different offsets) — jitter is harmless there too.
+                    let jitter = options.notifyJitter
+                    if jitter > .zero {
+                        let maxMs =
+                            jitter.components.seconds * 1_000
+                            + jitter.components.attoseconds / 1_000_000_000_000_000
+                        try await Task.sleep(for: .milliseconds(Int64.random(in: 0...maxMs)))
                     }
                     continue
                 }
@@ -543,6 +532,23 @@ public struct StrandWorker: Service {
                     metadata: .forError(error) + ["strand.queue": .string(queueName)]
                 )
             }
+        }
+    }
+
+    // MARK: - Heartbeat loop
+
+    /// Fires `notifySignal` every `pollInterval` so the poll loop wakes to claim
+    /// tasks that became PENDING via paths that don’t send NOTIFY — SLEEPING
+    /// timer expiry and brief LISTEN reconnect windows.
+    ///
+    /// Running as a structured sibling in the same task group means its
+    /// `Task.sleep` is cancelled once by the parent group on shutdown, not
+    /// repeatedly by sibling-cancel (which leaks the `runTimer` continuation).
+    private func heartbeatLoop(notifySignal: _SlotSignal) async throws {
+        while true {
+            try Task.checkCancellation()
+            try await Task.sleep(for: options.pollInterval)
+            notifySignal.signal()
         }
     }
 
@@ -1023,4 +1029,5 @@ private final class _SlotSignal: Sendable {
         // After waking from cancellation, throw so the dispatch loop exits.
         try Task.checkCancellation()
     }
+
 }

--- a/Sources/Strand/Worker.swift
+++ b/Sources/Strand/Worker.swift
@@ -357,20 +357,36 @@ public struct StrandWorker: Service {
 
         try await withTaskCancellationOrGracefulShutdownHandler {
             do {
-                try await withThrowingTaskGroup(of: Void.self) { group in
+                // heartbeatLoop and leaseExpiryLoop exit *voluntarily* when
+                // Task.isShuttingDownGracefully becomes true (to avoid runTimer
+                // continuation leaks on their internal sleeps).  A regular
+                // withThrowingTaskGroup + group.next() would treat those normal
+                // returns as the first child completion and immediately call
+                // group.cancelAll(), killing the shutdown task's sleep before
+                // the grace period could run.
+                //
+                // A discarding group silently discards normal completions; only
+                // a *throw* exits the group.  The shutdown task throws after the
+                // full gracefulShutdownTimeout, which cancels any still-running
+                // children (pollLoop, listenLoop) and lets run() return cleanly.
+                try await withThrowingDiscardingTaskGroup { group in
                     group.addTask { try await self.pollLoop(workerID: workerID, notifySignal: notifySignal) }
                     group.addTask { try await self.listenLoop(notifySignal: notifySignal) }
                     group.addTask { try await self.heartbeatLoop(notifySignal: notifySignal) }
                     group.addTask { try await self.leaseExpiryLoop() }
                     group.addTask {
-                        // Wait for shutdown signal.
+                        // Wait for the graceful-shutdown signal from
+                        // onCancelOrGracefulShutdown below.
                         await stream.first { _ in true }
+
+                        // Wake pollLoop if it is parked in notifySignal.wait() so
+                        // it checks Task.isShuttingDownGracefully and exits its
+                        // while loop, letting in-flight runTask children finish.
+                        notifySignal.signal()
 
                         // Immediately expire all in-flight runs for this worker so
                         // the next worker's leaseExpiryLoop picks them up on its
                         // first sweep rather than waiting up to claimTimeout.
-                        // Runs in structured context — guaranteed to finish or be
-                        // cancelled with everything else. No fire-and-forget Task needed.
                         let _ = try? await self.postgres.query(
                             """
                             UPDATE strand.runs
@@ -382,11 +398,20 @@ public struct StrandWorker: Service {
                             logger: self.logger
                         )
 
-                        try Task.checkCancellation()
+                        // Grace period: give in-flight tasks time to finish.
+                        // Task.sleep responds to task *cancellation* (forced
+                        // shutdown / ServiceGroup timeout) by throwing
+                        // CancellationError, which exits the group immediately.
+                        // On graceful shutdown the sleep runs to completion;
+                        // the explicit throw below then drives the group exit.
                         try await Task.sleep(for: self.options.gracefulShutdownTimeout)
+
+                        // Reached only after the full graceful grace period.
+                        // Throwing from a discarding-group child cancels all
+                        // remaining siblings (pollLoop if still draining) and
+                        // propagates out — caught below.
+                        throw CancellationError()
                     }
-                    try await group.next()
-                    group.cancelAll()
                 }
             } catch is CancellationError {}
         } onCancelOrGracefulShutdown: {
@@ -422,7 +447,11 @@ public struct StrandWorker: Service {
         // Execution tasks are added as independent children of the same group
         // so cancellation propagates cleanly on graceful shutdown.
         try await withThrowingDiscardingTaskGroup { group in
-            while true {
+            // When graceful shutdown fires the shutdown task signals notifySignal
+            // to unblock this loop, then we detect isShuttingDownGracefully here
+            // and exit the while loop.  withThrowingDiscardingTaskGroup then waits
+            // for all in-flight runTask children to complete before pollLoop returns.
+            while !Task.isShuttingDownGracefully && !Task.isCancelled {
                 try Task.checkCancellation()
 
                 let free = maxConcurrency - running.value
@@ -454,8 +483,9 @@ public struct StrandWorker: Service {
                             metadata: .forError(error) + ["strand.queue": .string(queueName)]
                         )
                     }
-                    try Task.checkCancellation()
-                    try await Task.sleep(for: options.pollInterval)
+                    try? await cancelWhenGracefulShutdown {
+                        try await Task.sleep(for: options.pollInterval)
+                    }
                     continue
                 }
 
@@ -474,7 +504,12 @@ public struct StrandWorker: Service {
                         let maxMs =
                             jitter.components.seconds * 1_000
                             + jitter.components.attoseconds / 1_000_000_000_000_000
-                        try await Task.sleep(for: .milliseconds(Int64.random(in: 0...maxMs)))
+                        // try? so a graceful-shutdown CancellationError from
+                        // cancelWhenGracefulShutdown doesn't propagate into the
+                        // inner discarding group and kill in-flight runTasks.
+                        try? await cancelWhenGracefulShutdown {
+                            try await Task.sleep(for: .milliseconds(Int64.random(in: 0...maxMs)))
+                        }
                     }
                     continue
                 }
@@ -516,9 +551,15 @@ public struct StrandWorker: Service {
     private func leaseExpiryLoop() async throws {
         let queueName = options.queue
 
-        while true {
-            try Task.checkCancellation()
-            try await Task.sleep(for: options.leaseExpiryInterval)
+        while !Task.isShuttingDownGracefully && !Task.isCancelled {
+            // try? for the same reason as heartbeatLoop: cancelWhenGracefulShutdown
+            // throws on graceful shutdown, and we must not let that propagate out
+            // of this function into the discarding group.
+            try? await cancelWhenGracefulShutdown {
+                try await Task.sleep(for: self.options.leaseExpiryInterval)
+            }
+            // Re-check after the sleep — shutdown may have fired mid-interval.
+            guard !Task.isShuttingDownGracefully && !Task.isCancelled else { break }
             do {
                 try await Queries.sweepExpiredLeases(
                     on: postgres,
@@ -545,9 +586,15 @@ public struct StrandWorker: Service {
     /// `Task.sleep` is cancelled once by the parent group on shutdown, not
     /// repeatedly by sibling-cancel (which leaks the `runTimer` continuation).
     private func heartbeatLoop(notifySignal: _SlotSignal) async throws {
-        while true {
-            try Task.checkCancellation()
-            try await Task.sleep(for: options.pollInterval)
+        while !Task.isShuttingDownGracefully && !Task.isCancelled {
+            // try? is essential: cancelWhenGracefulShutdown throws CancellationError
+            // on graceful shutdown.  Without try? that error propagates out of this
+            // function and into withThrowingDiscardingTaskGroup, which then cancels
+            // all siblings (including the shutdown task's grace-period sleep)
+            // before the timeout can run.
+            try? await cancelWhenGracefulShutdown {
+                try await Task.sleep(for: self.options.pollInterval)
+            }
             notifySignal.signal()
         }
     }
@@ -566,14 +613,35 @@ public struct StrandWorker: Service {
         let channel = StrandChannels.tasks
         let myNotification = StrandChannels.Notification(namespace: namespace, queue: options.queue)
 
-        while true {
-            try Task.checkCancellation()
+        // cancelWhenGracefulShutdown is used for two reasons:
+        //
+        // 1. Fast voluntary exit on graceful shutdown.
+        //    cancelWhenGracefulShutdown detects Task.isShuttingDownGracefully
+        //    and cancels the postgres.withConnection body via an inner task
+        //    group.  Without it the loop would keep the connection open until
+        //    the while-condition check on the next iteration (up to the full
+        //    reconnect / poll cycle).
+        //
+        // 2. NIO runTimer continuation safety.
+        //    When cancelWhenGracefulShutdown cancels the inner scope, the
+        //    *outer* listenLoop task is still alive (it will execute the
+        //    catch block and return).  NIO's event-loop cleanup callbacks —
+        //    including any runTimer continuations scheduled during connection
+        //    teardown — have time to fire within this window.  If the outer
+        //    task were torn down at the same moment (e.g. by the grace-period
+        //    throw after gracefulShutdownTimeout), those continuations would
+        //    be leaked.
+        //
+        // The reconnect sleep uses the same wrapper for reason 2.
+        while !Task.isShuttingDownGracefully && !Task.isCancelled {
             do {
-                try await postgres.withConnection { conn in
-                    try await conn.listen(on: channel) { notifications in
-                        for try await note in notifications {
-                            if note.payload == myNotification.payload {
-                                notifySignal.signal()
+                try await cancelWhenGracefulShutdown {
+                    try await self.postgres.withConnection { conn in
+                        try await conn.listen(on: channel) { notifications in
+                            for try await note in notifications {
+                                if note.payload == myNotification.payload {
+                                    notifySignal.signal()
+                                }
                             }
                         }
                     }
@@ -585,7 +653,11 @@ public struct StrandWorker: Service {
                     "LISTEN connection lost — reconnecting",
                     metadata: .forError(error)
                 )
-                try await Task.sleep(for: .seconds(1))
+                // Wrap the reconnect sleep for the same reason: a raw
+                // group.cancelAll() mid-sleep leaks the runTimer continuation.
+                try await cancelWhenGracefulShutdown {
+                    try await Task.sleep(for: .seconds(1))
+                }
             }
         }
     }

--- a/Tests/StrandTests/SchedulerIntegrationTests.swift
+++ b/Tests/StrandTests/SchedulerIntegrationTests.swift
@@ -193,4 +193,158 @@ struct SchedulerIntegrationTests {
             try? await client.deleteSchedule(id: scheduleID)
         }
     }
+
+    // ── 3 ───────────────────────────────────────────────────────────────────────────
+    //
+    // `last_run_at` stores the scheduled slot time, not the wall-clock fire time.
+    //
+    // `markScheduleFired` is called with `firedAt: row.scheduledAt` — the
+    // `next_run_at` value that triggered the fire.  When the scheduler catches
+    // up a missed slot the wall-clock time and the slot time diverge (e.g. a
+    // slot due at 13:00 UTC may be processed at 12:19 UTC the following day);
+    // `last_run_at` must always reflect the slot, not the poll time, so the
+    // UI displays a coherent cadence.
+    //
+    // We snapshot `nextRunAt` immediately after registration (that is the slot
+    // the scheduler will fire), start the scheduler, wait for one fire, then
+    // assert `lastRunAt == snapshotted nextRunAt` within floating-point tolerance.
+    //
+    @Test(
+        "markScheduleFired stores the scheduled slot time, not the wall-clock fire time",
+        .tags(.integration)
+    )
+    func firedAtIsScheduledSlotNotWallClock() async throws {
+        try await withTestEnvironment { client in
+            // Register with startsAt in the past so the schedule is
+            // immediately due on the first scheduler poll.
+            let scheduleID = try await client.schedule(
+                name: "sit-firedat-test",
+                pattern: .interval(.seconds(5)),
+                workflowType: SitSimpleWorkflow.self,
+                input: .done,
+                startsAt: Date.now.addingTimeInterval(-10)
+            )
+
+            // Capture the scheduled slot time before the scheduler fires.
+            let preFireList = try await client.listSchedules(queue: client.queueName)
+            guard
+                let scheduledSlot =
+                    preFireList
+                    .first(where: { $0.name == "sit-firedat-test" })?.nextRunAt
+            else {
+                Issue.record("schedule must have a nextRunAt after registration")
+                return
+            }
+
+            // Start the scheduler (no worker needed — markScheduleFired runs
+            // independently of whether a worker processes the enqueued task).
+            let scheduler = StrandScheduler(
+                client: client,
+                options: SchedulerOptions(sleepCap: .seconds(1))
+            )
+            let schedulerTask = Task { try? await scheduler.run() }
+            defer { schedulerTask.cancel() }
+
+            // Wait until the schedule has been fired at least once.
+            let deadline = ContinuousClock.now + .seconds(5)
+            while ContinuousClock.now < deadline {
+                let list = try await client.listSchedules(queue: client.queueName)
+                if (list.first(where: { $0.name == "sit-firedat-test" })?.runCount ?? 0) >= 1 {
+                    break
+                }
+                try await Task.sleep(for: .milliseconds(200))
+            }
+
+            // lastRunAt must equal scheduledSlot (the slot the scheduler fired),
+            // not the wall-clock time the scheduler happened to poll.
+            let postFireList = try await client.listSchedules(queue: client.queueName)
+            let lastRunAt =
+                postFireList
+                .first(where: { $0.name == "sit-firedat-test" })?.lastRunAt
+
+            #expect(lastRunAt != nil, "lastRunAt must be set after the schedule fires")
+            if let lastRunAt {
+                // Both values come from the same Postgres TIMESTAMPTZ column
+                // decoded through the same path — they must be bit-identical.
+                let drift = abs(lastRunAt.timeIntervalSince(scheduledSlot))
+                #expect(
+                    drift < 0.001,
+                    "lastRunAt (\(lastRunAt)) must equal the scheduled slot (\(scheduledSlot)), not the wall-clock fire time; drift = \(drift)s"
+                )
+            }
+
+            try? await client.deleteSchedule(id: scheduleID)
+        }
+    }
+
+    // ── 4 ───────────────────────────────────────────────────────────────────────────
+    //
+    // `upsertSchedule` never moves `next_run_at` backwards.
+    //
+    // The ON CONFLICT clause uses `GREATEST(existing, incoming)` so that a
+    // scheduler restart — which recomputes `next_run_at` from scratch via
+    // catch-up recovery — cannot reset an already-advanced schedule to an
+    // earlier slot.  Without this guard, restarts cause spurious re-fires
+    // (idempotent at the task level but they inflate `run_count` and corrupt
+    // `last_run_at` with the catch-up wall-clock time).
+    //
+    // Test sequence:
+    //  1. Register with no startsAt → next_run_at ≈ now + 3600 s (future).
+    //  2. Re-register the same name with startsAt 2 h ago → catch-up recovery
+    //     computes next_run_at ≈ now, which is earlier than the existing value.
+    //  3. Assert the DB still holds the original future next_run_at.
+    //
+    @Test(
+        "upsertSchedule preserves next_run_at when re-registration computes an earlier value",
+        .tags(.integration)
+    )
+    func upsertPreservesNextRunAtOnReregistration() async throws {
+        try await withTestEnvironment { client in
+            // Step 1: fresh registration, no startsAt → next_run_at ≈ now + 3600s.
+            let scheduleID = try await client.schedule(
+                name: "sit-greatest-test",
+                pattern: .interval(.seconds(3600)),
+                workflowType: SitSimpleWorkflow.self,
+                input: .done
+            )
+
+            let initial = try await client.listSchedules(queue: client.queueName)
+            guard
+                let initialNextRunAt =
+                    initial
+                    .first(where: { $0.name == "sit-greatest-test" })?.nextRunAt
+            else {
+                Issue.record("schedule must have nextRunAt after fresh registration")
+                return
+            }
+
+            // Step 2: re-register the same name with startsAt 2 hours ago.
+            // .latest accuracy fast-forwards nextRunAt to the most recent
+            // elapsed 1-hour boundary, which is ≤ now — well behind the
+            // already-set initialNextRunAt (≈ now + 3600s).
+            _ = try await client.schedule(
+                name: "sit-greatest-test",  // same name → ON CONFLICT DO UPDATE
+                pattern: .interval(.seconds(3600)),
+                workflowType: SitSimpleWorkflow.self,
+                input: .done,
+                startsAt: Date.now.addingTimeInterval(-7200)  // 2 hours ago
+            )
+
+            // Step 3: next_run_at must not have moved backward.
+            let after = try await client.listSchedules(queue: client.queueName)
+            let afterNextRunAt =
+                after
+                .first(where: { $0.name == "sit-greatest-test" })?.nextRunAt
+
+            #expect(afterNextRunAt != nil, "nextRunAt must remain set after re-registration")
+            if let afterNextRunAt {
+                #expect(
+                    afterNextRunAt >= initialNextRunAt.addingTimeInterval(-1),
+                    "next_run_at must not regress on re-registration: was \(initialNextRunAt), got \(afterNextRunAt)"
+                )
+            }
+
+            try? await client.deleteSchedule(id: scheduleID)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixed worker shutdown hang, addressed scheduler service

## Changes

Add static schedule declarations and make scheduler/worker behaviour more robust.

- Introduce StrandSchedule and allow StrandScheduler to accept a `schedules: [StrandSchedule]` list that is upserted to the DB at startup (fail-fast on bad declarations).
- Move schedule registration for the HackerNews example into the scheduler constructor and update README + doc page with examples and guidance for static vs runtime schedule registration.
- Update schedule upsert SQL to use GREATEST(...) for `next_run_at` and derive `is_active` from it to avoid regressing next_run_at on re-registration.
- Ensure `markScheduleFired` stores the scheduled slot time (`row.scheduledAt`) as `last_run_at` instead of wall-clock fire time; add integration tests to assert this and to verify `next_run_at` preservation.
- Improve worker shutdown and shutdown-related sleeps: switch to a discarding task group for controlled shutdown, use cancelWhenGracefulShutdown wrappers for sleeps and connection/listen loops to avoid runTimer/continuation leaks, and signal/expire in-flight runs on graceful shutdown.
- Pin postgres-nio to a specific revision (820771e) due to a runTimer continuation leak fix until an official release is available.

Also include small API documentation tweaks and example updates to reflect new static schedule API.

## Testing

<!-- How did you verify this works? Did you run `swift test`? -->

- [x] `swift test` passes locally

## AI Disclosure

<!--
  REQUIRED if any AI assistance was used — see CONTRIBUTING.md.
  Delete this section entirely if no AI was involved.
-->

- [ ] I used AI assistance while working on this PR

**Tool(s) used:** <!-- e.g. Claude, Copilot, ChatGPT -->

**Extent of use:**
<!-- Describe honestly. Examples:
  - Generated first draft of WorkflowDag.tsx, reviewed and edited manually.
  - Used for commit message suggestions only.
  - Pair-programmed the entire feature; all output was reviewed.
-->

**Was the PR description itself AI-generated?** No

Closes #2 