### PR TITLE
Use confirmation callbacks and poll for event wait

### DIFF
--- a/Tests/StrandTests/IntegrationTests.swift
+++ b/Tests/StrandTests/IntegrationTests.swift
@@ -440,8 +440,15 @@ struct EventTests {
                 input: EventWaitInput(eventName: eventName)
             )
 
-            // Give the workflow time to start and register the event wait.
-            try await Task.sleep(for: .milliseconds(400))
+            // Wait until the workflow has registered its event_waits row (state = WAITING).
+            // A fixed sleep is fragile on slow CI runners — if the first activation
+            // hasn't finished by the time we emit, the event fires before the wait
+            // is registered and the workflow never resumes.
+            let waitDeadline = ContinuousClock.now + .seconds(5)
+            while ContinuousClock.now < waitDeadline {
+                if let snap = try await handle.snapshot(), snap.state == .waiting { break }
+                try await Task.sleep(for: .milliseconds(50))
+            }
             try await client.emitEvent(eventName, payload: EventPayload(msg: "from-test"))
 
             let result = try await handle.result(timeout: .seconds(10))

--- a/Tests/StrandTests/LocalActivityTests.swift
+++ b/Tests/StrandTests/LocalActivityTests.swift
@@ -75,15 +75,13 @@ private struct MixedWorkflow: Workflow {
 }
 
 // Simple regular activity used by MixedWorkflow.
-// Accepts an optional TestExpectation so the mixed-activity test can
-// receive push notification instead of polling the DB.
 private struct ReverseLocalActivity: ActivityDefinition {
     typealias Input = String
     typealias Output = String
-    var done: TestExpectation?
+    var onRan: (@Sendable () -> Void)?
     func run(input: String, context: ActivityContext) async throws -> String {
         let result = String(input.reversed())
-        done?.trigger()
+        onRan?()
         return result
     }
 }
@@ -160,33 +158,33 @@ struct LocalActivityTests {
     @Test("local and regular activities can be mixed in the same workflow")
     func mixedLocalAndRegularActivity() async throws {
         try await withTestEnvironment { client in
-            // Push-based: ReverseLocalActivity triggers the expectation the
-            // instant it runs. No polling, no 2-second backoff window.
-            let done = TestExpectation()
-            let workerTask = startWorker(
-                postgres: client.postgres,
-                queueName: client.queueName,
-                logger: client.logger,
-                workflows: [MixedWorkflow.self],
-                activities: [UppercaseActivity(), ReverseLocalActivity(done: done)]
-            )
-            defer { workerTask.cancel() }
+            try await confirmation("ReverseLocalActivity ran") { confirm in
+                let workerTask = startWorker(
+                    postgres: client.postgres,
+                    queueName: client.queueName,
+                    logger: client.logger,
+                    workflows: [MixedWorkflow.self],
+                    activities: [UppercaseActivity(), ReverseLocalActivity(onRan: { confirm() })]
+                )
+                defer { workerTask.cancel() }
 
-            let handle = try await client.startWorkflow(
-                MixedWorkflow.self,
-                options: .init(),
-                input: "abc"
-            )
-            // "abc" → local uppercase → "ABC" → regular reverse → "CBA"
-            try await done.wait(for: "ReverseLocalActivity", timeout: .seconds(30))
-            let snap = try await awaitTerminal(
-                client: client,
-                taskID: handle.taskID,
-                timeout: .seconds(10)
-            )
-            #expect(snap.state == .completed)
-            let result = try snap.decodeResult(as: String.self)
-            #expect(result == "CBA")
+                let handle = try await client.startWorkflow(
+                    MixedWorkflow.self,
+                    options: .init(),
+                    input: "abc"
+                )
+                // "abc" → local uppercase → "ABC" → regular reverse → "CBA".
+                // awaitTerminal guarantees the activity completed before we return,
+                // so confirmation will see exactly 1 call to confirm().
+                let snap = try await awaitTerminal(
+                    client: client,
+                    taskID: handle.taskID,
+                    timeout: .seconds(30)
+                )
+                #expect(snap.state == .completed)
+                let result = try snap.decodeResult(as: String.self)
+                #expect(result == "CBA")
+            }
         }
     }
 

--- a/Tests/StrandTests/MetricsTests.swift
+++ b/Tests/StrandTests/MetricsTests.swift
@@ -172,9 +172,9 @@ private struct SimpleWorkflow: Workflow {
 private struct SimpleActivity: ActivityDefinition {
     typealias Input = String
     typealias Output = String
-    var done: TestExpectation?
+    var onRan: (@Sendable () -> Void)?
     func run(input: String, context: ActivityContext) async throws -> String {
-        done?.trigger()
+        onRan?()
         return input.uppercased()
     }
 }
@@ -268,25 +268,27 @@ struct MetricsTests {
         let metrics = TestMetricsFactory()
 
         try await withTestEnvironment { client in
-            let done = TestExpectation()
-            let workerTask = startWorker(
-                postgres: client.postgres,
-                queueName: client.queueName,
-                logger: client.logger,
-                workflows: [ActivityWorkflowM.self],
-                activities: [SimpleActivity(done: done)],
-                metricsFactory: metrics
-            )
-            defer { workerTask.cancel() }
+            try await confirmation("SimpleActivity ran") { confirm in
+                let workerTask = startWorker(
+                    postgres: client.postgres,
+                    queueName: client.queueName,
+                    logger: client.logger,
+                    workflows: [ActivityWorkflowM.self],
+                    activities: [SimpleActivity(onRan: { confirm() })],
+                    metricsFactory: metrics
+                )
+                defer { workerTask.cancel() }
 
-            let handle = try await client.startWorkflow(
-                ActivityWorkflowM.self,
-                options: .init(),
-                input: "hello"
-            )
-            try await done.wait(for: "SimpleActivity", timeout: .seconds(30))
-            let result = try await handle.result(timeout: .seconds(10))
-            #expect(result == "HELLO")
+                let handle = try await client.startWorkflow(
+                    ActivityWorkflowM.self,
+                    options: .init(),
+                    input: "hello"
+                )
+                // handle.result() only returns after the activity completed,
+                // so confirmation sees exactly 1 confirm() call.
+                let result = try await handle.result(timeout: .seconds(30))
+                #expect(result == "HELLO")
+            }
         }
 
         // Workflow + activity are each claimed tasks → at least 2 duration samples.
@@ -344,22 +346,22 @@ struct TracingTests {
 
         // ── Activity span ─────────────────────────────────────────────────────
         try await withTestEnvironment { client in
-            let done = TestExpectation()
-            let workerTask = startWorker(
-                postgres: client.postgres,
-                queueName: client.queueName,
-                logger: client.logger,
-                workflows: [ActivityWorkflowM.self],
-                activities: [SimpleActivity(done: done)]
-            )
-            defer { workerTask.cancel() }
-            let handle = try await client.startWorkflow(
-                ActivityWorkflowM.self,
-                options: .init(),
-                input: "span-test"
-            )
-            try await done.wait(for: "SimpleActivity", timeout: .seconds(30))
-            _ = try await awaitTerminal(client: client, taskID: handle.taskID, timeout: .seconds(10))
+            try await confirmation("SimpleActivity ran") { confirm in
+                let workerTask = startWorker(
+                    postgres: client.postgres,
+                    queueName: client.queueName,
+                    logger: client.logger,
+                    workflows: [ActivityWorkflowM.self],
+                    activities: [SimpleActivity(onRan: { confirm() })]
+                )
+                defer { workerTask.cancel() }
+                let handle = try await client.startWorkflow(
+                    ActivityWorkflowM.self,
+                    options: .init(),
+                    input: "span-test"
+                )
+                _ = try await awaitTerminal(client: client, taskID: handle.taskID, timeout: .seconds(30))
+            }
         }
 
         let actSpan = tracer.span(named: "SimpleActivity")


### PR DESCRIPTION
## Summary

Attempt number 3 at fixing flaky tests

## Changes

Replace fragile TestExpectation usage with onRan closure + confirmation helper in several tests to get push-style notifications without DB polling. In IntegrationTests, remove a fixed sleep and poll the workflow snapshot (up to 5s) until state == .waiting before emitting the event to avoid flakiness on slow CI. Adjusted related timeouts/comments to reflect the more robust synchronization.

## Testing

<!-- How did you verify this works? Did you run `swift test`? -->

- [x] `swift test` passes locally

## AI Disclosure

None

- [ ] I used AI assistance while working on this PR

**Tool(s) used:** <!-- e.g. Claude, Copilot, ChatGPT -->

**Extent of use:**
<!-- Describe honestly. Examples:
  - Generated first draft of WorkflowDag.tsx, reviewed and edited manually.
  - Used for commit message suggestions only.
  - Pair-programmed the entire feature; all output was reviewed.
-->

**Was the PR description itself AI-generated?** No
