### PR TITLE
Add dev workflows, notifier, and metrics buffering

### DIFF
--- a/Examples/Sources/DevServer/DevServer.swift
+++ b/Examples/Sources/DevServer/DevServer.swift
@@ -147,9 +147,10 @@ private func makePostgres(logger: Logger) -> PostgresClient {
     )
     // Pool sizing: Σ(activityConcurrency) + Σ(workflowConcurrency)
     //            + N workers × 3 (listenLoop + poll + lease)
-    //            + headroom for HTTP handlers
-    // ordersWorker (16+8) + reportsWorker (8+4) + 2×3 + 8 HTTP = 50
-    config.options.maximumConnections = 50
+    //            + headroom for HTTP handlers + notifier
+    // ordersWorker (16+8) + reportsWorker (8+4) + 2×3 + 8 HTTP + 1 notifier = 51
+    // Add headroom for podcast fan-outs (up to 8 parallel TranscribeSegment)
+    config.options.maximumConnections = 60
     return PostgresClient(configuration: config, backgroundLogger: logger)
 }
 
@@ -160,14 +161,44 @@ private func runSeeder(
     reports: StrandClient,
     logger: Logger
 ) async {
-    // postgres.run() is now managed by Application; give it a moment.
+    // Give the postgres pool a moment to be ready before the first seed.
     try? await Task.sleep(for: .milliseconds(500))
+    guard !Task.isShuttingDownGracefully else { return }
+
     await seedBatch(orders: orders, reports: reports, logger: logger)
 
-    while !Task.isCancelled {
-        try? await Task.sleep(for: .seconds(30))
-        guard !Task.isCancelled else { break }
+    var tick = 0
+    // Task.isShuttingDownGracefully is set via task-local storage by
+    // ServiceLifecycle when the ServiceGroup receives SIGTERM/SIGINT.
+    // It propagates into unstructured Tasks spawned from a managed context,
+    // so this check exits the loop without waiting for the next tick.
+    while !Task.isShuttingDownGracefully && !Task.isCancelled {
+        // cancelWhenGracefulShutdown wakes the sleep immediately on shutdown
+        // instead of waiting the full 30 s before the loop condition is checked.
+        try? await cancelWhenGracefulShutdown {
+            try await Task.sleep(for: .seconds(30))
+        }
+        guard !Task.isShuttingDownGracefully && !Task.isCancelled else { break }
+        tick += 1
         await seedOne(orders: orders, logger: logger)
+        // Billing: every 2 ticks (~60 s)
+        if tick % 2 == 0 {
+            let userID = Int.random(in: 4000...9999)
+            let email = "user\(userID)@example.com"
+            do {
+                _ = try await orders.startWorkflow(
+                    MonthlyBillingWorkflow.self,
+                    input: BillingInput(userID: userID, userEmail: email, adminEmail: "billing@example.com")
+                )
+                logger.info("[seeder] periodic billing userID=\(userID)")
+            } catch { logger.warning("[seeder] periodic billing: \(error)") }
+        }
+        // Voice training: every 4 ticks (~120 s)
+        if tick % 4 == 0 {
+            await seedVoiceTraining(client: orders, logger: logger)
+        }
+        // Podcast: every tick (~30 s) — short runs, good throughput driver
+        await seedOnePodcast(client: orders, logger: logger)
     }
 }
 
@@ -224,6 +255,10 @@ private func seedBatch(
     } catch {
         logger.warning("[seeder] misc tasks: \(error)")
     }
+
+    await seedBilling(client: orders, logger: logger)
+    await seedVoiceTraining(client: orders, logger: logger)
+    await seedPodcast(client: orders, logger: logger)
 }
 
 private func seedOne(orders: StrandClient, logger: Logger) async {
@@ -238,6 +273,90 @@ private func seedOne(orders: StrandClient, logger: Logger) async {
         logger.info("[seeder] periodic order \(id)")
     } catch {
         logger.warning("[seeder] periodic order: \(error)")
+    }
+}
+
+private func seedBilling(client: StrandClient, logger: Logger) async {
+    let users: [(Int, String, String)] = [
+        (1001, "alice@example.com", "billing@example.com"),
+        (1042, "bob@example.com", "billing@example.com"),
+        (2087, "carol@example.com", "billing@example.com"),
+        (3314, "dave@example.com", "billing@example.com"),
+    ]
+    for (userID, email, admin) in users {
+        do {
+            _ = try await client.startWorkflow(
+                MonthlyBillingWorkflow.self,
+                input: BillingInput(userID: userID, userEmail: email, adminEmail: admin)
+            )
+            logger.info("[seeder] billing userID=\(userID) enqueued")
+        } catch {
+            logger.warning("[seeder] billing userID=\(userID): \(error)")
+        }
+    }
+}
+
+private func seedVoiceTraining(client: StrandClient, logger: Logger) async {
+    let jobName = "voice-\(Int(Date().timeIntervalSince1970) % 10_000)"
+    do {
+        _ = try await client.startWorkflow(
+            TrainVoiceAssistantWorkflow.self,
+            input: TrainingJobInput(
+                jobName: jobName,
+                partitions: [
+                    CountryPartitionInput(country: "ID", partition: 0, variants: 2),
+                    CountryPartitionInput(country: "JP", partition: 1, variants: 4),
+                    CountryPartitionInput(country: "PN", partition: 2, variants: 2),
+                ]
+            )
+        )
+        logger.info("[seeder] voice training job '\(jobName)' enqueued")
+    } catch {
+        logger.warning("[seeder] voice training: \(error)")
+    }
+}
+
+private func seedPodcast(client: StrandClient, logger: Logger) async {
+    // Seed a variety of episode lengths on startup to populate the metrics dashboard.
+    // Longer episodes fan out to more parallel TranscribeSegment activities.
+    let episodes: [(String, String, Int)] = [
+        ("Corecursive", "The Mess We're In with Joe Armstrong", 120),  // 8 segments
+        ("The Changelog", "Swift on the Server", 45),  // 3 segments
+        ("How I Built This", "Figma: Dylan Field", 35),  // 2 segments
+        ("Darknet Diaries", "The Twitter Hack", 60),  // 4 segments
+    ]
+    for (show, title, duration) in episodes {
+        do {
+            _ = try await client.startWorkflow(
+                PodcastTranscriptionWorkflow.self,
+                input: PodcastEpisodeInput(showName: show, episodeTitle: title, durationMinutes: duration)
+            )
+            logger.info("[seeder] podcast '\(show)' enqueued (\(duration) min)")
+        } catch {
+            logger.warning("[seeder] podcast '\(show)': \(error)")
+        }
+    }
+}
+
+private func seedOnePodcast(client: StrandClient, logger: Logger) async {
+    let episodes: [(String, String, Int)] = [
+        ("Corecursive", "Forget Passwords with Randall Degges", 90),  // 6 segments
+        ("Corecursive", "The Mess We're In with Joe Armstrong", 120),  // 8 segments
+        ("Hardcore History", "Blueprint for Armageddon", 180),  // 8 segments (capped)
+        ("The Changelog", "Open Source AI", 45),  // 3 segments
+        ("Darknet Diaries", "SolarWinds", 55),  // 3 segments
+        ("How I Built This", "Stripe: Patrick Collison", 40),  // 2 segments
+        ("Software Unscripted", "Type Systems", 60),  // 4 segments
+    ]
+    let (show, title, duration) = episodes.randomElement()!
+    do {
+        _ = try await client.startWorkflow(
+            PodcastTranscriptionWorkflow.self,
+            input: PodcastEpisodeInput(showName: show, episodeTitle: title, durationMinutes: duration)
+        )
+        logger.info("[seeder] periodic podcast '\(show)' (\(duration) min)")
+    } catch {
+        logger.warning("[seeder] periodic podcast: \(error)")
     }
 }
 
@@ -306,6 +425,33 @@ private func seedOne(orders: StrandClient, logger: Logger) async {
             options: StrandOptions(logger: logger)
         )
 
+        // ── Shared LISTEN/NOTIFY hub ───────────────────────────────────────────────────────
+        // One StrandNotifier holds the single Postgres LISTEN connection for
+        // the entire process.  Both workers subscribe to strand_tasks; the
+        // MetricsBroadcastListener subscribes to strand_metrics.
+        // Before this: 2 workers × 1 listenLoop = 2 dedicated connections.
+        // After: 1 notifier, 2 subscribers — all share the same connection.
+        let notifier = StrandNotifier(
+            postgres: postgres,
+            channels: [StrandNotifier.tasksChannel, StrandNotifier.metricsChannel],
+            logger: logger
+        )
+
+        // ── Metrics ─────────────────────────────────────────────────────────────────────
+        // AggregatedMetricsBuffer: workers write exec times here after each
+        // task; StrandMetricsLoop flushes it every 5 s, compresses into
+        // DDSketches, and includes them in the broadcast so the dashboard
+        // can show p50/p95/p99 without any additional DB queries.
+        let metricsBuffer = AggregatedMetricsBuffer()
+        let metricsCache = MetricsCache()
+        let metricsListener = MetricsBroadcastListener(
+            notifier: notifier,
+            cache: metricsCache,
+            logger: logger
+        )
+        let metricsLoop = StrandMetricsLoop(client: ordersClient, metricsBuffer: metricsBuffer)
+
+        // ── Workers ─────────────────────────────────────────────────────────────────────────
         let ordersWorker = StrandWorker(
             postgres: postgres,
             options: WorkerOptions(
@@ -320,10 +466,30 @@ private func seedOne(orders: StrandClient, logger: Logger) async {
                 // Only 2 workers on this server — no thundering herd, no jitter needed.
                 notifyJitter: .zero
             ),
+            notifier: notifier,
+            metricsBuffer: metricsBuffer,
             workflows: [
                 ProcessOrderWorkflow.self,
                 GreetUserWorkflow.self,
                 FlakyTaskWorkflow.self,
+                MonthlyBillingWorkflow.self,
+                TrainVoiceAssistantWorkflow.self,
+                TrainCountryModelWorkflow.self,
+                PodcastTranscriptionWorkflow.self,
+            ],
+            activities: [
+                CalculateInvoiceActivity(),
+                ChargeCreditCardActivity(),
+                GeneratePDFActivity(),
+                SendEmailActivity(),
+                IngestTextCorpusActivity(),
+                AnalyzeTextCorpusActivity(),
+                GenerateVoiceModelActivity(),
+                PublishModelsActivity(),
+                DownloadEpisodeActivity(),
+                TranscribeSegmentActivity(),
+                MergeTranscriptActivity(),
+                GenerateChaptersActivity(),
             ],
             logger: logger
         )
@@ -339,11 +505,17 @@ private func seedOne(orders: StrandClient, logger: Logger) async {
                 leaseExpiryInterval: .seconds(5),
                 notifyJitter: .zero
             ),
+            notifier: notifier,
+            metricsBuffer: metricsBuffer,
             workflows: [GenerateReportWorkflow.self],
             logger: logger
         )
 
-        let router = StrandServer.buildRouter(client: ordersClient, postgres: postgres)
+        let router = StrandServer.buildRouter(
+            client: ordersClient,
+            postgres: postgres,
+            metricsCache: metricsCache
+        )
 
         var app = Application(
             router: router,
@@ -351,14 +523,13 @@ private func seedOne(orders: StrandClient, logger: Logger) async {
             logger: logger
         )
 
-        // Mirror the Hummingbird todos-postgres pattern exactly:
-        //   addServices → postgres, then workers (all managed by the Application)
-        //   beforeServerStarts → schema check + seed (postgres is live by here)
-        //   runService() → starts everything, handles SIGTERM/SIGINT
-        app.addServices(observability)  // must be first so OTel is live before any spans are emitted
+        app.addServices(observability)  // OTel must be first so spans are emitted correctly
         app.addServices(postgres)
+        app.addServices(notifier)  // one LISTEN connection, fans out to workers + listener
         app.addServices(ordersWorker)
         app.addServices(reportsWorker)
+        app.addServices(metricsListener)  // receives strand_metrics broadcasts→ updates cache
+        app.addServices(metricsLoop)  // broadcasts live counts every 5 s
 
         app.beforeServerStarts {
             try await ordersClient.verifySchema()

--- a/Examples/Sources/DevServer/MonthlyBilling/Activities/CalculateInvoiceActivity.swift
+++ b/Examples/Sources/DevServer/MonthlyBilling/Activities/CalculateInvoiceActivity.swift
@@ -1,0 +1,29 @@
+import Strand
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+struct CalculateInvoiceActivity: ActivityDefinition {
+    struct Input: Codable, Sendable {
+        let userID: Int
+    }
+    typealias Output = InvoiceData
+
+    func run(input: Input, context: ActivityContext) async throws -> InvoiceData {
+        try await Task.sleep(for: .milliseconds(Int64.random(in: 800...2_000)))
+        let invoiceID = "INV-\(input.userID)-\(Int(Date().timeIntervalSince1970) % 100_000)"
+        let rawAmount = Double.random(in: 49.99...499.99)
+        let amount = (rawAmount * 100).rounded() / 100
+        context.logger.info(
+            "Calculated invoice",
+            metadata: [
+                "invoiceID": .string(invoiceID),
+                "amount": .stringConvertible(amount),
+            ]
+        )
+        return InvoiceData(invoiceID: invoiceID, amount: amount)
+    }
+}

--- a/Examples/Sources/DevServer/MonthlyBilling/Activities/ChargeCreditCardActivity.swift
+++ b/Examples/Sources/DevServer/MonthlyBilling/Activities/ChargeCreditCardActivity.swift
@@ -1,0 +1,23 @@
+import Strand
+
+struct ChargeCreditCardActivity: ActivityDefinition {
+    struct Input: Codable, Sendable {
+        let invoiceID: String
+        let amount: Double
+    }
+    typealias Output = ChargeData
+
+    func run(input: Input, context: ActivityContext) async throws -> ChargeData {
+        try await Task.sleep(for: .milliseconds(Int64.random(in: 400...1_000)))
+        let chargeID = "ch_\(String(input.invoiceID.suffix(6)).lowercased())"
+        context.logger.info(
+            "Charged credit card",
+            metadata: [
+                "chargeID": .string(chargeID),
+                "invoiceID": .string(input.invoiceID),
+                "amount": .stringConvertible(input.amount),
+            ]
+        )
+        return ChargeData(chargeID: chargeID, invoiceID: input.invoiceID)
+    }
+}

--- a/Examples/Sources/DevServer/MonthlyBilling/Activities/GeneratePDFActivity.swift
+++ b/Examples/Sources/DevServer/MonthlyBilling/Activities/GeneratePDFActivity.swift
@@ -1,0 +1,22 @@
+import Strand
+
+struct GeneratePDFActivity: ActivityDefinition {
+    struct Input: Codable, Sendable {
+        let invoiceID: String
+        let chargeID: String
+    }
+    typealias Output = String
+
+    func run(input: Input, context: ActivityContext) async throws -> String {
+        try await Task.sleep(for: .milliseconds(Int64.random(in: 600...1_500)))
+        let pdfPath = "/receipts/\(input.invoiceID)/receipt.pdf"
+        context.logger.info(
+            "Generated PDF receipt",
+            metadata: [
+                "pdfPath": .string(pdfPath),
+                "invoiceID": .string(input.invoiceID),
+            ]
+        )
+        return pdfPath
+    }
+}

--- a/Examples/Sources/DevServer/MonthlyBilling/Activities/SendEmailActivity.swift
+++ b/Examples/Sources/DevServer/MonthlyBilling/Activities/SendEmailActivity.swift
@@ -1,0 +1,32 @@
+import Strand
+
+struct SendEmailActivity: ActivityDefinition {
+    struct Input: Codable, Sendable {
+        let to: String
+        let subject: String
+        let failureRate: Double
+    }
+    typealias Output = StrandVoid
+
+    func run(input: Input, context: ActivityContext) async throws -> StrandVoid {
+        try await Task.sleep(for: .milliseconds(Int64.random(in: 200...700)))
+
+        if context.attempt <= 2 && Double.random(in: 0..<1) < input.failureRate {
+            throw RateLimitError()
+        }
+
+        context.logger.info(
+            "Sent email",
+            metadata: [
+                "to": .string(input.to),
+                "subject": .string(input.subject),
+                "attempt": .stringConvertible(context.attempt),
+            ]
+        )
+        return StrandVoid()
+    }
+}
+
+struct RateLimitError: Error, CustomStringConvertible {
+    var description: String { "email send error: rate limit exceeded" }
+}

--- a/Examples/Sources/DevServer/MonthlyBilling/BillingTypes.swift
+++ b/Examples/Sources/DevServer/MonthlyBilling/BillingTypes.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Strand
+
+struct BillingInput: Codable, Sendable {
+    let userID: Int
+    let userEmail: String
+    let adminEmail: String
+}
+
+struct InvoiceData: Codable, Sendable {
+    let invoiceID: String
+    let amount: Double
+}
+
+struct ChargeData: Codable, Sendable {
+    let chargeID: String
+    let invoiceID: String
+}
+
+struct BillingResult: Codable, Sendable {
+    let invoiceID: String
+    let chargeID: String
+    let pdfPath: String
+}

--- a/Examples/Sources/DevServer/MonthlyBilling/Workflows/MonthlyBillingWorkflow.swift
+++ b/Examples/Sources/DevServer/MonthlyBilling/Workflows/MonthlyBillingWorkflow.swift
@@ -1,0 +1,81 @@
+import Strand
+
+/// Simulates a monthly billing pipeline:
+///
+/// 1. CalculateInvoice — compute the invoice amount
+/// 2. ChargeCreditCard — process the payment
+/// 3. GeneratePDF      — produce a PDF receipt
+/// 4. SendEmail (fan-out) — notify the user (60 % transient fail rate) and
+///    admin (10 % transient fail rate) in parallel
+struct MonthlyBillingWorkflow: Workflow {
+    typealias Input = BillingInput
+    typealias Output = BillingResult
+
+    mutating func run(
+        context: WorkflowContext<Self>,
+        input: BillingInput
+    ) async throws -> BillingResult {
+        // Step 1 — calculate invoice
+        let invoice = try await context.runActivity(
+            CalculateInvoiceActivity.self,
+            input: .init(userID: input.userID),
+            options: ActivityOptions(maxAttempts: 3)
+        )
+
+        // Step 2 — charge card
+        let charge = try await context.runActivity(
+            ChargeCreditCardActivity.self,
+            input: .init(invoiceID: invoice.invoiceID, amount: invoice.amount),
+            options: ActivityOptions(maxAttempts: 3)
+        )
+
+        // Step 3 — generate PDF
+        let pdfPath = try await context.runActivity(
+            GeneratePDFActivity.self,
+            input: .init(invoiceID: invoice.invoiceID, chargeID: charge.chargeID),
+            options: ActivityOptions(maxAttempts: 3)
+        )
+
+        // Step 4 — fan-out: send emails in parallel
+        try await withThrowingTaskGroup(of: StrandVoid.self) { group in
+            // User email — high failure rate (60 %) to show retries in the dashboard
+            group.addTask {
+                try await context.runActivity(
+                    SendEmailActivity.self,
+                    input: .init(
+                        to: input.userEmail,
+                        subject: "Your receipt for \(invoice.invoiceID)",
+                        failureRate: 0.60
+                    ),
+                    options: ActivityOptions(
+                        maxAttempts: 5,
+                        retryStrategy: .backoff(
+                            initial: .milliseconds(300),
+                            multiplier: 2.0,
+                            cap: .seconds(4)
+                        )
+                    )
+                )
+            }
+            // Admin notification — low failure rate (10 %)
+            group.addTask {
+                try await context.runActivity(
+                    SendEmailActivity.self,
+                    input: .init(
+                        to: input.adminEmail,
+                        subject: "Billing notification: \(invoice.invoiceID)",
+                        failureRate: 0.10
+                    ),
+                    options: ActivityOptions(maxAttempts: 3)
+                )
+            }
+            try await group.waitForAll()
+        }
+
+        return BillingResult(
+            invoiceID: invoice.invoiceID,
+            chargeID: charge.chargeID,
+            pdfPath: pdfPath
+        )
+    }
+}

--- a/Examples/Sources/DevServer/PodcastTranscription/Activities/DownloadEpisodeActivity.swift
+++ b/Examples/Sources/DevServer/PodcastTranscription/Activities/DownloadEpisodeActivity.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Strand
+
+/// Simulates fetching a podcast audio file from a CDN.
+/// Returns the episode ID and the number of ~15-minute segments the
+/// workflow will fan out to (capped at 8 so dev runs stay snappy).
+struct DownloadEpisodeActivity: ActivityDefinition {
+    struct Input: Codable, Sendable {
+        let showName: String
+        let episodeTitle: String
+        let durationMinutes: Int
+    }
+    typealias Output = DownloadedEpisode
+
+    func run(input: Input, context: ActivityContext) async throws -> DownloadedEpisode {
+        try await Task.sleep(for: .milliseconds(Int64.random(in: 500...1_200)))
+        let slug = input.showName.lowercased().replacingOccurrences(of: " ", with: "-")
+        let episodeID = "\(slug)-\(Int(Date().timeIntervalSince1970) % 100_000)"
+        // One segment per 15 minutes, minimum 2, maximum 8
+        let segments = max(2, min(8, input.durationMinutes / 15))
+        context.logger.info(
+            "episode downloaded",
+            metadata: [
+                "episode_id": .string(episodeID),
+                "segments": .stringConvertible(segments),
+            ]
+        )
+        return DownloadedEpisode(
+            episodeID: episodeID,
+            audioPath: "/audio/\(episodeID).mp3",
+            segments: segments,
+            durationMinutes: input.durationMinutes
+        )
+    }
+}

--- a/Examples/Sources/DevServer/PodcastTranscription/Activities/GenerateChaptersActivity.swift
+++ b/Examples/Sources/DevServer/PodcastTranscription/Activities/GenerateChaptersActivity.swift
@@ -1,0 +1,21 @@
+import Strand
+
+/// Simulates an LLM pass over the full transcript to extract chapter markers.
+struct GenerateChaptersActivity: ActivityDefinition {
+    typealias Input = ChapterInput
+    typealias Output = ChaptersResult
+
+    func run(input: Input, context: ActivityContext) async throws -> ChaptersResult {
+        try await Task.sleep(for: .milliseconds(Int64.random(in: 800...1_600)))
+        // Roughly one chapter per 15 minutes; at least 1
+        let chapters = max(1, input.durationMinutes / 15)
+        context.logger.info(
+            "chapters generated",
+            metadata: [
+                "episode_id": .string(input.episodeID),
+                "chapters": .stringConvertible(chapters),
+            ]
+        )
+        return ChaptersResult(chaptersGenerated: chapters)
+    }
+}

--- a/Examples/Sources/DevServer/PodcastTranscription/Activities/MergeTranscriptActivity.swift
+++ b/Examples/Sources/DevServer/PodcastTranscription/Activities/MergeTranscriptActivity.swift
@@ -1,0 +1,20 @@
+import Strand
+
+/// Joins all parallel segment transcripts into one document.
+/// This is the bottom point of the diamond — N parallel results converge here.
+struct MergeTranscriptActivity: ActivityDefinition {
+    typealias Input = MergeInput
+    typealias Output = FullTranscript
+
+    func run(input: Input, context: ActivityContext) async throws -> FullTranscript {
+        try await Task.sleep(for: .milliseconds(Int64.random(in: 300...700)))
+        let ordered = input.segments.sorted { $0.segmentIndex < $1.segmentIndex }
+        let merged = ordered.map(\.text).joined(separator: "\n\n")
+        let totalWords = ordered.reduce(0) { $0 + $1.wordCount }
+        return FullTranscript(
+            episodeID: input.episodeID,
+            text: merged,
+            wordCount: totalWords
+        )
+    }
+}

--- a/Examples/Sources/DevServer/PodcastTranscription/Activities/TranscribeSegmentActivity.swift
+++ b/Examples/Sources/DevServer/PodcastTranscription/Activities/TranscribeSegmentActivity.swift
@@ -1,0 +1,23 @@
+import Strand
+
+/// Simulates running speech-to-text on one ~15-minute audio segment.
+/// Multiple instances of this activity run in parallel — they form the wide
+/// part of the diamond fan-out.
+struct TranscribeSegmentActivity: ActivityDefinition {
+    typealias Input = SegmentInput
+    typealias Output = SegmentTranscript
+
+    func run(input: Input, context: ActivityContext) async throws -> SegmentTranscript {
+        // Transcription is CPU-heavy — each segment takes 0.8–1.8 s in sim
+        try await Task.sleep(for: .milliseconds(Int64.random(in: 800...1_800)))
+        let wordsPerSegment = Int.random(in: 1_800...2_400)
+        let text =
+            "Segment \(input.segmentIndex + 1)/\(input.totalSegments): "
+            + "[simulated transcript — \(wordsPerSegment) words]"
+        return SegmentTranscript(
+            segmentIndex: input.segmentIndex,
+            text: text,
+            wordCount: wordsPerSegment
+        )
+    }
+}

--- a/Examples/Sources/DevServer/PodcastTranscription/PodcastTypes.swift
+++ b/Examples/Sources/DevServer/PodcastTranscription/PodcastTypes.swift
@@ -1,0 +1,75 @@
+import Strand
+
+// MARK: - Podcast transcription pipeline types
+//
+// Diamond workflow shape:
+//
+//       [DownloadEpisode]
+//      /       |        \
+//   [T0]     [T1]  …  [TN]    ← N parallel TranscribeSegment activities
+//      \       |        /
+//       [MergeTranscript]       ← fan-in: all N segments joined
+//              |
+//       [GenerateChapters]
+
+struct PodcastEpisodeInput: Codable, Sendable {
+    let showName: String
+    let episodeTitle: String
+    /// Total episode duration — determines how many segments to fan out to.
+    let durationMinutes: Int
+}
+
+/// Output of DownloadEpisodeActivity.
+struct DownloadedEpisode: Codable, Sendable {
+    let episodeID: String
+    let audioPath: String
+    /// Number of ~15-minute segments this episode is split into (2–8).
+    let segments: Int
+    let durationMinutes: Int
+}
+
+/// Input/output for a single segment transcription.
+struct SegmentInput: Codable, Sendable {
+    let episodeID: String
+    let segmentIndex: Int
+    let totalSegments: Int
+}
+
+struct SegmentTranscript: Codable, Sendable {
+    let segmentIndex: Int
+    let text: String
+    let wordCount: Int
+}
+
+/// Input for the fan-in merge step.
+struct MergeInput: Codable, Sendable {
+    let episodeID: String
+    /// All segment transcripts, in any order — merge sorts by segmentIndex.
+    let segments: [SegmentTranscript]
+}
+
+struct FullTranscript: Codable, Sendable {
+    let episodeID: String
+    let text: String
+    let wordCount: Int
+}
+
+struct ChapterInput: Codable, Sendable {
+    let episodeID: String
+    /// Full merged transcript text (simulated; short in dev).
+    let transcript: String
+    let durationMinutes: Int
+}
+
+struct ChaptersResult: Codable, Sendable {
+    let chaptersGenerated: Int
+}
+
+struct PodcastResult: Codable, Sendable {
+    let episodeID: String
+    let showName: String
+    let episodeTitle: String
+    let wordCount: Int
+    let chaptersGenerated: Int
+    let transcriptPath: String
+}

--- a/Examples/Sources/DevServer/PodcastTranscription/Workflows/PodcastTranscriptionWorkflow.swift
+++ b/Examples/Sources/DevServer/PodcastTranscription/Workflows/PodcastTranscriptionWorkflow.swift
@@ -1,0 +1,85 @@
+import Strand
+
+/// Transcribes a podcast episode using a diamond fan-out / fan-in pattern.
+///
+/// ```
+///        [DownloadEpisode]          ← one activity
+///       /       |         \
+///    [T0]     [T1]  …   [TN]       ← N parallel TranscribeSegment (diamond wide)
+///       \       |         /
+///        [MergeTranscript]          ← fan-in (diamond point)
+///               |
+///        [GenerateChapters]         ← one final activity
+/// ```
+///
+/// N scales with `durationMinutes / 15` (capped 2–8) so longer episodes
+/// exercise wider fan-outs and generate more activity completions per cycle.
+struct PodcastTranscriptionWorkflow: Workflow {
+    typealias Input = PodcastEpisodeInput
+    typealias Output = PodcastResult
+
+    mutating func run(
+        context: WorkflowContext<Self>,
+        input: PodcastEpisodeInput
+    ) async throws -> PodcastResult {
+
+        // ── Step 1: Download ──────────────────────────────────────────────────
+        let episode = try await context.runActivity(
+            DownloadEpisodeActivity.self,
+            input: .init(
+                showName: input.showName,
+                episodeTitle: input.episodeTitle,
+                durationMinutes: input.durationMinutes
+            ),
+            options: ActivityOptions(maxAttempts: 3)
+        )
+
+        // ── Step 2: Fan-out — transcribe all segments in parallel ─────────────
+        // Each segment runs as an independent activity; they form the wide part
+        // of the diamond. The workflow is WAITING while all are in-flight.
+        var transcripts: [SegmentTranscript] = []
+        try await withThrowingTaskGroup(of: SegmentTranscript.self) { group in
+            for i in 0..<episode.segments {
+                group.addTask {
+                    try await context.runActivity(
+                        TranscribeSegmentActivity.self,
+                        input: SegmentInput(
+                            episodeID: episode.episodeID,
+                            segmentIndex: i,
+                            totalSegments: episode.segments
+                        ),
+                        options: ActivityOptions(maxAttempts: 3)
+                    )
+                }
+            }
+            for try await t in group { transcripts.append(t) }
+        }
+
+        // ── Step 3: Fan-in — merge (diamond converge point) ───────────────────
+        let merged = try await context.runActivity(
+            MergeTranscriptActivity.self,
+            input: MergeInput(episodeID: episode.episodeID, segments: transcripts),
+            options: ActivityOptions(maxAttempts: 3)
+        )
+
+        // ── Step 4: Generate chapter markers from the merged transcript ────────
+        let chapters = try await context.runActivity(
+            GenerateChaptersActivity.self,
+            input: ChapterInput(
+                episodeID: episode.episodeID,
+                transcript: merged.text,
+                durationMinutes: episode.durationMinutes
+            ),
+            options: ActivityOptions(maxAttempts: 3)
+        )
+
+        return PodcastResult(
+            episodeID: episode.episodeID,
+            showName: input.showName,
+            episodeTitle: input.episodeTitle,
+            wordCount: merged.wordCount,
+            chaptersGenerated: chapters.chaptersGenerated,
+            transcriptPath: "/transcripts/\(episode.episodeID)/transcript.txt"
+        )
+    }
+}

--- a/Examples/Sources/DevServer/TrainVoiceAssistant/Activities/AnalyzeTextCorpusActivity.swift
+++ b/Examples/Sources/DevServer/TrainVoiceAssistant/Activities/AnalyzeTextCorpusActivity.swift
@@ -1,0 +1,30 @@
+import Strand
+
+struct AnalyzeTextCorpusActivity: ActivityDefinition {
+    struct Input: Codable, Sendable {
+        let country: String
+        let variant: Int
+        let partition: Int
+        let corpusSize: Int
+    }
+    typealias Output = CorpusAnalysis
+
+    func run(input: Input, context: ActivityContext) async throws -> CorpusAnalysis {
+        try await Task.sleep(for: .milliseconds(Int64.random(in: 500...1_500)))
+        let analysisPath = "/analysis/\(input.country)/v\(input.variant)/features.bin"
+        context.logger.info(
+            "Analyzed text corpus",
+            metadata: [
+                "country": .string(input.country),
+                "variant": .stringConvertible(input.variant),
+                "corpusSize": .stringConvertible(input.corpusSize),
+                "analysisPath": .string(analysisPath),
+            ]
+        )
+        return CorpusAnalysis(
+            country: input.country,
+            variant: input.variant,
+            analysisPath: analysisPath
+        )
+    }
+}

--- a/Examples/Sources/DevServer/TrainVoiceAssistant/Activities/GenerateVoiceModelActivity.swift
+++ b/Examples/Sources/DevServer/TrainVoiceAssistant/Activities/GenerateVoiceModelActivity.swift
@@ -1,0 +1,23 @@
+import Strand
+
+struct GenerateVoiceModelActivity: ActivityDefinition {
+    struct Input: Codable, Sendable {
+        let country: String
+        let analysisPaths: [String]
+    }
+    typealias Output = VoiceModel
+
+    func run(input: Input, context: ActivityContext) async throws -> VoiceModel {
+        try await Task.sleep(for: .milliseconds(Int64.random(in: 1_500...3_000)))
+        let modelPath = "/models/\(input.country)/voice_v1.bin"
+        context.logger.info(
+            "Generated voice model",
+            metadata: [
+                "country": .string(input.country),
+                "analysisCount": .stringConvertible(input.analysisPaths.count),
+                "modelPath": .string(modelPath),
+            ]
+        )
+        return VoiceModel(country: input.country, modelPath: modelPath)
+    }
+}

--- a/Examples/Sources/DevServer/TrainVoiceAssistant/Activities/IngestTextCorpusActivity.swift
+++ b/Examples/Sources/DevServer/TrainVoiceAssistant/Activities/IngestTextCorpusActivity.swift
@@ -1,0 +1,23 @@
+import Strand
+
+struct IngestTextCorpusActivity: ActivityDefinition {
+    struct Input: Codable, Sendable {
+        let country: String
+        let partition: Int
+    }
+    typealias Output = CorpusData
+
+    func run(input: Input, context: ActivityContext) async throws -> CorpusData {
+        try await Task.sleep(for: .milliseconds(Int64.random(in: 1_500...3_000)))
+        let rowCount = Int.random(in: 80_000...500_000)
+        context.logger.info(
+            "Ingested text corpus",
+            metadata: [
+                "country": .string(input.country),
+                "partition": .stringConvertible(input.partition),
+                "rowCount": .stringConvertible(rowCount),
+            ]
+        )
+        return CorpusData(country: input.country, partition: input.partition, rowCount: rowCount)
+    }
+}

--- a/Examples/Sources/DevServer/TrainVoiceAssistant/Activities/PublishModelsActivity.swift
+++ b/Examples/Sources/DevServer/TrainVoiceAssistant/Activities/PublishModelsActivity.swift
@@ -1,0 +1,20 @@
+import Strand
+
+struct PublishModelsActivity: ActivityDefinition {
+    typealias Input = PublishInput
+    typealias Output = PublishResult
+
+    func run(input: Input, context: ActivityContext) async throws -> PublishResult {
+        try await Task.sleep(for: .milliseconds(Int64.random(in: 800...1_500)))
+        let registry = "registry.strand.dev"
+        context.logger.info(
+            "Published voice models",
+            metadata: [
+                "jobName": .string(input.jobName),
+                "registry": .string(registry),
+                "modelsPublished": .stringConvertible(input.modelPaths.count),
+            ]
+        )
+        return PublishResult(registry: registry, modelsPublished: input.modelPaths.count)
+    }
+}

--- a/Examples/Sources/DevServer/TrainVoiceAssistant/TrainingTypes.swift
+++ b/Examples/Sources/DevServer/TrainVoiceAssistant/TrainingTypes.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Strand
+
+struct TrainingJobInput: Codable, Sendable {
+    let jobName: String
+    let partitions: [CountryPartitionInput]
+}
+
+struct CountryPartitionInput: Codable, Sendable {
+    let country: String
+    let partition: Int
+    let variants: Int
+}
+
+struct CorpusData: Codable, Sendable {
+    let country: String
+    let partition: Int
+    let rowCount: Int
+}
+
+struct CorpusAnalysis: Codable, Sendable {
+    let country: String
+    let variant: Int
+    let analysisPath: String
+}
+
+struct VoiceModel: Codable, Sendable {
+    let country: String
+    let modelPath: String
+}
+
+struct CountryModelResult: Codable, Sendable {
+    let country: String
+    let modelPath: String
+    let variantsAnalyzed: Int
+}
+
+struct PublishInput: Codable, Sendable {
+    let jobName: String
+    let modelPaths: [String]
+}
+
+struct PublishResult: Codable, Sendable {
+    let registry: String
+    let modelsPublished: Int
+}
+
+struct TrainingJobResult: Codable, Sendable {
+    let jobName: String
+    let modelsPublished: Int
+    let countries: [String]
+}

--- a/Examples/Sources/DevServer/TrainVoiceAssistant/Workflows/TrainCountryModelWorkflow.swift
+++ b/Examples/Sources/DevServer/TrainVoiceAssistant/Workflows/TrainCountryModelWorkflow.swift
@@ -1,0 +1,62 @@
+import Strand
+
+/// Per-country child workflow used by ``TrainVoiceAssistantWorkflow``.
+///
+/// Pipeline for a single country/partition:
+/// 1. IngestTextCorpus  — download & store the raw corpus
+/// 2. AnalyzeTextCorpus — run N variant analyses in parallel (fan-out)
+/// 3. GenerateVoiceModel — train the model from all analysis artefacts
+struct TrainCountryModelWorkflow: Workflow {
+    typealias Input = CountryPartitionInput
+    typealias Output = CountryModelResult
+
+    mutating func run(
+        context: WorkflowContext<Self>,
+        input: CountryPartitionInput
+    ) async throws -> CountryModelResult {
+        // Step 1: ingest corpus for this country/partition
+        let corpus = try await context.runActivity(
+            IngestTextCorpusActivity.self,
+            input: .init(country: input.country, partition: input.partition),
+            options: ActivityOptions(maxAttempts: 3)
+        )
+
+        // Step 2: parallel analysis — one task per variant
+        var analyses: [CorpusAnalysis] = []
+        try await withThrowingTaskGroup(of: CorpusAnalysis.self) { group in
+            for variant in 0..<input.variants {
+                group.addTask {
+                    try await context.runActivity(
+                        AnalyzeTextCorpusActivity.self,
+                        input: .init(
+                            country: input.country,
+                            variant: variant,
+                            partition: input.partition,
+                            corpusSize: corpus.rowCount
+                        ),
+                        options: ActivityOptions(maxAttempts: 3)
+                    )
+                }
+            }
+            for try await analysis in group {
+                analyses.append(analysis)
+            }
+        }
+
+        // Step 3: generate voice model from all analyses
+        let model = try await context.runActivity(
+            GenerateVoiceModelActivity.self,
+            input: .init(
+                country: input.country,
+                analysisPaths: analyses.map(\.analysisPath)
+            ),
+            options: ActivityOptions(maxAttempts: 3)
+        )
+
+        return CountryModelResult(
+            country: input.country,
+            modelPath: model.modelPath,
+            variantsAnalyzed: analyses.count
+        )
+    }
+}

--- a/Examples/Sources/DevServer/TrainVoiceAssistant/Workflows/TrainVoiceAssistantWorkflow.swift
+++ b/Examples/Sources/DevServer/TrainVoiceAssistant/Workflows/TrainVoiceAssistantWorkflow.swift
@@ -1,0 +1,66 @@
+import Strand
+
+/// Top-level voice-assistant training job.
+///
+/// Fans out one ``TrainCountryModelWorkflow`` child per country partition
+/// (ID/JP/PN) in parallel, then publishes all generated models once every
+/// country has completed.
+///
+/// ```
+/// ┌──────────────┬──────────────┬──────────────┐
+/// TrainCountry   TrainCountry   TrainCountry
+///    (ID)           (JP)           (PN)
+///       └──────────────┴──────────────┘
+///                      │
+///               PublishModels
+/// ```
+struct TrainVoiceAssistantWorkflow: Workflow {
+    typealias Input = TrainingJobInput
+    typealias Output = TrainingJobResult
+
+    mutating func run(
+        context: WorkflowContext<Self>,
+        input: TrainingJobInput
+    ) async throws -> TrainingJobResult {
+        // Fan-out: one child workflow per country partition, all in parallel
+        var countryResults: [CountryModelResult] = []
+        try await withThrowingTaskGroup(of: CountryModelResult.self) { group in
+            for partition in input.partitions {
+                group.addTask {
+                    try await context.runChildWorkflow(
+                        TrainCountryModelWorkflow.self,
+                        input: partition
+                    )
+                }
+            }
+            for try await result in group {
+                countryResults.append(result)
+            }
+        }
+
+        // Publish all generated models
+        let published = try await context.runActivity(
+            PublishModelsActivity.self,
+            input: .init(
+                jobName: input.jobName,
+                modelPaths: countryResults.map(\.modelPath)
+            ),
+            options: ActivityOptions(maxAttempts: 3)
+        )
+
+        context.logger.info(
+            "Voice training job complete",
+            metadata: [
+                "jobName": .string(input.jobName),
+                "modelsPublished": .stringConvertible(published.modelsPublished),
+                "registry": .string(published.registry),
+            ]
+        )
+
+        return TrainingJobResult(
+            jobName: input.jobName,
+            modelsPublished: published.modelsPublished,
+            countries: countryResults.map(\.country)
+        )
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,8 @@ let package = Package(
         ),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0"),
+        .package(url: "https://github.com/adam-fowler/compress-nio.git", from: "1.4.2"),
+        .package(url: "https://github.com/swift-extras/swift-extras-base64.git", from: "1.0.0"),
     ],
     targets: [
         .target(
@@ -46,6 +48,8 @@ let package = Package(
                 ),
                 .product(name: "DequeModule", package: "swift-collections"),
                 .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
+                .product(name: "CompressNIO", package: "compress-nio"),
+                .product(name: "ExtrasBase64", package: "swift-extras-base64"),
             ],
             swiftSettings: [
                 // Non-isolated async functions run on a generic executor, not the caller's actor.

--- a/Sources/Strand/Activity.swift
+++ b/Sources/Strand/Activity.swift
@@ -384,26 +384,13 @@ extension ActivityDefinition {
                 fatalDeadline?.renew()
             }
         )
-        // OTel span: one span per activity execution attempt.
-        // SpanKind.consumer: child of the outer task consumer span; ServiceContext
-        // propagates automatically via task-local storage so no addLink is needed.
-        // Zero-cost no-op when no tracing backend is bootstrapped.
+        // Worker.runTask already opens a .consumer span (with the workflow activation
+        // span as its parent) that covers the full claim lifecycle.  Opening a second
+        // identical span here produces duplicate entries in Jaeger — same name, same
+        // strand.run.id, same attempt — which look like replay bugs.
+        // The activity just runs directly inside the outer span.
         do {
-            let output = try await withSpan(Self.name, ofKind: .consumer) { span in
-                span.attributes[StrandLogKeys.taskName] = SpanAttribute.string(Self.name)
-                span.attributes[StrandLogKeys.taskKind] = SpanAttribute.string(
-                    TaskKind.activity.rawValue
-                )
-                span.attributes[StrandLogKeys.taskID] = SpanAttribute.string(
-                    claimed.taskID.uuidString.lowercased()
-                )
-                span.attributes[StrandLogKeys.runID] = SpanAttribute.string(
-                    claimed.runID.uuidString.lowercased()
-                )
-                span.attributes[StrandLogKeys.queue] = SpanAttribute.string(exec.queue)
-                span.attributes[StrandLogKeys.attempt] = SpanAttribute.int(Int64(claimed.attempt))
-                return try await self.run(input: input, context: ctx)
-            }
+            let output = try await self.run(input: input, context: ctx)
             return try JSON.encode(output)
         } catch let typedFailure as Failure {
             // Typed failure declared by the activity — encode the full Codable value.

--- a/Sources/Strand/AggregatedMetricsBuffer.swift
+++ b/Sources/Strand/AggregatedMetricsBuffer.swift
@@ -1,0 +1,87 @@
+import Synchronization
+
+// MARK: - AggregatedMetricsBuffer
+
+/// Thread-safe in-memory buffer that accumulates task execution timings from
+/// one or more ``StrandWorker`` instances.
+///
+/// Workers call ``record(queue:taskName:state:execMs:waitMs:)`` synchronously
+/// after each terminal execution (zero allocation per call — just a Mutex lock
+/// + map update).  ``StrandMetricsLoop`` calls ``flush()`` every broadcast
+/// cycle to atomically swap out the buffer and serialise the accumulated
+/// ``DDSketch`` values into the `pg_notify` payload.
+///
+/// ## Buffer key
+///
+/// Entries are keyed by `"queue/taskName/state"` so completed and failed tasks
+/// are tracked in separate sketches — a task that always fails in 2 ms should
+/// not pollute the p95 of a task that succeeds in 200 ms.
+///
+/// Create one instance at the application level and pass it to every worker
+/// and to the metrics loop:
+///
+/// ```swift
+/// let metricsBuffer = AggregatedMetricsBuffer()
+/// let worker  = StrandWorker(..., metricsBuffer: metricsBuffer)
+/// let loop    = StrandMetricsLoop(client: client, metricsBuffer: metricsBuffer)
+/// ```
+public final class AggregatedMetricsBuffer: Sendable {
+
+    // MARK: - Internal entry
+
+    struct _Entry {
+        /// Wall-clock duration from claim to terminal state (ms).
+        var execTime: DDSketch = DDSketch()
+        /// Time spent waiting in the queue before being claimed (ms).
+        var waitTime: DDSketch = DDSketch()
+    }
+
+    // MARK: - Storage
+
+    private let _mutex: Mutex<[String: _Entry]> = Mutex([:])
+
+    public init() {}
+
+    // MARK: - Writer API (called by StrandWorker)
+
+    /// Record one task execution.
+    ///
+    /// - Parameters:
+    ///   - queue: The queue the task ran on.
+    ///   - taskName: The registered task name.
+    ///   - state: Terminal state — `.completed` or `.failed`.
+    ///   - execMs: Wall-clock execution duration in milliseconds.
+    ///   - waitMs: Time spent in the queue before being claimed (ms).
+    ///             Pass 0 or a negative value to skip wait_time recording.
+    public func record(
+        queue: String,
+        taskName: String,
+        state: TaskState,
+        execMs: Double,
+        waitMs: Double = 0
+    ) {
+        guard execMs > 0 else { return }
+        _mutex.withLock { entries in
+            let key = "\(queue)/\(taskName)/\(state.rawValue)"
+            entries[key, default: _Entry()].execTime.insert(execMs)
+            if waitMs > 0 {
+                entries[key, default: _Entry()].waitTime.insert(waitMs)
+            }
+        }
+    }
+
+    // MARK: - Reader API (called by StrandMetricsLoop)
+
+    /// Atomically returns all accumulated entries and resets the buffer to empty.
+    ///
+    /// Each entry maps `"queue/taskName/state"` to a pair of ``DDSketch``
+    /// values (exec_time and wait_time).  Returns an empty dict if no tasks
+    /// completed since the last flush.
+    func flush() -> [String: _Entry] {
+        _mutex.withLock { entries in
+            let snapshot = entries
+            entries = [:]
+            return snapshot
+        }
+    }
+}

--- a/Sources/Strand/DB/ManagementQueries.swift
+++ b/Sources/Strand/DB/ManagementQueries.swift
@@ -35,10 +35,15 @@ package struct TaskSummaryRow: Sendable {
     package let parentTaskId: UUID?
     /// Schedule name that triggered this task, or `nil` if not scheduled.
     package let scheduleName: String?
+    /// Human-readable workflow ID set at enqueue time via ``WorkflowOptions/id``.
+    /// Auto-generated as `"WorkflowName-<ms>"` when not explicitly provided.
+    /// `nil` for activity tasks (spawned internally, not via `startWorkflow`).
+    package let workflowId: String?
 }
 
 extension TaskSummaryRow {
-    /// Column order: id, name, queue, state, attempt, created_at, completed_at, kind, parent_task_id, scheduling_metadata
+    /// Column order: id, name, queue, state, attempt, created_at, completed_at,
+    ///               kind, parent_task_id, scheduling_metadata, idempotency_key
     package init(row: PostgresRow) throws {
         var col = row.makeIterator()
         id = try col.next()!.decode(UUID.self, context: .default)
@@ -51,6 +56,7 @@ extension TaskSummaryRow {
         kind = try col.next()!.decode(TaskKind.self, context: .default)
         parentTaskId = try col.next()!.decode(UUID?.self, context: .default)
         scheduleName = try col.next()!.decode(SchedulingMetadata?.self, context: .default)?.scheduledBy
+        workflowId = try col.next()!.decode(String?.self, context: .default)
     }
 }
 
@@ -72,6 +78,8 @@ package struct TaskDetailRow: Sendable {
     package let parentTaskId: UUID?
     /// Scheduling metadata decoded from task headers, or `nil` if not scheduled.
     package let schedulingMetadata: SchedulingMetadata?
+    /// Human-readable workflow ID (stored as `idempotency_key`). See ``TaskSummaryRow/workflowId``.
+    package let workflowId: String?
 }
 
 extension TaskDetailRow {
@@ -92,6 +100,7 @@ extension TaskDetailRow {
         kind = try col.next()!.decode(TaskKind.self, context: .default)
         parentTaskId = try col.next()!.decode(UUID?.self, context: .default)
         schedulingMetadata = try col.next()!.decode(SchedulingMetadata?.self, context: .default)
+        workflowId = try col.next()!.decode(String?.self, context: .default)
     }
 }
 
@@ -129,11 +138,13 @@ package struct QueueStatsRow: Sendable {
     package let createdAt: Date
     package let pending: Int
     package let running: Int
+    /// Workflows suspended on a `ctx.sleep(for:)` timer.
     package let sleeping: Int
+    /// Workflows suspended waiting for an activity, child workflow, or named event.
+    package let waiting: Int
     package let completed: Int
     package let failed: Int
     package let cancelled: Int
-    /// Whether the queue is administratively paused (requires is_paused column migration).
     package let isPaused: Bool
 }
 
@@ -145,6 +156,7 @@ extension QueueStatsRow {
         pending = try col.next()!.decode(Int.self, context: .default)
         running = try col.next()!.decode(Int.self, context: .default)
         sleeping = try col.next()!.decode(Int.self, context: .default)
+        waiting = try col.next()!.decode(Int.self, context: .default)
         completed = try col.next()!.decode(Int.self, context: .default)
         failed = try col.next()!.decode(Int.self, context: .default)
         cancelled = try col.next()!.decode(Int.self, context: .default)
@@ -189,12 +201,13 @@ package enum ManagementQueries {
             SELECT
               q.name,
               q.created_at,
-              COUNT(t.id) FILTER (WHERE t.state = 'PENDING')                    AS pending,
-              COUNT(t.id) FILTER (WHERE t.state = 'RUNNING')                    AS running,
-              COUNT(t.id) FILTER (WHERE t.state IN ('SLEEPING', 'WAITING'))     AS sleeping,
-              COUNT(t.id) FILTER (WHERE t.state = 'COMPLETED')                  AS completed,
-              COUNT(t.id) FILTER (WHERE t.state = 'FAILED')                     AS failed,
-              COUNT(t.id) FILTER (WHERE t.state = 'CANCELLED')                  AS cancelled,
+              COUNT(t.id) FILTER (WHERE t.state = 'PENDING')    AS pending,
+              COUNT(t.id) FILTER (WHERE t.state = 'RUNNING')    AS running,
+              COUNT(t.id) FILTER (WHERE t.state = 'SLEEPING')   AS sleeping,
+              COUNT(t.id) FILTER (WHERE t.state = 'WAITING')    AS waiting,
+              COUNT(t.id) FILTER (WHERE t.state = 'COMPLETED')  AS completed,
+              COUNT(t.id) FILTER (WHERE t.state = 'FAILED')     AS failed,
+              COUNT(t.id) FILTER (WHERE t.state = 'CANCELLED')  AS cancelled,
               q.is_paused
             FROM strand.queues q
             LEFT JOIN strand.tasks t ON t.queue = q.name AND t.namespace_id = q.namespace_id
@@ -221,12 +234,13 @@ package enum ManagementQueries {
             SELECT
               q.name,
               q.created_at,
-              COUNT(t.id) FILTER (WHERE t.state = 'PENDING')                    AS pending,
-              COUNT(t.id) FILTER (WHERE t.state = 'RUNNING')                    AS running,
-              COUNT(t.id) FILTER (WHERE t.state IN ('SLEEPING', 'WAITING'))     AS sleeping,
-              COUNT(t.id) FILTER (WHERE t.state = 'COMPLETED')                  AS completed,
-              COUNT(t.id) FILTER (WHERE t.state = 'FAILED')                     AS failed,
-              COUNT(t.id) FILTER (WHERE t.state = 'CANCELLED')                  AS cancelled,
+              COUNT(t.id) FILTER (WHERE t.state = 'PENDING')    AS pending,
+              COUNT(t.id) FILTER (WHERE t.state = 'RUNNING')    AS running,
+              COUNT(t.id) FILTER (WHERE t.state = 'SLEEPING')   AS sleeping,
+              COUNT(t.id) FILTER (WHERE t.state = 'WAITING')    AS waiting,
+              COUNT(t.id) FILTER (WHERE t.state = 'COMPLETED')  AS completed,
+              COUNT(t.id) FILTER (WHERE t.state = 'FAILED')     AS failed,
+              COUNT(t.id) FILTER (WHERE t.state = 'CANCELLED')  AS cancelled,
               q.is_paused
             FROM strand.queues q
             LEFT JOIN strand.tasks t ON t.queue = q.name AND t.namespace_id = q.namespace_id
@@ -260,7 +274,8 @@ package enum ManagementQueries {
         let fetchLimit = limit + 1  // fetch one extra to detect a next page
         let stream = try await client.query(
             """
-            SELECT id, name, queue, state, attempt, created_at, completed_at, kind, parent_task_id, scheduling_metadata
+            SELECT id, name, queue, state, attempt, created_at, completed_at,
+                   kind, parent_task_id, scheduling_metadata, idempotency_key
             FROM strand.tasks
             WHERE namespace_id = \(namespaceID)
               AND (\(queue)::text IS NULL OR queue = \(queue))
@@ -292,7 +307,7 @@ package enum ManagementQueries {
             """
             SELECT id, name, queue, params, state, attempt, max_attempts,
                    created_at, first_run_at, completed_at, result, cancelled_at,
-                   kind, parent_task_id, scheduling_metadata
+                   kind, parent_task_id, scheduling_metadata, idempotency_key
             FROM strand.tasks WHERE id = \(taskID) AND namespace_id = \(namespaceID)
             """,
             logger: logger
@@ -441,12 +456,18 @@ package enum ManagementQueries {
         }
         let stream = try await client.query(
             """
+            -- Each state clause uses its own terminal timestamp so the
+            -- partial indexes (strand_tasks_completed_at_idx, etc.) can be
+            -- used instead of scanning the full table.
             WITH to_delete AS (
                 SELECT id FROM strand.tasks
                 WHERE namespace_id = \(namespaceID)
                   AND (\(queue)::text IS NULL OR queue = \(queue))
-                  AND state IN ('COMPLETED', 'FAILED', 'CANCELLED')
-                  AND created_at < NOW() - \(effectiveAgeSeconds) * INTERVAL '1 second'
+                  AND (
+                        (state = 'COMPLETED' AND completed_at < NOW() - \(effectiveAgeSeconds) * INTERVAL '1 second')
+                     OR (state = 'CANCELLED' AND cancelled_at < NOW() - \(effectiveAgeSeconds) * INTERVAL '1 second')
+                     OR (state = 'FAILED'    AND created_at   < NOW() - \(effectiveAgeSeconds) * INTERVAL '1 second')
+                  )
                 LIMIT \(limit)
                 FOR UPDATE SKIP LOCKED
             ),
@@ -559,7 +580,8 @@ extension ManagementQueries {
         let fetchLimit = limit + 1
         let stream = try await client.query(
             """
-            SELECT id, name, queue, state, attempt, created_at, completed_at, kind, parent_task_id, scheduling_metadata
+            SELECT id, name, queue, state, attempt, created_at, completed_at,
+                   kind, parent_task_id, scheduling_metadata, idempotency_key
             FROM strand.tasks
             WHERE namespace_id = \(namespaceID)
               AND parent_task_id = \(parentTaskID)
@@ -582,18 +604,24 @@ extension ManagementQueries {
 
 package struct WorkerRow: Sendable {
     package let workerID: String
-    package let runningTasks: Int
-    package let completedRecently: Int  // completed/failed in last 5 min
-    package let lastSeenAt: Date?
-    package let leaseExpiresAt: Date?
+    package let queue: String  // from strand.workers.queue
+    package let concurrency: Int  // from strand.workers.concurrency
+    package let runningTasks: Int  // from strand.workers.running
+    package let completedRecently: Int  // from strand.runs JOIN
+    package let startedAt: Date  // from strand.workers.started_at
+    package let lastSeenAt: Date?  // from strand.workers.updated_at
+    package let leaseExpiresAt: Date?  // from strand.runs JOIN
 }
 
 extension WorkerRow {
     package init(row: PostgresRow) throws {
         var col = row.makeIterator()
         workerID = try col.next()!.decode(String.self, context: .default)
+        queue = try col.next()!.decode(String.self, context: .default)
+        concurrency = try col.next()!.decode(Int.self, context: .default)
         runningTasks = try col.next()!.decode(Int.self, context: .default)
         completedRecently = try col.next()!.decode(Int.self, context: .default)
+        startedAt = try col.next()!.decode(Date.self, context: .default)
         lastSeenAt = try col.next()!.decode(Date?.self, context: .default)
         leaseExpiresAt = try col.next()!.decode(Date?.self, context: .default)
     }
@@ -628,8 +656,8 @@ extension WorkerTaskRow {
 }
 
 extension ManagementQueries {
-    /// Returns worker summaries: currently-running workers + any that were
-    /// active in the last 5 minutes.
+    /// Returns worker summaries sourced from `strand.workers` (live heartbeat rows),
+    /// LEFT JOIN `strand.runs` for `completedRecently` and `leaseExpiresAt`.
     package static func listWorkers(
         on client: PostgresClient,
         namespaceID: String,
@@ -638,21 +666,31 @@ extension ManagementQueries {
         let stream = try await client.query(
             """
             SELECT
-              worker_id,
-              COUNT(*)       FILTER (WHERE state = 'RUNNING')                       AS running_tasks,
-              COUNT(*)       FILTER (WHERE state IN ('COMPLETED','FAILED','CANCELLED')
-                                      AND finished_at > NOW() - INTERVAL '5 minutes') AS completed_recently,
-              MAX(GREATEST(COALESCE(started_at, created_at),
-                           COALESCE(finished_at, created_at)))                      AS last_seen_at,
-              MAX(lease_expires_at) FILTER (WHERE state = 'RUNNING')               AS lease_expires_at
-            FROM strand.runs
-            WHERE namespace_id = \(namespaceID)
-              AND worker_id IS NOT NULL
-              AND (state = 'RUNNING'
-                OR (state IN ('COMPLETED','FAILED','CANCELLED')
-                    AND finished_at > NOW() - INTERVAL '5 minutes'))
-            GROUP BY worker_id
-            ORDER BY running_tasks DESC, last_seen_at DESC
+              w.id              AS worker_id,
+              w.queue,
+              w.concurrency,
+              w.running         AS running_tasks,
+              COALESCE(r.completed_recently, 0) AS completed_recently,
+              w.started_at,
+              w.updated_at      AS last_seen_at,
+              r.lease_expires_at
+            FROM strand.workers w
+            LEFT JOIN (
+              SELECT
+                worker_id,
+                COUNT(*) FILTER (WHERE state IN ('COMPLETED','FAILED','CANCELLED')
+                                   AND finished_at > NOW() - INTERVAL '5 minutes') AS completed_recently,
+                MAX(lease_expires_at) FILTER (WHERE state = 'RUNNING') AS lease_expires_at
+              FROM strand.runs
+              WHERE namespace_id = \(namespaceID)
+                AND worker_id IS NOT NULL
+                AND (state = 'RUNNING'
+                  OR (state IN ('COMPLETED','FAILED','CANCELLED')
+                      AND finished_at > NOW() - INTERVAL '5 minutes'))
+              GROUP BY worker_id
+            ) r ON r.worker_id = w.id
+            WHERE w.namespace_id = \(namespaceID)
+            ORDER BY w.running DESC, w.updated_at DESC
             """,
             logger: logger
         )
@@ -662,30 +700,42 @@ extension ManagementQueries {
     }
 
     /// Returns the summary row for one worker plus its 50 most recent task runs.
-    /// Returns `nil` when the worker hasn't been seen in the last 24 hours.
+    /// Returns `nil` when the worker has no row in `strand.workers`.
     package static func getWorkerDetail(
         on client: PostgresClient,
         namespaceID: String,
         workerID: String,
         logger: Logger
     ) async throws -> (summary: WorkerRow?, recentTasks: [WorkerTaskRow]) {
-        // Summary — same aggregation as listWorkers but for one worker.
+        // Summary — same shape as listWorkers but filtered to one worker.
         let summaryStream = try await client.query(
             """
             SELECT
-              worker_id,
-              COUNT(*)       FILTER (WHERE state = 'RUNNING')                       AS running_tasks,
-              COUNT(*)       FILTER (WHERE state IN ('COMPLETED','FAILED','CANCELLED')
-                                      AND finished_at > NOW() - INTERVAL '5 minutes') AS completed_recently,
-              MAX(GREATEST(COALESCE(started_at, created_at),
-                           COALESCE(finished_at, created_at)))                      AS last_seen_at,
-              MAX(lease_expires_at) FILTER (WHERE state = 'RUNNING')               AS lease_expires_at
-            FROM strand.runs
-            WHERE namespace_id = \(namespaceID)
-              AND worker_id    = \(workerID)
-              AND (state = 'RUNNING'
-                OR started_at > NOW() - INTERVAL '24 hours')
-            GROUP BY worker_id
+              w.id              AS worker_id,
+              w.queue,
+              w.concurrency,
+              w.running         AS running_tasks,
+              COALESCE(r.completed_recently, 0) AS completed_recently,
+              w.started_at,
+              w.updated_at      AS last_seen_at,
+              r.lease_expires_at
+            FROM strand.workers w
+            LEFT JOIN (
+              SELECT
+                worker_id,
+                COUNT(*) FILTER (WHERE state IN ('COMPLETED','FAILED','CANCELLED')
+                                   AND finished_at > NOW() - INTERVAL '5 minutes') AS completed_recently,
+                MAX(lease_expires_at) FILTER (WHERE state = 'RUNNING') AS lease_expires_at
+              FROM strand.runs
+              WHERE namespace_id = \(namespaceID)
+                AND worker_id    = \(workerID)
+                AND (state = 'RUNNING'
+                  OR (state IN ('COMPLETED','FAILED','CANCELLED')
+                      AND finished_at > NOW() - INTERVAL '5 minutes'))
+              GROUP BY worker_id
+            ) r ON r.worker_id = w.id
+            WHERE w.namespace_id = \(namespaceID)
+              AND w.id           = \(workerID)
             """,
             logger: logger
         )

--- a/Sources/Strand/DB/Queries.swift
+++ b/Sources/Strand/DB/Queries.swift
@@ -195,7 +195,7 @@ enum Queries {
                 logger.debug(
                     "task enqueued",
                     metadata: [
-                        "strand.task_id": .string(taskID.uuidString),
+                        "strand.task_id": .stringConvertible(taskID),
                         "strand.task_name": .string(taskName),
                         "strand.queue": .string(queue),
                         "strand.namespace": .string(namespaceID),
@@ -299,7 +299,7 @@ enum Queries {
                     lease_expires_at = NOW() + COALESCE(NULLIF(c.timeout_seconds, 0), \(claimTimeoutSeconds)) * INTERVAL '1 second',
                     started_at       = COALESCE(r.started_at, NOW())
                 FROM candidate c WHERE r.id = c.id
-                RETURNING r.id, r.task_id, r.attempt, r.version, r.wake_event, r.event_payload
+                RETURNING r.id, r.task_id, r.attempt, r.version, r.wake_event, r.event_payload, r.available_at
             ),
             task_upd AS (
                 UPDATE strand.tasks t
@@ -311,7 +311,8 @@ enum Queries {
             SELECT c.id, c.task_id, c.attempt, c.version,
                    t.name, t.params, t.retry_strategy, t.max_attempts, t.headers,
                    c.wake_event, c.event_payload,
-                   t.parent_task_id, t.kind, t.timeout_seconds, t.scheduling_metadata
+                   t.parent_task_id, t.kind, t.timeout_seconds, t.scheduling_metadata,
+                   c.available_at
             FROM claimed c JOIN strand.tasks t ON t.id = c.task_id
             ORDER BY c.id
             """,
@@ -700,7 +701,7 @@ enum Queries {
 
         logger.debug(
             "task cancelled",
-            metadata: ["strand.task_id": .string(taskID.uuidString)]
+            metadata: ["strand.task_id": .stringConvertible(taskID)]
         )
     }
 
@@ -1064,6 +1065,96 @@ enum Queries {
                 logger: logger
             )
         }
+    }
+
+    // MARK: - Worker heartbeat
+
+    /// Upserts a worker heartbeat row into `strand.workers`.
+    /// Called on startup (running=0) and on every heartbeat tick (with current running count).
+    static func upsertWorker(
+        on client: PostgresClient,
+        workerID: String,
+        namespaceID: String,
+        queue: String,
+        concurrency: Int,
+        running: Int,
+        logger: Logger
+    ) async throws {
+        try await client.query(
+            """
+            INSERT INTO strand.workers (id, namespace_id, queue, concurrency, running, started_at, updated_at)
+            VALUES (\(workerID), \(namespaceID), \(queue), \(concurrency), \(running), NOW(), NOW())
+            ON CONFLICT (id, namespace_id, queue)
+            DO UPDATE SET
+                concurrency  = EXCLUDED.concurrency,
+                running      = EXCLUDED.running,
+                updated_at   = NOW()
+            """,
+            logger: logger
+        )
+    }
+
+    /// Deletes a worker row — called on clean shutdown.
+    /// Workers killed without a graceful shutdown are swept by `sweepStaleWorkers`.
+    static func deleteWorker(
+        on client: PostgresClient,
+        workerID: String,
+        namespaceID: String,
+        queue: String,
+        logger: Logger
+    ) async throws {
+        try await client.query(
+            """
+            DELETE FROM strand.workers
+            WHERE id           = \(workerID)
+              AND namespace_id = \(namespaceID)
+              AND queue        = \(queue)
+            """,
+            logger: logger
+        )
+    }
+
+    /// Graceful-shutdown helper: expires in-flight run leases and removes the
+    /// worker heartbeat row in a single round-trip.
+    ///
+    /// Previously these were two separate queries (two pool checkouts, two
+    /// network round-trips). The CTE folds them into one atomic statement.
+    static func shutdownWorker(
+        on client: PostgresClient,
+        workerID: String,
+        namespaceID: String,
+        queue: String,
+        logger: Logger
+    ) async throws {
+        try await client.query(
+            """
+            WITH expire_runs AS (
+                UPDATE strand.runs
+                SET lease_expires_at = NOW()
+                WHERE worker_id    = \(workerID)
+                  AND namespace_id = \(namespaceID)
+                  AND state        = \(TaskState.running)
+            )
+            DELETE FROM strand.workers
+            WHERE id           = \(workerID)
+              AND namespace_id = \(namespaceID)
+              AND queue        = \(queue)
+            """,
+            logger: logger
+        )
+    }
+
+    /// Removes worker rows whose `updated_at` is older than `olderThanSeconds`.
+    /// Called on each heartbeat tick so stale entries from crashed workers are cleaned up.
+    static func sweepStaleWorkers(
+        on client: PostgresClient,
+        olderThanSeconds: Int,
+        logger: Logger
+    ) async throws {
+        try await client.query(
+            "DELETE FROM strand.workers WHERE updated_at < NOW() - \(olderThanSeconds) * INTERVAL '1 second'",
+            logger: logger
+        )
     }
 
     // MARK: - continueAsNew for child workflows

--- a/Sources/Strand/DB/RowDecoding.swift
+++ b/Sources/Strand/DB/RowDecoding.swift
@@ -48,6 +48,11 @@ struct ClaimedTask: Sendable {
     /// Scheduling metadata injected by `StrandScheduler`. `nil` for directly-enqueued tasks.
     let schedulingMetadata: SchedulingMetadata?
 
+    /// The wall-clock time at which this run last became PENDING/SLEEPING (i.e. available
+    /// for claiming).  Used to compute `wait_time` — how long the task spent in the queue
+    /// before a worker picked it up.
+    let availableAt: Date
+
     /// `true` when this attempt is the last one allowed.
     ///
     /// Used to decide whether a thrown error should mark the OTel span `ERROR`.
@@ -62,7 +67,8 @@ struct ClaimedTask: Sendable {
 extension ClaimedTask {
     /// Decode from the column order returned by the claim CTE:
     /// run_id, task_id, attempt, version, task_name, params,
-    /// retry_strategy, max_attempts, headers, wake_event, event_payload
+    /// retry_strategy, max_attempts, headers, wake_event, event_payload,
+    /// parent_task_id, kind, timeout_seconds, scheduling_metadata, available_at
     init(row: PostgresRow) throws {
         var col = row.makeIterator()
         runID = try col.next()!.decode(UUID.self, context: .default)
@@ -88,6 +94,7 @@ extension ClaimedTask {
         kind = try col.next()!.decode(TaskKind.self, context: .default)
         timeoutSeconds = try col.next()!.decode(Int?.self, context: .default)
         schedulingMetadata = try col.next()!.decode(SchedulingMetadata?.self, context: .default)
+        availableAt = try col.next()!.decode(Date.self, context: .default)
     }
 }
 

--- a/Sources/Strand/Errors.swift
+++ b/Sources/Strand/Errors.swift
@@ -152,8 +152,23 @@ public protocol NonRetryableError: Error {}
 /// Pre-encoded activity failure reason thrown from `ActivityDefinition._run`.
 /// Carries the JSON BYTEA that should be stored verbatim in `strand.runs.failure_reason`.
 /// `StrandWorker.runTask` catches this to bypass re-encoding in `FailureReason`.
-struct _TypedActivityFailure: Error {
+struct _TypedActivityFailure: Error, CustomStringConvertible {
     let reasonBuffer: ByteBuffer
+
+    /// Human-readable description used by OTel’s `withSpan` when recording this
+    /// error as an exception attribute on the activity span.
+    /// Without this, swift-distributed-tracing falls back to `String(describing:)`
+    /// which emits the raw struct internals: `_TypedActivityFailure(reasonBuffer: [7b...])`.
+    var description: String {
+        struct Reason: Decodable {
+            let name: String
+            let message: String
+        }
+        if let r = try? JSON.decode(Reason.self, from: reasonBuffer) {
+            return "\(r.name): \(r.message)"
+        }
+        return "activity failed"
+    }
 
     /// Builds the failure reason payload and encodes it as JSON.
     /// Falls back to a minimal JSON string if encoding itself fails.

--- a/Sources/Strand/Internal/DDSketch.swift
+++ b/Sources/Strand/Internal/DDSketch.swift
@@ -1,0 +1,132 @@
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+// MARK: - DDSketch
+
+/// A DDSketch histogram with 2 % relative error.
+///
+/// ## How it works
+///
+/// Each measurement is mapped to a logarithmic bucket:
+///
+///     bin(v) = ⌈log(v) / log(γ)⌉
+///
+/// where `γ = (1 + ε) / (1 − ε)` and `ε = 0.02`. Values inside the same
+/// bucket are at most 2 % apart, so any quantile estimate has at most 2 %
+/// relative error.  The number of buckets grows as `O(log(max/min))` which
+/// for millisecond timings (1 ms – 10 min) is roughly 300 bins regardless of
+/// how many measurements were recorded.
+///
+/// ## Thread safety
+///
+/// `DDSketch` is a value type (`struct`).  Use a `Mutex` or similar when
+/// sharing across tasks; see ``AggregatedMetricsBuffer``.
+public struct DDSketch: Sendable {
+
+    // MARK: - Constants
+
+    public static let errorRate: Double = 0.02
+    /// γ = (1 + ε) / (1 − ε)
+    public static let gamma: Double = (1 + errorRate) / (1 - errorRate)  // ≈ 1.0408
+    /// 1 / log(γ)  — multiply by log(v) to get the bin index
+    public static let invLogGamma: Double = 1.0 / log(gamma)  // ≈ 25.07
+    /// log₂(γ) — used with exp2() for fast bucket midpoint reconstruction.
+    /// Avoids per-call log() inside pow(): γ^x = 2^(x · log₂γ).
+    public static let log2gamma: Double = log2(gamma)  // ≈ 0.05715
+
+    // MARK: - Storage
+
+    /// Logarithmic bucket index → observation count.
+    private(set) var bins: [Int: Int] = [:]
+    /// Total number of observations inserted.
+    private(set) var count: Int = 0
+
+    // MARK: - Mutation
+
+    /// Record one measurement (in milliseconds).  Values ≤ 0 are silently ignored.
+    public mutating func insert(_ ms: Double) {
+        guard ms > 0 else { return }
+        let bin = Int((log(ms) * Self.invLogGamma).rounded(.up))
+        bins[bin, default: 0] += 1
+        count += 1
+    }
+
+    /// Merge another sketch into this one (in-place).
+    public mutating func merge(_ other: DDSketch) {
+        for (bin, n) in other.bins {
+            bins[bin, default: 0] += n
+        }
+        count += other.count
+    }
+
+    // MARK: - Query
+
+    /// Estimate the `q`-th quantile (0 … 1), returned in milliseconds.
+    ///
+    /// Returns `nil` when the sketch is empty.
+    ///
+    /// ## Error guarantee
+    ///
+    /// Each value `v` is placed in bucket `k = ⌈log(v)/log(γ)⌉`.  The estimate
+    /// uses the *geometric midpoint* `γ^(k‒0.5)` rather than the ceiling `γ^k`.
+    /// Any value `v` in bucket `k` satisfies `γ^(k−1) < v ≤ γ^k`, so:
+    ///
+    ///   max overestimate  = γ^(k−0.5) / γ^(k−1) − 1 = γ^0.5 − 1 ≈ 2 %
+    ///   max underestimate = 1 − γ^(k−0.5) / γ^k   = 1 − γ^(−0.5) ≈ 2 %
+    ///
+    /// This matches the symmetric `±2 %` guarantee cited in the DDSketch paper.
+    public func quantile(_ q: Double) -> Double? {
+        guard count > 0, (0...1).contains(q) else { return nil }
+        let target = Int((q * Double(count)).rounded(.up))
+        var accumulated = 0
+        for key in bins.keys.sorted() {
+            accumulated += bins[key, default: 0]
+            if accumulated >= target {
+                // Geometric midpoint: γ^(k−0.5) = 2^((k−0.5) · log₂γ)
+                // exp2 maps to a single hardware instruction; pow() would
+                // internally compute exp(x·log(γ)), paying log() every call.
+                return exp2((Double(key) - 0.5) * Self.log2gamma)
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Serialisation
+
+    /// A `Codable` representation that fits inside a `pg_notify` payload.
+    ///
+    /// JSON dict keys must be strings, so bin indices are encoded as their
+    /// decimal string representation.  The decoder converts them back to `Int`.
+    public struct Serialized: Codable, Sendable {
+        /// Bucket index (as decimal string) → observation count.
+        public let bins: [String: Int]
+        /// Total number of observations.
+        public let size: Int
+
+        public init(from sketch: DDSketch) {
+            bins = Dictionary(uniqueKeysWithValues: sketch.bins.map { ("\($0.key)", $0.value) })
+            size = sketch.count
+        }
+
+        /// Estimate the `q`-th quantile (ms).  Returns `nil` for an empty sketch.
+        /// Uses the geometric midpoint `γ^(k−0.5)` for symmetric ±2 % error.
+        public func quantile(_ q: Double) -> Double? {
+            guard size > 0, (0...1).contains(q) else { return nil }
+            let target = Int((q * Double(size)).rounded(.up))
+            let sorted = bins.compactMap { k, v -> (Int, Int)? in
+                Int(k).map { ($0, v) }
+            }.sorted { $0.0 < $1.0 }
+            var accumulated = 0
+            for (key, n) in sorted {
+                accumulated += n
+                if accumulated >= target {
+                    return exp2((Double(key) - 0.5) * DDSketch.log2gamma)
+                }
+            }
+            return nil
+        }
+    }
+}

--- a/Sources/Strand/Internal/DDSketch.swift
+++ b/Sources/Strand/Internal/DDSketch.swift
@@ -1,7 +1,9 @@
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
-import Foundation
+#if canImport(Darwin)
+import Darwin  // For macOS, iOS, watchOS, tvOS
+#elseif canImport(Glibc)
+import Glibc  // For Linux
+#elseif os(Windows)
+import ucrt  // For Windows
 #endif
 
 // MARK: - DDSketch

--- a/Sources/Strand/Internal/JSONHelpers.swift
+++ b/Sources/Strand/Internal/JSONHelpers.swift
@@ -1,4 +1,4 @@
-import NIOCore
+package import NIOCore
 import NIOFoundationCompat
 
 #if canImport(FoundationEssentials)
@@ -12,7 +12,7 @@ import Foundation
 ///
 /// `NIOFoundationCompat` provides the `encodeAsByteBuffer` and
 /// `decode(_:from:ByteBuffer)` overloads used here.
-enum JSON {
+package enum JSON {
 
     // MARK: - Shared instances
     //
@@ -32,7 +32,7 @@ enum JSON {
     /// available option without a third-party JSON library.
     ///
     /// - Throws: `StrandError.serialization` if encoding fails.
-    static func encode<T: Encodable & Sendable>(_ value: T) throws(StrandError) -> ByteBuffer {
+    package static func encode<T: Encodable & Sendable>(_ value: T) throws(StrandError) -> ByteBuffer {
         do {
             return try encoder.encodeAsByteBuffer(value, allocator: allocator)
         } catch {
@@ -47,7 +47,7 @@ enum JSON {
     /// ByteBuffer's backing storage.
     ///
     /// - Throws: `StrandError.serialization` if decoding fails.
-    static func decode<T: Decodable>(
+    package static func decode<T: Decodable>(
         _ type: T.Type,
         from buffer: ByteBuffer
     ) throws(StrandError) -> T {
@@ -75,7 +75,7 @@ enum JSON {
     /// (unlike the failable `string.data(using: .utf8)` form), so no optional is needed.
     ///
     /// - Throws: `StrandError.serialization` if decoding fails.
-    static func decode<T: Decodable>(_ type: T.Type, from string: String) throws(StrandError) -> T {
+    package static func decode<T: Decodable>(_ type: T.Type, from string: String) throws(StrandError) -> T {
         do {
             return try decoder.decode(type, from: Data(string.utf8))
         } catch {
@@ -86,7 +86,7 @@ enum JSON {
     /// Decode `type` from an optional buffer. Returns `nil` for `nil` or
     /// empty buffers (representing SQL `NULL` / empty JSON columns).
     /// - Throws: `StrandError.serialization` if `JSONDecoder` fails.
-    static func decodeOptional<T: Decodable>(
+    package static func decodeOptional<T: Decodable>(
         _ type: T.Type,
         from buffer: ByteBuffer?
     ) throws(StrandError) -> T? {

--- a/Sources/Strand/Internal/JSONHelpers.swift
+++ b/Sources/Strand/Internal/JSONHelpers.swift
@@ -20,7 +20,7 @@ package enum JSON {
     // JSONEncoder / JSONDecoder are classes; construction allocates and initialises
     // strategy tables. Both are `Sendable` in Swift 6 and stateless after init
     // (we never mutate date/key strategies), so sharing across concurrent tasks is safe.
-    private static let allocator = ByteBufferAllocator()
+    package static let allocator = ByteBufferAllocator()
     private static let encoder = JSONEncoder()
     private static let decoder = JSONDecoder()
 

--- a/Sources/Strand/Internal/PayloadCompression.swift
+++ b/Sources/Strand/Internal/PayloadCompression.swift
@@ -1,50 +1,53 @@
-// Import full Foundation (not FoundationEssentials) so NSData.compressed is
-// available.  This API ships in Foundation on macOS 10.15+ and in
-// swift-corelibs-foundation on Linux since Swift 5.7.
-import Foundation
+import CompressNIO
+import ExtrasBase64
 import NIOCore
 
-// MARK: - Gzip + base64 encode/decode
+// MARK: - Zlib + base64 encode/decode
 //
-// Large pg_notify payloads (DDSketch JSON) are gzip-compressed and
-// base64-encoded to stay within Postgres’s 8 000-byte hard limit:
+// Large pg_notify payloads (DDSketch JSON) are compressed and base64-encoded
+// to stay within Postgres's 8 000-byte hard limit:
 //
-//   encode: json → gzip → base64 string
-//   decode: starts with "{" → plain JSON; otherwise base64 → gzip → json
+//   encode: ByteBuffer → zlib compress → base64 string
+//   decode: starts with "{" → plain JSON; otherwise base64 → zlib decompress → JSON
 
-/// Gzip-compress `buf` and return a base64-encoded string.
+/// Zlib-compress `buf` and return a base64-encoded string.
 ///
-/// DDSketch JSON compresses 5–10× under gzip, keeping broadcast payloads
-/// well within Postgres’s 8 000-byte `pg_notify` limit.
+/// DDSketch JSON compresses 5–10×, keeping broadcast payloads well within
+/// Postgres's 8 000-byte `pg_notify` limit.
 ///
-/// Returns `nil` if Foundation's zlib compression is unavailable on the
-/// current platform, in which case the caller falls back to plain JSON.
+/// Returns `nil` if compression fails, in which case the caller falls back
+/// to sending the plain JSON string.
 func _zlibDeflate(_ buf: ByteBuffer) -> String? {
-    guard let bytes = buf.getBytes(at: buf.readerIndex, length: buf.readableBytes) else {
+    do {
+        var input = buf
+        var compressed = try input.compress(with: .zlib, allocator: JSON.allocator)
+        guard let bytes = compressed.readBytes(length: compressed.readableBytes) else {
+            return nil
+        }
+        return Base64.encodeToString(bytes: bytes)
+    } catch {
         return nil
     }
-    let data = Data(bytes)
-    guard let compressed = try? (data as NSData).compressed(using: .zlib) as Data else {
-        return nil
-    }
-    return compressed.base64EncodedString()
 }
 
 /// Decode a payload that is either:
 /// - Plain JSON (starts with `{`) — e.g. from a SQL `pg_notify()` call.
-/// - Base64-encoded gzip-compressed JSON — e.g. from `_zlibDeflate()` above.
+/// - Base64 + zlib-compressed JSON — e.g. from `_zlibDeflate()` above.
 ///
 /// Returns `nil` if decoding or decompression fails.
 package func _decodeMetricsBroadcast(_ text: String) -> StrandMetricsBroadcast? {
     if text.hasPrefix("{") {
-        // Plain JSON fast path.
+        // Plain JSON fast path — no decompression needed.
         return try? JSON.decode(StrandMetricsBroadcast.self, from: text)
     }
-    // base64 + gzip path.
-    guard
-        let compressed = Data(base64Encoded: text),
-        let decompressed = try? (compressed as NSData).decompressed(using: .zlib) as Data,
-        let json = String(data: decompressed, encoding: .utf8)
-    else { return nil }
-    return try? JSON.decode(StrandMetricsBroadcast.self, from: json)
+    // base64 → zlib decompress → JSON
+    do {
+        let compressedBytes = try Base64.decode(string: text)
+        var buf = JSON.allocator.buffer(capacity: compressedBytes.count)
+        buf.writeBytes(compressedBytes)
+        let decompressed = try buf.decompress(with: .zlib, allocator: JSON.allocator)
+        return try JSON.decode(StrandMetricsBroadcast.self, from: decompressed)
+    } catch {
+        return nil
+    }
 }

--- a/Sources/Strand/Internal/PayloadCompression.swift
+++ b/Sources/Strand/Internal/PayloadCompression.swift
@@ -1,0 +1,50 @@
+// Import full Foundation (not FoundationEssentials) so NSData.compressed is
+// available.  This API ships in Foundation on macOS 10.15+ and in
+// swift-corelibs-foundation on Linux since Swift 5.7.
+import Foundation
+import NIOCore
+
+// MARK: - Gzip + base64 encode/decode
+//
+// Large pg_notify payloads (DDSketch JSON) are gzip-compressed and
+// base64-encoded to stay within Postgres’s 8 000-byte hard limit:
+//
+//   encode: json → gzip → base64 string
+//   decode: starts with "{" → plain JSON; otherwise base64 → gzip → json
+
+/// Gzip-compress `buf` and return a base64-encoded string.
+///
+/// DDSketch JSON compresses 5–10× under gzip, keeping broadcast payloads
+/// well within Postgres’s 8 000-byte `pg_notify` limit.
+///
+/// Returns `nil` if Foundation's zlib compression is unavailable on the
+/// current platform, in which case the caller falls back to plain JSON.
+func _zlibDeflate(_ buf: ByteBuffer) -> String? {
+    guard let bytes = buf.getBytes(at: buf.readerIndex, length: buf.readableBytes) else {
+        return nil
+    }
+    let data = Data(bytes)
+    guard let compressed = try? (data as NSData).compressed(using: .zlib) as Data else {
+        return nil
+    }
+    return compressed.base64EncodedString()
+}
+
+/// Decode a payload that is either:
+/// - Plain JSON (starts with `{`) — e.g. from a SQL `pg_notify()` call.
+/// - Base64-encoded gzip-compressed JSON — e.g. from `_zlibDeflate()` above.
+///
+/// Returns `nil` if decoding or decompression fails.
+package func _decodeMetricsBroadcast(_ text: String) -> StrandMetricsBroadcast? {
+    if text.hasPrefix("{") {
+        // Plain JSON fast path.
+        return try? JSON.decode(StrandMetricsBroadcast.self, from: text)
+    }
+    // base64 + gzip path.
+    guard
+        let compressed = Data(base64Encoded: text),
+        let decompressed = try? (compressed as NSData).decompressed(using: .zlib) as Data,
+        let json = String(data: decompressed, encoding: .utf8)
+    else { return nil }
+    return try? JSON.decode(StrandMetricsBroadcast.self, from: json)
+}

--- a/Sources/Strand/Internal/StrandLogMetadata.swift
+++ b/Sources/Strand/Internal/StrandLogMetadata.swift
@@ -51,8 +51,8 @@ extension Logger {
     /// Returns a copy of this logger enriched with task-activation metadata.
     func withTaskContext(_ task: ClaimedTask) -> Logger {
         self.with([
-            StrandLogKeys.taskID: .string(task.taskID.uuidString.lowercased()),
-            StrandLogKeys.runID: .string(task.runID.uuidString.lowercased()),
+            StrandLogKeys.taskID: .stringConvertible(task.taskID),
+            StrandLogKeys.runID: .stringConvertible(task.runID),
             StrandLogKeys.taskName: .string(task.taskName),
             StrandLogKeys.attempt: .stringConvertible(task.attempt),
         ])

--- a/Sources/Strand/Internal/StrandMetrics.swift
+++ b/Sources/Strand/Internal/StrandMetrics.swift
@@ -51,9 +51,13 @@ public enum StrandMetrics {
 // MARK: - LISTEN/NOTIFY channel names
 
 /// Internal PostgreSQL channel names and payload type for LISTEN/NOTIFY wakeups.
-enum StrandChannels {
+package enum StrandChannels {
     /// Channel on which workers LISTEN and `enqueueTask` sends NOTIFY.
-    static let tasks = "strand_tasks"
+    package static let tasks = "strand_tasks"
+
+    /// Channel on which `StrandMetricsLoop` broadcasts pre-computed queue counts
+    /// and ``MetricsBroadcastListener`` in the dashboard server listens.
+    package static let metrics = "strand_metrics"
 
     // MARK: - Payload type
 
@@ -62,18 +66,18 @@ enum StrandChannels {
     /// Wire format: `"<namespace>/<queue>"`. Splitting on the first `/` allows
     /// a queue name that contains `/` as long as the namespace does not
     /// (namespace IDs are plain identifiers validated by a Postgres FK).
-    struct Notification: Sendable {
-        let namespace: String
-        let queue: String
+    package struct Notification: Sendable {
+        package let namespace: String
+        package let queue: String
 
         /// Creates a notification for the given namespace and queue.
-        init(namespace: String, queue: String) {
+        package init(namespace: String, queue: String) {
             self.namespace = namespace
             self.queue = queue
         }
 
         /// Parses a raw NOTIFY payload. Returns `nil` if the format is unrecognised.
-        init?(payload: String) {
+        package init?(payload: String) {
             guard let slash = payload.firstIndex(of: "/") else { return nil }
             let ns = String(payload[..<slash])
             let q = String(payload[payload.index(after: slash)...])
@@ -83,7 +87,7 @@ enum StrandChannels {
         }
 
         /// The encoded string passed as the `pg_notify` payload.
-        var payload: String { "\(namespace)/\(queue)" }
+        package var payload: String { "\(namespace)/\(queue)" }
     }
 }
 

--- a/Sources/Strand/Internal/WorkflowRegistration.swift
+++ b/Sources/Strand/Internal/WorkflowRegistration.swift
@@ -68,8 +68,8 @@ final class _WorkflowTaskCache<W: Workflow>: @unchecked Sendable {
         _ = _mutex.withLock { $0.removeValue(forKey: taskID) }
     }
 
-    /// Cancel every cached Task — called from a cancellation handler so that
-    /// worker shutdown also cleans up Tasks that are parked mid-activation.
+    /// Cancel every cached Task — called on worker shutdown so that all
+    /// parked handler Tasks are torn down cleanly.
     func cancelAll() {
         _mutex.withLock { states in
             for (_, state) in states {
@@ -79,6 +79,27 @@ final class _WorkflowTaskCache<W: Workflow>: @unchecked Sendable {
             }
             states.removeAll()
         }
+    }
+
+    /// Cancel and evict ONE workflow’s handler Task.
+    ///
+    /// Called from `WorkflowRegistration.activate`’s cancellation handler so
+    /// that a `ClaimTimeoutError` or unexpected failure on workflow A does
+    /// **not** cancel the handler Tasks of unrelated workflows B, C, … that
+    /// are running concurrently on the same worker.
+    ///
+    /// For worker shutdown every active activation fires this independently
+    /// for its own `taskID` — the net result is identical to `cancelAll()`
+    /// but without cross-contamination between workflows.
+    func evictOne(_ taskID: UUID) {
+        let cached = _mutex.withLock { states -> CachedState? in
+            defer { states.removeValue(forKey: taskID) }
+            return states[taskID]
+        }
+        guard let cached else { return }
+        cached.executor.cancelPending()
+        cached.executor.drain()
+        cached.task.cancel()
     }
 }
 
@@ -96,12 +117,26 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
         exec: _WorkerExec,
         cache: _WorkflowTaskCache<W>
     ) async throws -> ByteBuffer? {
-        // Wrap the whole activation so that worker shutdown (Task cancellation)
-        // also tears down any cached handler Task for this workflow instance.
+        // Cancellation handler: fires when THIS activation task is cancelled
+        // (ClaimTimeoutError, worker shutdown, or any other fatal error).
+        //
+        // Critically: use evictOne rather than cancelAll.
+        // cancelAll() would cancel the handler Tasks of EVERY workflow currently
+        // running on this worker, not just the one that timed out. That would
+        // orphan workflows B, C, … whenever workflow A hits its claim timeout.
+        //
+        // evictOne() cancels only this workflow’s handler Task and removes it
+        // from the cache. The next attempt (failRun creates attempt N+1) will
+        // then take the fresh path (_activate) and rebuild from checkpoints
+        // rather than trying to resumeActivation on a cancelled handler.
+        //
+        // Worker shutdown: each concurrent activation fires evictOne for its own
+        // taskID independently — net result is identical to cancelAll, just
+        // scoped correctly.
         try await withTaskCancellationHandler {
             try await _activate(claimed: claimed, exec: exec, cache: cache)
         } onCancel: {
-            cache.cancelAll()
+            cache.evictOne(claimed.taskID)
         }
     }
 

--- a/Sources/Strand/Internal/WorkflowScheduling.swift
+++ b/Sources/Strand/Internal/WorkflowScheduling.swift
@@ -1,4 +1,5 @@
 import NIOCore
+import Tracing
 
 #if canImport(FoundationEssentials)
 import FoundationEssentials
@@ -177,6 +178,25 @@ extension WorkflowRegistration {
         }
 
         if !scheduleCommands.isEmpty {
+            // Build a headers buffer carrying the current workflow activation span so
+            // every activity and child workflow this activation spawns appears as a
+            // child span in Jaeger / OTLP collectors rather than a disconnected trace.
+            //
+            // `ServiceContext.current` is the span opened by Worker.runTask's
+            // `withSpan(claimed.taskName, ...)` — active for the entire duration of
+            // drain() and applyScheduleCommands.  Injecting it here is the standard
+            // W3C trace-context propagation pattern used by all async messaging systems
+            // (Kafka, SQS, AMQP, etc.).  OTel parent-child relationships are causal,
+            // not temporal — the child span may legitimately start after the parent ends.
+            var _spanHeaders: [String: String] = [:]
+            InstrumentationSystem.tracer.inject(
+                ServiceContext.current ?? .topLevel,
+                into: &_spanHeaders,
+                using: DictionaryInjector()
+            )
+            let childHeadersBuf: ByteBuffer? =
+                _spanHeaders.isEmpty ? nil : try? JSON.encode(_spanHeaders)
+
             // Enqueue activities / child workflows (idempotent — safe if row exists).
             var enqueued: [(seqNum: Int, taskID: UUID)] = []
             for cmd in scheduleCommands {
@@ -194,7 +214,7 @@ extension WorkflowRegistration {
                         queue: options.queue ?? exec.queue,
                         taskName: name,
                         paramsBuffer: actInput,
-                        headersBuffer: nil,
+                        headersBuffer: childHeadersBuf,
                         retryStrategyBuffer: options.retryStrategy.flatMap { try? JSON.encode($0) },
                         maxAttempts: options.maxAttempts,
                         cancellationBuffer: nil,
@@ -380,7 +400,7 @@ extension WorkflowRegistration {
                         queue: targetQueue,
                         taskName: name,
                         paramsBuffer: wfInput,
-                        headersBuffer: nil,
+                        headersBuffer: childHeadersBuf,
                         retryStrategyBuffer: nil,
                         maxAttempts: nil,
                         cancellationBuffer: nil,
@@ -461,16 +481,31 @@ extension WorkflowRegistration {
                         completedCount = try col.next()!.decode(Int.self, context: .default)
                     }
 
-                    if completedCount == enqueued.count {
-                        // All children already finished — go PENDING so the next poll
-                        // re-activates immediately rather than waiting for events that
-                        // already fired and were missed.
+                    // Go PENDING if ANY child has already completed, not just ALL.
+                    // The `for try await r in group` loop delivers results one at a time,
+                    // so even a single completion requires a re-activation to make progress.
+                    //
+                    // The del_orphans CTE deletes event_waits for the completed children
+                    // in the same atomic operation.  Without this, the partial-completion
+                    // re-wait in step 7 would find them on every subsequent activation and
+                    // repeatedly go PENDING for no-op deliveries (spin loop).
+                    if completedCount > 0 {
                         try await conn.query(
                             """
-                            WITH r AS (
+                            WITH
+                            del_orphans AS (
+                                DELETE FROM strand.event_waits ew
+                                USING strand.task_completions tc
+                                WHERE ew.run_id        = \(claimed.runID)
+                                  AND ew.child_task_id = tc.task_id
+                                  AND tc.task_id       = ANY(\(childTaskIDs))
+                            ),
+                            r AS (
                                 UPDATE strand.runs
-                                SET state = \(TaskState.pending), available_at = NOW(),
-                                    worker_id = NULL, lease_expires_at = NULL
+                                SET state        = \(TaskState.pending),
+                                    available_at = NOW(),
+                                    worker_id    = NULL,
+                                    lease_expires_at = NULL
                                 WHERE id = \(claimed.runID)
                                 RETURNING id
                             )
@@ -479,7 +514,6 @@ extension WorkflowRegistration {
                             """,
                             logger: exec.logger
                         )
-                        // Run is PENDING — notify workers immediately.
                         let notification = StrandChannels.Notification(namespace: exec.namespace, queue: exec.queue)
                         try await conn.query(
                             "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
@@ -579,18 +613,28 @@ extension WorkflowRegistration {
                     -- event_waits whose children have already completed but whose
                     -- wake signal was silently dropped (parent was RUNNING at the time).
                     -- child_task_id is a typed UUID FK — direct join, no string parsing.
-                    SELECT COUNT(*) AS cnt
+                    SELECT ew.child_task_id
                     FROM strand.event_waits ew
                     JOIN strand.task_completions tc ON tc.task_id = ew.child_task_id
                     WHERE ew.run_id        = \(claimed.runID)
                       AND ew.child_task_id IS NOT NULL
                 ),
+                del_orphans AS (
+                    -- Delete the orphaned event_waits immediately so they do not
+                    -- re-trigger a PENDING transition on the NEXT re-activation
+                    -- (which would cause a spin loop: re-activate → no progress →
+                    -- PENDING again, ad infinitum, until the remaining children finish).
+                    DELETE FROM strand.event_waits ew
+                    USING missed m
+                    WHERE ew.run_id        = \(claimed.runID)
+                      AND ew.child_task_id = m.child_task_id
+                ),
                 run_upd AS (
                     UPDATE strand.runs
-                    SET state            = CASE WHEN (SELECT cnt FROM missed) > 0
+                    SET state            = CASE WHEN (SELECT COUNT(*) FROM missed) > 0
                                                THEN \(TaskState.pending)
                                                ELSE \(TaskState.waiting) END,
-                        available_at     = CASE WHEN (SELECT cnt FROM missed) > 0
+                        available_at     = CASE WHEN (SELECT COUNT(*) FROM missed) > 0
                                                THEN NOW()
                                                ELSE available_at END,
                         worker_id        = NULL,
@@ -613,6 +657,70 @@ extension WorkflowRegistration {
                 "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
                 logger: exec.logger
             )
+
+            // ── 7B. Post-wait snapshot-isolation recovery ───────────────────────────────
+            // Step 7's CTE runs under Postgres snapshot isolation: it cannot see
+            // task_completions rows that committed AFTER step 7's snapshot started.
+            // In the exact race window where a sibling worker commits a child
+            // completion concurrently with step 7, the run goes WAITING with no
+            // further signal to ever wake it — stuck forever.
+            //
+            // This follow-up query executes as a NEW statement (READ COMMITTED —
+            // fresh snapshot) and therefore sees all concurrent commits that step 7
+            // missed.  If any remaining event_wait children have now completed,
+            // flip WAITING → PENDING and notify.
+            //
+            // del_orphans here serves the same spin-loop prevention role as in step 7.
+            let recoveryStream = try await exec.postgres.query(
+                """
+                WITH
+                missed AS (
+                    SELECT ew.child_task_id
+                    FROM strand.event_waits ew
+                    JOIN strand.task_completions tc ON tc.task_id = ew.child_task_id
+                    WHERE ew.run_id        = \(claimed.runID)
+                      AND ew.child_task_id IS NOT NULL
+                ),
+                del_orphans AS (
+                    DELETE FROM strand.event_waits ew
+                    USING missed m
+                    WHERE ew.run_id        = \(claimed.runID)
+                      AND ew.child_task_id = m.child_task_id
+                ),
+                run_upd AS (
+                    UPDATE strand.runs
+                    SET state        = \(TaskState.pending),
+                        available_at = NOW(),
+                        worker_id    = NULL,
+                        lease_expires_at = NULL
+                    WHERE id    = \(claimed.runID)
+                      AND state = \(TaskState.waiting)
+                      AND (SELECT COUNT(*) FROM missed) > 0
+                    RETURNING id
+                )
+                UPDATE strand.tasks
+                SET state = \(TaskState.pending)
+                FROM run_upd
+                WHERE strand.tasks.id           = \(claimed.taskID)
+                  AND strand.tasks.namespace_id = \(exec.namespace)
+                RETURNING strand.tasks.id
+                """,
+                logger: exec.logger
+            )
+            if try await recoveryStream.first(where: { _ in true }) != nil {
+                exec.logger.debug(
+                    "partial-completion recovery: snapshot-isolation race detected — run set to PENDING",
+                    metadata: [
+                        "strand.task_id": .stringConvertible(claimed.taskID),
+                        "strand.run_id": .stringConvertible(claimed.runID),
+                    ]
+                )
+                let recoveryNote = StrandChannels.Notification(namespace: exec.namespace, queue: exec.queue)
+                try await exec.postgres.query(
+                    "SELECT pg_notify(\(StrandChannels.tasks), \(recoveryNote.payload))",
+                    logger: exec.logger
+                )
+            }
         }
 
         // ── 8. Cache the live Task for the next activation ───────────────────────────

--- a/Sources/Strand/Schedule/StrandScheduler.swift
+++ b/Sources/Strand/Schedule/StrandScheduler.swift
@@ -362,7 +362,7 @@ public struct StrandScheduler: Service {
             "schedule fired",
             metadata: [
                 "strand.schedule_name": .string(row.name),
-                "strand.schedule_id": .string(row.id.uuidString),
+                "strand.schedule_id": .stringConvertible(row.id),
                 "strand.task_name": .string(row.taskName),
                 "strand.queue": .string(row.queue),
                 "strand.scheduled_at": .string(row.scheduledAt.ISO8601Format()),

--- a/Sources/Strand/StrandMetricsLoop.swift
+++ b/Sources/Strand/StrandMetricsLoop.swift
@@ -1,0 +1,340 @@
+import Logging
+import NIOCore
+public import ServiceLifecycle
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+// MARK: - Broadcast payload
+
+/// Live task-count snapshot for one namespace, broadcast every
+/// ``StrandMetricsOptions/interval`` via `pg_notify('strand_metrics', ...)`.
+///
+/// Consumed by ``MetricsBroadcastListener`` in the dashboard server so
+/// ``MetricsRoutes`` never issues on-demand COUNT queries.
+public struct StrandMetricsBroadcast: Codable, Sendable {
+    /// The namespace these counts belong to.
+    public let namespace: String
+    /// Unix timestamp (seconds since 1970) when this snapshot was computed.
+    public let at: Double
+    /// One entry per active queue — live task counts.
+    public let queues: [QueueSnapshot]
+    /// Per-(queue, task) execution-time distributions flushed since the last
+    /// broadcast.  `nil` when no tasks completed in this cycle.
+    public let timings: [TimingSnapshot]?
+
+    public struct QueueSnapshot: Codable, Sendable {
+        public let queue: String
+        public let pending: Int
+        public let running: Int
+        public let sleeping: Int
+        public let waiting: Int
+        /// Tasks completed or failed per second in the most recent broadcast cycle.
+        /// `nil` when no ``AggregatedMetricsBuffer`` is wired into ``StrandMetricsLoop``.
+        public let throughputPerSec: Double?
+    }
+
+    /// Execution-time distribution for one (queue, task name, state) triple.
+    ///
+    /// Completed and failed tasks are tracked separately so a task that
+    /// always fails in 2 ms doesn't pollute the p95 of successful runs.
+    public struct TimingSnapshot: Codable, Sendable {
+        public let queue: String
+        public let taskName: String
+        /// Terminal state — `.completed` or `.failed`.
+        public let state: TaskState
+        /// Number of executions recorded in this cycle.
+        public let count: Int
+        /// Throughput rate for this (queue, task, state) in the current cycle.
+        /// Computed as `count / broadcastIntervalSeconds`.
+        public let ratePerSec: Double
+        /// DDSketch of execution durations (milliseconds, ±2 % error).
+        public let execTime: DDSketch.Serialized
+        /// DDSketch of queue-wait durations — time from when the run became
+        /// PENDING to when a worker claimed it.  `nil` when not available.
+        public let waitTime: DDSketch.Serialized?
+    }
+}
+
+// MARK: - Options
+
+/// Configuration for ``StrandMetricsLoop``.
+public struct StrandMetricsOptions: Sendable {
+    /// How often to recompute and broadcast counts. Default: 5 s.
+    public var interval: Duration
+    /// Row-count threshold above which the loop switches from exact
+    /// `COUNT(*)` to `strand.count_estimate()` (query-planner estimate,
+    /// ~0.1 ms regardless of table size). Default: 50,000.
+    public var estimateThreshold: Int
+    /// Maximum number of (queue, task) timing entries included in each
+    /// broadcast, sorted by execution count descending so the busiest tasks
+    /// are always present.  Default: 20.
+    public var maxTimingEntries: Int
+
+    public init(
+        interval: Duration = .seconds(5),
+        estimateThreshold: Int = 50_000,
+        maxTimingEntries: Int = 20
+    ) {
+        self.interval = interval
+        self.estimateThreshold = estimateThreshold
+        self.maxTimingEntries = maxTimingEntries
+    }
+}
+
+// MARK: - Service
+
+/// Background service that pre-computes live task counts and broadcasts them
+/// via `pg_notify('strand_metrics', ...)` every ``StrandMetricsOptions/interval``.
+///
+/// Add it to your `ServiceGroup` alongside your workers and scheduler:
+///
+/// ```swift
+/// let metricsLoop = StrandMetricsLoop(client: client)
+///
+/// let group = ServiceGroup(services: [
+///     postgres, worker, scheduler, metricsLoop
+/// ])
+/// ```
+///
+/// The ``MetricsBroadcastListener`` in the dashboard server subscribes to the
+/// broadcast and keeps an in-memory cache so ``MetricsRoutes`` never issues
+/// COUNT queries per dashboard request.
+///
+/// ## Adaptive counting
+///
+/// For each `(queue, state)` pair, the loop remembers the previous measurement:
+/// - Previous count < ``StrandMetricsOptions/estimateThreshold``:
+///   exact `COUNT(*)` — fast via partial indexes for small tables.
+/// - Previous count ≥ threshold: `strand.count_estimate()` — the query
+///   planner's own statistics, sub-millisecond at any table size.
+///
+/// The threshold decision is updated each cycle, so queues that grow large
+/// automatically migrate to the estimate path without any configuration change.
+public struct StrandMetricsLoop: Service {
+    private let client: StrandClient
+    private let options: StrandMetricsOptions
+    /// Shared buffer written by ``StrandWorker`` after each task completes.
+    /// Flushed once per broadcast cycle and included in the payload.
+    private let metricsBuffer: AggregatedMetricsBuffer?
+
+    public init(
+        client: StrandClient,
+        options: StrandMetricsOptions = .init(),
+        metricsBuffer: AggregatedMetricsBuffer? = nil
+    ) {
+        self.client = client
+        self.options = options
+        self.metricsBuffer = metricsBuffer
+    }
+
+    public func run() async throws {
+        let logger = client.logger
+        logger.info("metrics loop starting")
+        defer { logger.info("metrics loop stopped") }
+
+        // Per "queue/state" count from the previous cycle — drives the
+        // exact-vs-estimate decision on the next one.
+        var previousCounts: [String: Int] = [:]
+
+        while !Task.isShuttingDownGracefully && !Task.isCancelled {
+            // cancelWhenGracefulShutdown exits the sleep quickly on shutdown
+            // without leaking the NIO runTimer continuation.
+            try? await cancelWhenGracefulShutdown {
+                try await Task.sleep(for: self.options.interval)
+            }
+            guard !Task.isShuttingDownGracefully && !Task.isCancelled else { break }
+
+            do {
+                try await broadcast(previousCounts: &previousCounts)
+            } catch {
+                logger.error(
+                    "metrics loop broadcast failed",
+                    metadata: ["error": "\(String(reflecting: error))"]
+                )
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func broadcast(previousCounts: inout [String: Int]) async throws {
+        let queues = try await client.listQueues()
+        guard !queues.isEmpty else { return }
+
+        // ── Interval ─────────────────────────────────────────────────────────
+        // Used to convert accumulated counts into per-second rates.
+        // Guarded at 1 s so a misconfigured zero interval never causes division
+        // by zero (rate would just be inflated rather than crashing).
+        let intervalSecs = max(
+            1.0,
+            Double(options.interval.components.seconds)
+                + Double(options.interval.components.attoseconds) / 1e18
+        )
+
+        // ── Flush timing buffer BEFORE the queue DB queries ───────────────────
+        // Flushing first guarantees the per-queue throughput numbers and the
+        // individual timing snapshots come from the same buffer drain — no
+        // interleaving with the next cycle's records.
+        var flushedTimings: [String: AggregatedMetricsBuffer._Entry] = [:]
+        var queueThroughput: [String: Double] = [:]
+        if let buffer = metricsBuffer {
+            flushedTimings = buffer.flush()
+            for (key, entry) in flushedTimings where entry.execTime.count > 0 {
+                // Key format: "queue/taskName/state"
+                let parts = key.split(separator: "/", maxSplits: 2)
+                guard parts.count == 3 else { continue }
+                let q = String(parts[0])
+                queueThroughput[q, default: 0] += Double(entry.execTime.count) / intervalSecs
+            }
+        }
+
+        // ── Queue count snapshots (async DB queries) ──────────────────────────
+        var snapshots: [StrandMetricsBroadcast.QueueSnapshot] = []
+
+        for queue in queues {
+            async let pending = countState(.pending, queue: queue, prev: previousCounts)
+            async let running = countState(.running, queue: queue, prev: previousCounts)
+            async let sleeping = countState(.sleeping, queue: queue, prev: previousCounts)
+            async let waiting = countState(.waiting, queue: queue, prev: previousCounts)
+
+            let (p, r, sl, w) = try await (pending, running, sleeping, waiting)
+
+            // Update the previous-counts table for next cycle.
+            previousCounts["\(queue)/\(TaskState.pending.rawValue)"] = p
+            previousCounts["\(queue)/\(TaskState.running.rawValue)"] = r
+            previousCounts["\(queue)/\(TaskState.sleeping.rawValue)"] = sl
+            previousCounts["\(queue)/\(TaskState.waiting.rawValue)"] = w
+
+            snapshots.append(
+                .init(
+                    queue: queue,
+                    pending: p,
+                    running: r,
+                    sleeping: sl,
+                    waiting: w,
+                    // nil when no metricsBuffer is wired; 0.0 when wired but idle
+                    throughputPerSec: metricsBuffer != nil
+                        ? queueThroughput[queue, default: 0]
+                        : nil
+                )
+            )
+        }
+
+        // ── Timing snapshots (from the pre-flushed buffer) ────────────────────
+        // Sort by count descending and cap at maxTimingEntries so the busiest
+        // tasks always appear and payload size stays bounded.
+        let timingSnapshots: [StrandMetricsBroadcast.TimingSnapshot]?
+        if !flushedTimings.isEmpty {
+            let built = flushedTimings.compactMap { key, entry -> StrandMetricsBroadcast.TimingSnapshot? in
+                guard entry.execTime.count > 0 else { return nil }
+                let parts = key.split(separator: "/", maxSplits: 2)
+                guard parts.count == 3,
+                    let state = TaskState(rawValue: String(parts[2]))
+                else { return nil }
+                return StrandMetricsBroadcast.TimingSnapshot(
+                    queue: String(parts[0]),
+                    taskName: String(parts[1]),
+                    state: state,
+                    count: entry.execTime.count,
+                    ratePerSec: Double(entry.execTime.count) / intervalSecs,
+                    execTime: DDSketch.Serialized(from: entry.execTime),
+                    waitTime: entry.waitTime.count > 0
+                        ? DDSketch.Serialized(from: entry.waitTime)
+                        : nil
+                )
+            }
+            .sorted { $0.count > $1.count }  // busiest first
+            .prefix(options.maxTimingEntries)
+
+            timingSnapshots = built.isEmpty ? nil : Array(built)
+        } else {
+            timingSnapshots = nil
+        }
+
+        let payload = StrandMetricsBroadcast(
+            namespace: client.namespaceID,
+            at: Date.now.timeIntervalSince1970,
+            queues: snapshots,
+            timings: timingSnapshots
+        )
+
+        // ── Compress + encode ────────────────────────────────────────────────────────────────
+        // DDSketch JSON compresses 5–10× under gzip, keeping the payload well
+        // within Postgres’s 8 000-byte pg_notify hard limit. The subscriber
+        // (MetricsBroadcastListener) tries base64 first; if decoding fails it
+        // falls back to plain JSON.
+        //
+        // Foundation.Compression is available on Apple platforms; on Linux
+        // swift-corelibs-foundation provides NSData.compressed(using:) since
+        // Swift 5.7. We use the raw ZLIB deflate API via NIOFoundationCompat
+        // to stay cross-platform without adding a new dependency.
+        let rawJSON = try JSON.encode(payload)
+        let notifyPayload: String
+        if let compressed = _zlibDeflate(rawJSON) {
+            notifyPayload = compressed
+        } else {
+            // Compression unavailable — send plain JSON and hope it fits.
+            notifyPayload = String(buffer: rawJSON)
+        }
+
+        try await client.postgres.query(
+            "SELECT pg_notify(\(StrandChannels.metrics), \(notifyPayload))",
+            logger: client.logger
+        )
+
+        client.logger.debug(
+            "metrics broadcast sent",
+            metadata: [
+                "strand.namespace": .string(client.namespaceID),
+                "strand.queue_count": .stringConvertible(snapshots.count),
+                "strand.payload_bytes": .stringConvertible(notifyPayload.utf8.count),
+            ]
+        )
+    }
+
+    /// Returns the count for the given state/queue, choosing between exact
+    /// COUNT(*) and the planner estimate based on the previous measurement.
+    private func countState(
+        _ state: TaskState,
+        queue: String,
+        prev: [String: Int]
+    ) async throws -> Int {
+        let previous = prev["\(queue)/\(state.rawValue)", default: 0]
+
+        if previous < options.estimateThreshold {
+            return try await exactCount(state: state, queue: queue)
+        } else {
+            return try await estimatedCount(state: state, queue: queue)
+        }
+    }
+
+    private func exactCount(state: TaskState, queue: String) async throws -> Int {
+        let stream = try await client.postgres.query(
+            """
+            SELECT COUNT(*)::integer
+            FROM strand.tasks
+            WHERE namespace_id = \(client.namespaceID)
+              AND queue = \(queue)
+              AND state = \(state)
+            """,
+            logger: client.logger
+        )
+        guard let row = try await stream.first(where: { _ in true }) else { return 0 }
+        var col = row.makeIterator()
+        return try col.next()!.decode(Int.self, context: .default)
+    }
+
+    private func estimatedCount(state: TaskState, queue: String) async throws -> Int {
+        let stream = try await client.postgres.query(
+            "SELECT strand.count_estimate(\(client.namespaceID), \(queue), \(state))",
+            logger: client.logger
+        )
+        guard let row = try await stream.first(where: { _ in true }) else { return 0 }
+        var col = row.makeIterator()
+        return (try col.next()!.decode(Int?.self, context: .default)) ?? 0
+    }
+}

--- a/Sources/Strand/StrandNotifier.swift
+++ b/Sources/Strand/StrandNotifier.swift
@@ -1,0 +1,202 @@
+public import Logging
+public import PostgresNIO
+public import ServiceLifecycle
+import Synchronization
+
+// MARK: - StrandNotifier
+
+/// Holds **one** persistent Postgres LISTEN connection and fans out
+/// notifications to any number of subscribers via `AsyncStream`.
+///
+/// Before this type existed every component that needed LISTEN/NOTIFY held its
+/// own dedicated connection.  `StrandNotifier` replaces all of them: declare
+/// the channels you need at construction time, pass the notifier to every
+/// component, and only one connection is ever open.
+///
+/// ```swift
+/// let notifier = StrandNotifier(
+///     postgres: postgres,
+///     channels: [StrandChannels.tasks, StrandChannels.metrics],
+///     logger: logger
+/// )
+/// let worker   = StrandWorker(postgres: postgres, notifier: notifier, ...)
+/// let listener = MetricsBroadcastListener(notifier: notifier, cache: cache, logger: logger)
+///
+/// let group = ServiceGroup(services: [postgres, notifier, worker, listener, ...])
+/// ```
+///
+/// ## Subscription model
+///
+/// Call ``stream(for:)`` to receive an `AsyncStream<String>` that yields the
+/// raw `pg_notify` payload for every notification on that channel.  When the
+/// consumer task exits (normally or by cancellation) its stream's
+/// `onTermination` handler automatically removes the subscription — no
+/// explicit cleanup required.
+///
+/// ```swift
+/// for await payload in notifier.stream(for: StrandChannels.tasks) {
+///     if payload == expectedPayload { notifySignal.signal() }
+/// }
+/// ```
+///
+/// ## Connection lifecycle
+///
+/// ``run()`` holds a single `PostgresConnection` for the lifetime of the
+/// service.  On drop (network hiccup, Postgres restart) it reconnects after
+/// a 1-second back-off and re-issues `LISTEN` for every declared channel.
+/// All `cancelWhenGracefulShutdown` / NIO runTimer guards from `listenLoop`
+/// are preserved here.
+public final class StrandNotifier: Service, Sendable {
+
+    // MARK: - Internal types
+
+    private struct _State {
+        /// Channel → { subscriber-id → continuation }.
+        ///
+        /// Dictionary keying gives O(1) removal on task cancellation
+        /// (vs O(N) scan in an Array). Dispatch iterates all values in O(N),
+        /// which is unavoidable regardless of collection type.
+        var subscriptions: [String: [UInt64: AsyncStream<String>.Continuation]] = [:]
+        var nextID: UInt64 = 0
+    }
+
+    // MARK: - Storage
+
+    private let _state: Mutex<_State> = Mutex(_State())
+
+    let postgres: PostgresClient
+    let logger: Logger
+    /// Channels on which `LISTEN` will be issued when the connection is (re-)established.
+    let channels: Set<String>
+
+    // MARK: - Init
+
+    // MARK: - Channel name constants
+
+    /// Channel on which workers receive task-ready notifications.
+    /// Pass in `channels:` when the notifier is shared with ``StrandWorker``.
+    public static let tasksChannel = "strand_tasks"
+
+    /// Channel on which ``StrandMetricsLoop`` broadcasts live task counts.
+    /// Pass in `channels:` when the notifier is shared with ``MetricsBroadcastListener``.
+    public static let metricsChannel = "strand_metrics"
+
+    // MARK: - Init
+
+    public init(
+        postgres: PostgresClient,
+        channels: Set<String>,
+        logger: Logger
+    ) {
+        self.postgres = postgres
+        self.channels = channels
+        self.logger = logger
+    }
+
+    // MARK: - Subscription
+
+    /// Returns an `AsyncStream<String>` that yields the raw `pg_notify` payload
+    /// for every notification arriving on `channel`.
+    ///
+    /// The stream is lightweight — just an `AsyncStream` backed by a stored
+    /// continuation.  Multiple callers may subscribe to the same channel and
+    /// each receives an independent copy of every notification.
+    ///
+    /// When the consumer task exits (cancellation or normal return) the stream's
+    /// `onTermination` handler removes the subscription automatically.
+    public func stream(for channel: String) -> AsyncStream<String> {
+        let (stream, continuation) = AsyncStream<String>.makeStream()
+
+        let id = _state.withLock { s -> UInt64 in
+            let id = s.nextID
+            s.nextID += 1
+            s.subscriptions[channel, default: [:]][id] = continuation
+            return id
+        }
+
+        // O(1) removal: just wipe the key.
+        continuation.onTermination = { [weak self] _ in
+            self?._state.withLock { s in
+                s.subscriptions[channel]?[id] = nil
+            }
+        }
+
+        return stream
+    }
+
+    // MARK: - Service
+
+    public func run() async throws {
+        logger.info(
+            "notifier starting",
+            metadata: ["strand.channels": .string(channels.sorted().joined(separator: ", "))]
+        )
+        defer {
+            // Finish every active stream so consumer for-await loops exit cleanly
+            // rather than blocking indefinitely.
+            _state.withLock { s in
+                for conts in s.subscriptions.values {
+                    for (_, cont) in conts { cont.finish() }
+                }
+                s.subscriptions.removeAll()
+            }
+            logger.info("notifier stopped")
+        }
+
+        while !Task.isShuttingDownGracefully && !Task.isCancelled {
+            do {
+                // cancelWhenGracefulShutdown wraps the entire connection body for
+                // the same two reasons documented in StrandWorker.listenLoop:
+                //
+                // 1. Fast voluntary exit: detects isShuttingDownGracefully and
+                //    cancels the inner scope immediately rather than waiting for
+                //    the next reconnect cycle.
+                //
+                // 2. NIO runTimer safety: the *outer* notifier task remains alive
+                //    while the inner scope cleans up, giving NIO's event-loop
+                //    callbacks the window they need to fire before the Swift task
+                //    is torn down (preventing leaked runTimer continuations).
+                try await cancelWhenGracefulShutdown {
+                    try await self.postgres.withConnection { conn in
+                        // One conn.listen() task per declared channel — all sharing
+                        // the same connection.  This is the fan-out: a single
+                        // Postgres wire connection services N subscribers.
+                        try await withThrowingTaskGroup(of: Void.self) { group in
+                            for channel in self.channels {
+                                let ch = channel
+                                group.addTask {
+                                    try await conn.listen(on: ch) { notifications in
+                                        for try await note in notifications {
+                                            // Dispatch to all subscribers for this channel.
+                                            // yield() is synchronous — no blocking here.
+                                            let subs = self._state.withLock { s in
+                                                s.subscriptions[ch] ?? [:]
+                                            }
+                                            // Dispatch to every subscriber in O(N).
+                                            for (_, cont) in subs {
+                                                cont.yield(note.payload)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            // Keep the closure alive until all listen tasks finish
+                            // (they run until the connection drops or is cancelled).
+                            try await group.waitForAll()
+                        }
+                    }
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                logger.warning(
+                    "notifier connection lost — reconnecting",
+                    metadata: .forError(error)
+                )
+                try? await cancelWhenGracefulShutdown {
+                    try await Task.sleep(for: .seconds(1))
+                }
+            }
+        }
+    }
+}

--- a/Sources/Strand/StrandPruner.swift
+++ b/Sources/Strand/StrandPruner.swift
@@ -1,0 +1,161 @@
+import Logging
+public import PostgresNIO
+public import ServiceLifecycle
+
+// MARK: - Options
+
+/// Configuration for ``StrandPruner``.
+public struct StrandPrunerOptions: Sendable {
+    /// How often to run a prune cycle. Default: 30 s.
+    public var interval: Duration
+    /// Maximum age of terminal tasks before they are deleted.
+    /// Default: `nil` — ``ManagementQueries/cleanupTasks`` reads the namespace
+    /// `retention_days` column when this is `nil`.
+    public var maxAge: Duration?
+    /// Maximum number of rows deleted per cycle (batched to avoid long locks).
+    /// Default: 10,000.
+    public var limit: Int
+    /// Queue to prune. `nil` = all queues in the namespace. Default: `nil`.
+    public var queue: String?
+    /// Postgres advisory lock key used for leader election.
+    /// Must be identical across every ``StrandPruner`` instance in the cluster
+    /// so only one instance runs cleanup per cycle.
+    /// Default: a stable constant derived from "StrandPN".
+    public var advisoryLockKey: Int64
+
+    public init(
+        interval: Duration = .seconds(30),
+        maxAge: Duration? = nil,
+        limit: Int = 10_000,
+        queue: String? = nil,
+        advisoryLockKey: Int64 = 0x5374_7261_6E64_504E  // "StrandPN"
+    ) {
+        self.interval = interval
+        self.maxAge = maxAge
+        self.limit = limit
+        self.queue = queue
+        self.advisoryLockKey = advisoryLockKey
+    }
+}
+
+// MARK: - Service
+
+/// Background service that periodically deletes terminal (completed/failed/cancelled)
+/// tasks older than a configurable age.
+///
+/// Add ``StrandPruner`` to your `ServiceGroup` to keep `strand.tasks` from growing
+/// unboundedly without requiring manual cleanup calls.
+///
+/// Only one instance in the cluster runs each cycle — leader election is via
+/// `pg_try_advisory_lock`. Non-leaders log a debug message and skip that cycle.
+///
+/// ```swift
+/// let pruner = StrandPruner(
+///     postgres: postgres,
+///     namespaceID: "default",
+///     options: StrandPrunerOptions(maxAge: .seconds(7 * 24 * 3600)) // 7 days
+/// )
+/// let group = ServiceGroup(services: [postgres, worker, pruner])
+/// ```
+public struct StrandPruner: Service {
+    private let postgres: PostgresClient
+    private let namespaceID: String
+    private let options: StrandPrunerOptions
+    private let logger: Logger
+
+    public init(
+        postgres: PostgresClient,
+        namespaceID: String = "default",
+        options: StrandPrunerOptions = .init(),
+        logger: Logger = Logger(label: "dev.strand.pruner")
+    ) {
+        self.postgres = postgres
+        self.namespaceID = namespaceID
+        self.options = options
+        self.logger = logger
+    }
+
+    // MARK: - Service
+
+    public func run() async throws {
+        logger.info(
+            "pruner starting",
+            metadata: [
+                "strand.namespace": .string(namespaceID),
+                "strand.interval": .string("\(options.interval)"),
+                "strand.limit": .stringConvertible(options.limit),
+            ]
+        )
+        defer { logger.info("pruner stopped") }
+
+        while !Task.isShuttingDownGracefully && !Task.isCancelled {
+            try? await cancelWhenGracefulShutdown {
+                try await Task.sleep(for: self.options.interval)
+            }
+            guard !Task.isShuttingDownGracefully && !Task.isCancelled else { break }
+
+            do {
+                try await tryPrune()
+            } catch {
+                logger.error(
+                    "pruner cycle failed",
+                    metadata: ["error": .string(String(reflecting: error))]
+                )
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func tryPrune() async throws {
+        // Hold a dedicated connection for the duration of the advisory lock so
+        // Postgres releases it automatically when the connection is returned,
+        // even if tryPrune throws.
+        try await postgres.withConnection { conn in
+            // pg_try_advisory_lock: non-blocking; returns true if we became leader.
+            let lockStream = try await conn.query(
+                "SELECT pg_try_advisory_lock(\(options.advisoryLockKey))",
+                logger: logger
+            )
+            guard let lockRow = try await lockStream.first(where: { _ in true }) else { return }
+            var lockCol = lockRow.makeIterator()
+            let acquired = try lockCol.next()!.decode(Bool.self, context: .default)
+
+            guard acquired else {
+                logger.debug(
+                    "pruner: not leader — skipping this cycle",
+                    metadata: ["strand.namespace": .string(namespaceID)]
+                )
+                return
+            }
+
+            // We are the leader for this cycle. Run cleanup on the main pool
+            // (it will use a separate connection from the pool; that's fine — the
+            // advisory lock is held here just to prevent other instances from
+            // starting a concurrent cleanup).
+            let ageSeconds: Int?
+            if let maxAge = options.maxAge {
+                ageSeconds = Int(maxAge.components.seconds)
+            } else {
+                ageSeconds = nil  // ManagementQueries.cleanupTasks reads namespace retention_days
+            }
+
+            _ = try await ManagementQueries.cleanupTasks(
+                on: postgres,
+                namespaceID: namespaceID,
+                queue: options.queue,
+                ageSeconds: ageSeconds,
+                limit: options.limit,
+                logger: logger
+            )
+
+            // Explicitly release the advisory lock so other instances can
+            // become leader on the next cycle (rather than waiting for the
+            // connection to be returned to the pool).
+            _ = try await conn.query(
+                "SELECT pg_advisory_unlock(\(options.advisoryLockKey))",
+                logger: logger
+            )
+        }
+    }
+}

--- a/Sources/Strand/Worker.swift
+++ b/Sources/Strand/Worker.swift
@@ -233,6 +233,15 @@ public struct StrandWorker: Service {
     /// `Sendable` handler registry — a class reference whose `let` store is
     /// data-race free by construction (written once in `init`, never mutated).
     private let _registry: Registry
+    /// Shared LISTEN/NOTIFY hub.  The worker subscribes to `strand_tasks`
+    /// via the notifier's `AsyncStream` — no separate Postgres connection
+    /// is opened.  The notifier must declare ``StrandChannels/tasks`` in its
+    /// `channels` set.
+    let notifier: StrandNotifier
+    /// Optional shared timing buffer.  When set, the worker records each
+    /// task's execution duration (in milliseconds) after every completion so
+    /// ``StrandMetricsLoop`` can include DDSketch percentiles in its broadcast.
+    private let metricsBuffer: AggregatedMetricsBuffer?
 
     /// Creates a worker with typed registration arrays.
     ///
@@ -248,6 +257,8 @@ public struct StrandWorker: Service {
     public init(
         postgres: PostgresClient,
         options: WorkerOptions = .init(),
+        notifier: StrandNotifier,
+        metricsBuffer: AggregatedMetricsBuffer? = nil,
         workflows: [any WorkflowRegistrable.Type] = [],
         activityContainers: [any ActivityContainerProtocol] = [],
         activities: [any ActivityBox] = [],
@@ -257,6 +268,8 @@ public struct StrandWorker: Service {
         self.postgres = postgres
         self.options = options
         self.namespace = options.namespace
+        self.notifier = notifier
+        self.metricsBuffer = metricsBuffer
         self.logger = logger
         self._metrics = _MetricsFactoryBox(value: metricsFactory ?? MetricsSystem.factory)
 
@@ -348,6 +361,21 @@ public struct StrandWorker: Service {
             logger: logger
         )
 
+        // Shared running counter — lifted here so heartbeatLoop can read it.
+        let running = _RunningCounter()
+
+        // Register this worker in strand.workers so the dashboard can see it.
+        // try? so a transient DB error on startup doesn't prevent the worker from running.
+        try? await Queries.upsertWorker(
+            on: postgres,
+            workerID: workerID,
+            namespaceID: namespace,
+            queue: options.queue,
+            concurrency: options.workflowConcurrency + options.activityConcurrency,
+            running: 0,
+            logger: logger
+        )
+
         let (stream, cont) = AsyncStream.makeStream(of: Void.self)
         // Signal shared between listenLoop (producer) and pollLoop (consumer).
         // _SlotSignal (Mutex + CheckedContinuation) has buffer-of-1 semantics:
@@ -370,9 +398,24 @@ public struct StrandWorker: Service {
                 // full gracefulShutdownTimeout, which cancels any still-running
                 // children (pollLoop, listenLoop) and lets run() return cleanly.
                 try await withThrowingDiscardingTaskGroup { group in
-                    group.addTask { try await self.pollLoop(workerID: workerID, notifySignal: notifySignal) }
-                    group.addTask { try await self.listenLoop(notifySignal: notifySignal) }
-                    group.addTask { try await self.heartbeatLoop(notifySignal: notifySignal) }
+                    group.addTask { try await self.pollLoop(workerID: workerID, notifySignal: notifySignal, running: running) }
+                    let myPayload = StrandChannels.Notification(
+                        namespace: self.namespace,
+                        queue: self.options.queue
+                    ).payload
+                    group.addTask {
+                        // cancelWhenGracefulShutdown: exit the stream loop immediately
+                        // on graceful shutdown rather than waiting for the notifier
+                        // to shut down and finish the stream.  Mirrors the pattern
+                        // used by heartbeatLoop and leaseExpiryLoop.
+                        await cancelWhenGracefulShutdown {
+                            for await payload in self.notifier.stream(for: StrandChannels.tasks) {
+                                if payload == myPayload { notifySignal.signal() }
+                            }
+                        }
+                        // Returns normally — discarded by withThrowingDiscardingTaskGroup.
+                    }
+                    group.addTask { try await self.heartbeatLoop(workerID: workerID, notifySignal: notifySignal, running: running) }
                     group.addTask { try await self.leaseExpiryLoop() }
                     group.addTask {
                         // Wait for the graceful-shutdown signal from
@@ -387,14 +430,15 @@ public struct StrandWorker: Service {
                         // Immediately expire all in-flight runs for this worker so
                         // the next worker's leaseExpiryLoop picks them up on its
                         // first sweep rather than waiting up to claimTimeout.
-                        let _ = try? await self.postgres.query(
-                            """
-                            UPDATE strand.runs
-                            SET lease_expires_at = NOW()
-                            WHERE worker_id     = \(workerID)
-                              AND namespace_id  = \(self.namespace)
-                              AND state         = \(TaskState.running)
-                            """,
+                        // Expire in-flight run leases + remove worker heartbeat row
+                        // in one round-trip so the next worker's leaseExpiryLoop
+                        // picks up the runs immediately and the dashboard stops
+                        // showing this worker at the same instant.
+                        try? await Queries.shutdownWorker(
+                            on: self.postgres,
+                            workerID: workerID,
+                            namespaceID: self.namespace,
+                            queue: self.options.queue,
                             logger: self.logger
                         )
 
@@ -431,16 +475,15 @@ public struct StrandWorker: Service {
     ///
     /// When all slots are occupied the loop parks on `_SlotSignal` — a
     /// `Mutex`-backed async wakeup that resumes as soon as any slot is freed.
-    private func pollLoop(workerID: String, notifySignal: _SlotSignal) async throws {
+    private func pollLoop(workerID: String, notifySignal: _SlotSignal, running: _RunningCounter) async throws {
         let queueName = options.queue
         let maxConcurrency =
             options.batchSize ?? (options.workflowConcurrency + options.activityConcurrency)
         let claimSecs = Int(options.claimTimeout.components.seconds)
 
-        // Slot counter shared between the dispatch body and execution tasks.
-        // `_RunningCounter` is `Sendable`; concurrent increment/decrement are
-        // data-race free via its internal `Mutex`.
-        let running = _RunningCounter()
+        // slotFreeSignal is local to pollLoop — used to wake the dispatch body
+        // when a running task finishes and frees a slot.  `running` is shared
+        // with heartbeatLoop (injected via parameter) so it can report live counts.
         let slotFreeSignal = _SlotSignal()
 
         // Dispatch body: claims work when slots are available, parks when full.
@@ -585,7 +628,7 @@ public struct StrandWorker: Service {
     /// Running as a structured sibling in the same task group means its
     /// `Task.sleep` is cancelled once by the parent group on shutdown, not
     /// repeatedly by sibling-cancel (which leaks the `runTimer` continuation).
-    private func heartbeatLoop(notifySignal: _SlotSignal) async throws {
+    private func heartbeatLoop(workerID: String, notifySignal: _SlotSignal, running: _RunningCounter) async throws {
         while !Task.isShuttingDownGracefully && !Task.isCancelled {
             // try? is essential: cancelWhenGracefulShutdown throws CancellationError
             // on graceful shutdown.  Without try? that error propagates out of this
@@ -596,6 +639,25 @@ public struct StrandWorker: Service {
                 try await Task.sleep(for: self.options.pollInterval)
             }
             notifySignal.signal()
+            // Upsert heartbeat row with current running count.
+            // try? so a transient DB blip doesn't abort the worker.
+            try? await Queries.upsertWorker(
+                on: postgres,
+                workerID: workerID,
+                namespaceID: namespace,
+                queue: options.queue,
+                concurrency: options.workflowConcurrency + options.activityConcurrency,
+                running: running.value,
+                logger: logger
+            )
+            // Sweep stale worker rows left by crashed peers
+            // (threshold: 3× pollInterval, floor 30 s).
+            let stalenessSeconds = Int(max(30, options.pollInterval.components.seconds * 3))
+            try? await Queries.sweepStaleWorkers(
+                on: postgres,
+                olderThanSeconds: stalenessSeconds,
+                logger: logger
+            )
         }
     }
 
@@ -700,6 +762,7 @@ public struct StrandWorker: Service {
         let fatalDeadline = TaskDeadline(timeout: fatalDeadlineTimeout)
 
         let taskStart = ContinuousClock.now
+        let taskStartWall = Date.now  // wall clock for wait_time
         let taskDims: [(String, String)] = [
             ("task_name", claimed.taskName),
             ("queue", options.queue),
@@ -719,21 +782,69 @@ public struct StrandWorker: Service {
                         self._metrics.value
                             .makeTimer(label: StrandMetrics.taskDuration, dimensions: taskDims)
                             .recordNanoseconds(elapsed.nanoseconds)
+                        // execMs is read after the task group exits via
+                        // (ContinuousClock.now - taskStart).  The ~1-2 ms overhead
+                        // from group teardown is negligible for p50/p95/p99.
                     }
                     // OTel span: one span per task execution attempt.
-                    // SpanKind.consumer: the worker is processing an async message
-                    // from the task queue. The producer span (enqueue call-site) ended
-                    // before this span starts, so we use addLink rather than
-                    // parent-child — the async gap breaks the parent-child model.
+                    //
+                    // Extract the W3C trace context from the task headers and use it
+                    // as the *parent* span.  This creates a proper parent-child
+                    // relationship in Jaeger / OTLP collectors:
+                    //
+                    //   • Activities / child-workflows enqueued by a workflow carry the
+                    //     workflow activation’s span (injected in applyScheduleCommands)
+                    //     → they appear nested under the workflow span.
+                    //
+                    //   • Root tasks enqueued directly (e.g. from an HTTP handler) carry
+                    //     the producer span (injected by StrandClient._enqueue)
+                    //     → they appear nested under the HTTP request span.
+                    //
+                    // OTel parent-child is causal, not temporal: the child span may start
+                    // after the parent ends.  This is standard async-messaging propagation
+                    // (Kafka, SQS, AMQP) and is handled correctly by all major collectors.
+                    //
                     // Zero-cost no-op when no tracing backend is bootstrapped.
-                    var linkCtx = ServiceContext.topLevel
+                    var parentCtx = ServiceContext.topLevel
                     InstrumentationSystem.tracer.extract(
                         claimed.headers,
-                        into: &linkCtx,
+                        into: &parentCtx,
                         using: DictionaryExtractor()
                     )
-                    return try await withSpan(claimed.taskName, ofKind: .consumer) { span in
-                        span.addLink(SpanLink(context: linkCtx, attributes: [:]))
+
+                    // ── Trace continuity (zero DB cost) ──────────────────────────
+                    // Workflows enqueued outside an HTTP context (seeders, cron)
+                    // have NULL headers — no traceparent at enqueue time — so
+                    // each activation creates a fresh root span in a different
+                    // Jaeger trace. The user sees one span per trace instead of
+                    // the full workflow history.
+                    //
+                    // Fix: derive a synthetic traceparent directly from the task
+                    // UUID (128 bits ≡ OTel trace ID). Because the UUID is stable
+                    // across every activation, all activations and their spawned
+                    // activities share the same trace ID → one complete trace in
+                    // Jaeger. No DB write, no extra round-trip.
+                    //
+                    // Workflows enqueued from an HTTP handler already have a real
+                    // traceparent extracted above; this block is skipped for them.
+                    if claimed.kind == .workflow && claimed.headers.isEmpty {
+                        // UUIDv7 hex (32 chars) = OTel trace ID (16 bytes).
+                        // Span ID (8 bytes) = first 16 hex chars of the UUID.
+                        // The synthetic “parent” span does not physically exist in
+                        // Jaeger; collectors treat these spans as trace roots while
+                        // still grouping them under the shared trace ID.
+                        let hex = claimed.taskID.uuidString
+                            .lowercased()
+                            .replacing("-", with: "")
+                        let syntheticParent = "00-\(hex)-\(hex.prefix(16))-01"
+                        InstrumentationSystem.tracer.extract(
+                            ["traceparent": syntheticParent],
+                            into: &parentCtx,
+                            using: DictionaryExtractor()
+                        )
+                    }
+
+                    return try await withSpan(claimed.taskName, context: parentCtx, ofKind: .consumer) { span in
                         span.attributes[StrandLogKeys.taskName] = SpanAttribute.string(
                             claimed.taskName
                         )
@@ -804,7 +915,16 @@ public struct StrandWorker: Service {
             }
             _metrics.value.makeCounter(label: StrandMetrics.tasksCompleted, dimensions: taskDims)
                 .increment(by: 1)
-            // nil → workflow suspended cleanly; DB already transitioned to SLEEPING.
+            // Record to DDSketch buffer with known state.
+            // nil result means the workflow suspended cleanly — still a "completed" execution
+            // from the worker’s perspective (it ran and handed off cleanly).
+            metricsBuffer?.record(
+                queue: options.queue,
+                taskName: claimed.taskName,
+                state: .completed,
+                execMs: Double((ContinuousClock.now - taskStart).nanoseconds) / 1_000_000.0,
+                waitMs: max(0, taskStartWall.timeIntervalSince(claimed.availableAt) * 1000)
+            )
         } catch is CancellationError {
             // Worker is shutting down (graceful SIGTERM or forced cancellation).
             // Leave the run in RUNNING state — the leaseExpiryLoop sweep will
@@ -875,6 +995,13 @@ public struct StrandWorker: Service {
             // Pre-encoded failure reason from ActivityDefinition._run — use verbatim.
             _metrics.value.makeCounter(label: StrandMetrics.tasksFailed, dimensions: taskDims)
                 .increment(by: 1)
+            metricsBuffer?.record(
+                queue: options.queue,
+                taskName: claimed.taskName,
+                state: .failed,
+                execMs: Double((ContinuousClock.now - taskStart).nanoseconds) / 1_000_000.0,
+                waitMs: max(0, taskStartWall.timeIntervalSince(claimed.availableAt) * 1000)
+            )
             do {
                 try await Queries.failRun(
                     on: postgres,
@@ -892,6 +1019,13 @@ public struct StrandWorker: Service {
         } catch {
             _metrics.value.makeCounter(label: StrandMetrics.tasksFailed, dimensions: taskDims)
                 .increment(by: 1)
+            metricsBuffer?.record(
+                queue: options.queue,
+                taskName: claimed.taskName,
+                state: .failed,
+                execMs: Double((ContinuousClock.now - taskStart).nanoseconds) / 1_000_000.0,
+                waitMs: max(0, taskStartWall.timeIntervalSince(claimed.availableAt) * 1000)
+            )
             let reason = FailureReason(error: error)
             do {
                 let buf =

--- a/Sources/StrandServer/MetricsCache.swift
+++ b/Sources/StrandServer/MetricsCache.swift
@@ -1,0 +1,171 @@
+import Logging
+public import PostgresNIO
+public import ServiceLifecycle
+@_spi(Internal) public import Strand
+import Synchronization
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+// MARK: - Cache
+
+/// Thread-safe in-memory cache of the latest ``StrandMetricsBroadcast``.
+///
+/// Updated by ``MetricsBroadcastListener`` when a `strand_metrics` pg_notify
+/// arrives. Read by ``MetricsRoutes`` to avoid per-request COUNT queries.
+///
+/// Broadcasts older than ``ttl`` are treated as stale; routes fall back to
+/// live DB queries until the next broadcast arrives.
+public final class MetricsCache: Sendable {
+
+    private struct _State {
+        var broadcast: StrandMetricsBroadcast?
+        var receivedAt: Date = .distantPast
+    }
+
+    private let _mutex: Mutex<_State> = Mutex(_State())
+
+    /// Maximum age of a cached broadcast before it is considered stale.
+    /// Default: 30 s — comfortably longer than the default 5 s broadcast
+    /// interval, so a single missed cycle never forces a live query.
+    public let ttl: Duration
+
+    public init(ttl: Duration = .seconds(30)) {
+        self.ttl = ttl
+    }
+
+    /// Replaces the cached broadcast with a freshly received one.
+    func update(_ broadcast: StrandMetricsBroadcast) {
+        _mutex.withLock { s in
+            s.broadcast = broadcast
+            s.receivedAt = Date.now
+        }
+    }
+
+    /// Returns the cached broadcast if one exists and is younger than ``ttl``,
+    /// otherwise `nil` (routes should fall back to live DB queries).
+    public func current() -> StrandMetricsBroadcast? {
+        _mutex.withLock { s in
+            guard let b = s.broadcast else { return nil }
+            let age = Date.now.timeIntervalSince(s.receivedAt)
+            guard age < Double(ttl.components.seconds) else { return nil }
+            return b
+        }
+    }
+}
+
+// MARK: - Listener service
+
+/// Service that receives ``StrandMetricsBroadcast`` notifications and keeps
+/// a ``MetricsCache`` up to date so ``MetricsRoutes`` never issues on-demand
+/// COUNT queries.
+///
+/// **Preferred (one connection)**: pass a ``StrandNotifier`` that already
+/// declares `"strand_metrics"` in its channels.  The listener subscribes to
+/// the notifier's `AsyncStream` — zero extra Postgres connections.
+///
+/// ```swift
+/// let notifier = StrandNotifier(
+///     postgres: postgres,
+///     channels: [StrandChannels.tasks, StrandChannels.metrics],
+///     logger: logger
+/// )
+/// let cache    = MetricsCache()
+/// let listener = MetricsBroadcastListener(notifier: notifier, cache: cache, logger: logger)
+/// // notifier replaces MetricsBroadcastListener's own connection entirely
+/// ```
+///
+/// **Fallback (own connection)**: omit `notifier` and provide `postgres` when
+/// the server process runs without a ``StrandNotifier``.
+public struct MetricsBroadcastListener: Service {
+    private let notifier: StrandNotifier?
+    private let postgres: PostgresClient?
+    private let cache: MetricsCache
+    private let logger: Logger
+
+    private static let channel = StrandChannels.metrics
+
+    /// Initialise with a shared ``StrandNotifier`` (preferred — no extra connection).
+    public init(notifier: StrandNotifier, cache: MetricsCache, logger: Logger) {
+        self.notifier = notifier
+        self.postgres = nil
+        self.cache = cache
+        self.logger = logger
+    }
+
+    /// Initialise with a dedicated Postgres client (fallback when no notifier is available).
+    public init(postgres: PostgresClient, cache: MetricsCache, logger: Logger) {
+        self.notifier = nil
+        self.postgres = postgres
+        self.cache = cache
+        self.logger = logger
+    }
+
+    public func run() async throws {
+        logger.debug("metrics broadcast listener starting")
+        defer { logger.debug("metrics broadcast listener stopped") }
+
+        if let notifier {
+            // Fast path: subscribe to the shared notifier stream.
+            // No Postgres connection needed here — the notifier owns it.
+            //
+            // cancelWhenGracefulShutdown is essential: without it, the for-await
+            // loop blocks until the notifier's stream finishes.  The notifier
+            // is an earlier service in the ServiceGroup so it shuts down AFTER
+            // this listener.  Without the wrapper the ServiceGroup would be stuck
+            // waiting for this run() to return, preventing every subsequent
+            // service (workers, notifier itself) from receiving their own
+            // graceful shutdown signal.
+            await cancelWhenGracefulShutdown {
+                for await payload in notifier.stream(for: Self.channel) {
+                    self.decode(payload)
+                }
+            }
+            return
+        }
+
+        // Fallback: own LISTEN connection (no StrandNotifier in this process).
+        guard let postgres else { return }
+
+        while !Task.isShuttingDownGracefully && !Task.isCancelled {
+            do {
+                try await cancelWhenGracefulShutdown {
+                    try await postgres.withConnection { conn in
+                        try await conn.listen(on: Self.channel) { notifications in
+                            for try await notification in notifications {
+                                self.decode(notification.payload)
+                            }
+                        }
+                    }
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                logger.warning(
+                    "metrics listener connection lost — reconnecting",
+                    metadata: ["error": "\(String(reflecting: error))"]
+                )
+                try? await cancelWhenGracefulShutdown {
+                    try await Task.sleep(for: .seconds(1))
+                }
+            }
+        }
+    }
+
+    private func decode(_ payload: String) {
+        // _decodeMetricsBroadcast handles both plain JSON ("{...}")
+        // and gzip+base64 encoded payloads from _zlibDeflate.
+        guard let broadcast = _decodeMetricsBroadcast(payload) else { return }
+        cache.update(broadcast)
+        logger.debug(
+            "metrics cache updated",
+            metadata: [
+                "strand.namespace": .string(broadcast.namespace),
+                "strand.queue_count": .stringConvertible(broadcast.queues.count),
+            ]
+        )
+    }
+}

--- a/Sources/StrandServer/Models.swift
+++ b/Sources/StrandServer/Models.swift
@@ -30,7 +30,10 @@ struct QueueResponse: Codable, Sendable {
     struct StatsBody: Codable, Sendable {
         let pending: Int
         let running: Int
+        /// Workflows suspended on a `ctx.sleep(for:)` timer.
         let sleeping: Int
+        /// Workflows suspended waiting for an activity, child workflow, or named event.
+        let waiting: Int
         let completed: Int
         let failed: Int
         let cancelled: Int
@@ -44,6 +47,7 @@ struct QueueResponse: Codable, Sendable {
             pending: row.pending,
             running: row.running,
             sleeping: row.sleeping,
+            waiting: row.waiting,
             completed: row.completed,
             failed: row.failed,
             cancelled: row.cancelled
@@ -72,6 +76,10 @@ struct TaskSummaryResponse: Codable, Sendable {
     let parentTaskId: UUID?
     /// Schedule name that triggered this task, or `null` if not scheduled.
     let scheduleName: String?
+    /// Human-readable workflow ID — the value passed to ``WorkflowOptions/id`` at
+    /// enqueue time, or the auto-generated `"WorkflowName-<ms>"` string.
+    /// `nil` for activity tasks (spawned internally, not via `startWorkflow`).
+    let workflowId: String?
 
     init(from row: TaskSummaryRow) {
         id = row.id
@@ -84,6 +92,7 @@ struct TaskSummaryResponse: Codable, Sendable {
         kind = row.kind
         parentTaskId = row.parentTaskId
         scheduleName = row.scheduleName
+        workflowId = row.workflowId
     }
 }
 extension TaskSummaryResponse: ResponseCodable {}
@@ -103,6 +112,8 @@ struct TaskDetailResponse: Codable, Sendable {
     let cancelledAt: Date?
     let kind: TaskKind
     let parentTaskId: UUID?
+    /// Human-readable workflow ID. See ``TaskSummaryResponse/workflowId``.
+    let workflowId: String?
     /// Scheduling metadata for tasks triggered by a schedule, or `null` if not scheduled.
     let scheduling: SchedulingInfoResponse?
 
@@ -121,6 +132,7 @@ struct TaskDetailResponse: Codable, Sendable {
         cancelledAt = row.cancelledAt
         kind = row.kind
         parentTaskId = row.parentTaskId
+        workflowId = row.workflowId
         scheduling = row.schedulingMetadata.map {
             SchedulingInfoResponse(
                 scheduleName: $0.scheduledBy,
@@ -280,8 +292,11 @@ extension WorkerTaskResponse: ResponseCodable {}
 
 struct WorkerDetailResponse: Codable, Sendable {
     let workerID: String
+    let queue: String
+    let concurrency: Int
     let runningTasks: Int
     let completedRecently: Int
+    let startedAt: Date?
     let lastSeenAt: Date?
     let leaseExpiresAt: Date?
     let isHealthy: Bool

--- a/Sources/StrandServer/Routes/MetricsRoutes.swift
+++ b/Sources/StrandServer/Routes/MetricsRoutes.swift
@@ -15,16 +15,42 @@ struct MetricsResponse: Codable, Sendable {
         let hour: String
         let count: Int
     }
+    struct TaskTiming: Codable, Sendable {
+        let queue: String
+        let taskName: String
+        let state: TaskState
+        let count: Int
+        /// Executions per second for this (queue, task, state) in the last broadcast cycle.
+        /// `nil` when no ``AggregatedMetricsBuffer`` is wired in.
+        let ratePerSec: Double?
+        /// p50 execution time in milliseconds (±2 % relative error).
+        let p50Ms: Double?
+        /// p95 execution time in milliseconds.
+        let p95Ms: Double?
+        /// p99 execution time in milliseconds.
+        let p99Ms: Double?
+        /// p50 queue-wait time (time from PENDING to claimed), milliseconds.
+        let p50WaitMs: Double?
+        /// p95 queue-wait time, milliseconds.
+        let p95WaitMs: Double?
+    }
     let completed: Int
     let failed: Int
     let cancelled: Int
     let pending: Int
     let running: Int
     let avgDurationMs: Int?
+    /// Total tasks completed or failed per second across all queues in the last broadcast cycle.
+    /// `nil` when no ``AggregatedMetricsBuffer`` is wired in or the broadcast cache is stale.
+    let throughputPerSec: Double?
     /// Completed tasks per hour for the last 24 h.
     let throughputPerHour: [Bucket]
     /// Failed tasks per hour for the last 24 h.
     let errorRatePerHour: [Bucket]
+    /// Per-(queue, task) latency percentiles from DDSketch.
+    /// Present only when ``StrandMetricsLoop`` and ``AggregatedMetricsBuffer``
+    /// are wired in and at least one task completed since the last broadcast.
+    let taskTimings: [TaskTiming]?
 }
 extension MetricsResponse: ResponseCodable {}
 
@@ -32,6 +58,7 @@ struct MetricsRoutes {
     let postgres: PostgresClient
     let defaultNamespaceID: String
     let logger: Logger
+    let cache: MetricsCache?
 
     func register(on router: some RouterMethods<StrandRequestContext>) {
 
@@ -39,19 +66,79 @@ struct MetricsRoutes {
         router.get("metrics") { _, ctx -> MetricsResponse in
             let ns = ctx.namespaceID
 
-            // ── Summary counts (last 24 h) ────────────────────────────────────
+            // ── Live counts: cache XOR DB ─────────────────────────────────────────────────────
+            //
+            // StrandMetricsLoop broadcasts PENDING/RUNNING/SLEEPING/WAITING
+            // counts for every queue every 5 s.  MetricsBroadcastListener
+            // receives and caches them.  When the cache is fresh we serve
+            // live counts from memory with zero DB queries.
+            //
+            // The broadcast is scoped to a namespace (broadcast.namespace).
+            // We sum across all queues in the broadcast to get namespace totals.
+            let pending: Int
+            let running: Int
+
+            if let broadcast = self.cache?.current(), broadcast.namespace == ns {
+                // Cache hit — no DB query at all for live counts.
+                pending = broadcast.queues.reduce(0) { $0 + $1.pending }
+                running = broadcast.queues.reduce(0) {
+                    $0 + $1.running + $1.sleeping + $1.waiting
+                }
+            } else {
+                // Cache miss or stale — query DB directly.
+                // Both states use strand_tasks_ns_queue_state_idx.
+                let liveStream = try await self.postgres.query(
+                    """
+                    SELECT
+                      (SELECT COUNT(*) FROM strand.tasks
+                       WHERE namespace_id = \(ns) AND state = 'PENDING') AS pending,
+                      (SELECT COUNT(*) FROM strand.tasks
+                       WHERE namespace_id = \(ns)
+                         AND state IN ('RUNNING','SLEEPING','WAITING')) AS running
+                    """,
+                    logger: self.logger
+                )
+                if let row = try await liveStream.first(where: { _ in true }) {
+                    var col = row.makeIterator()
+                    pending = try col.next()!.decode(Int.self, context: .default)
+                    running = try col.next()!.decode(Int.self, context: .default)
+                } else {
+                    pending = 0
+                    running = 0
+                }
+            }
+
+            // ── Terminal counts + avg duration (last 24 h) ──────────────────────────
+            //
+            // Always queried from the DB: the 24 h window is bounded and each
+            // state uses its own partial index so these are fast regardless of
+            // total table size:
+            //   COMPLETED → completed_at  strand_tasks_completed_at_idx
+            //   FAILED    → created_at    strand_tasks_failed_idx
+            //   CANCELLED → cancelled_at  strand_tasks_cancelled_at_idx
             let summaryStream = try await self.postgres.query(
                 """
                 SELECT
-                  COALESCE(SUM(CASE WHEN state = 'COMPLETED' THEN 1 ELSE 0 END), 0) AS completed,
-                  COALESCE(SUM(CASE WHEN state = 'FAILED'    THEN 1 ELSE 0 END), 0) AS failed,
-                  COALESCE(SUM(CASE WHEN state = 'CANCELLED' THEN 1 ELSE 0 END), 0) AS cancelled,
-                  COALESCE(SUM(CASE WHEN state = 'PENDING'   THEN 1 ELSE 0 END), 0) AS pending,
-                  COALESCE(SUM(CASE WHEN state IN ('RUNNING','SLEEPING','WAITING') THEN 1 ELSE 0 END), 0) AS running,
-                  AVG(EXTRACT(EPOCH FROM (completed_at - created_at)) * 1000)::bigint AS avg_ms
-                FROM strand.tasks
-                WHERE namespace_id = \(ns)
-                  AND created_at >= NOW() - INTERVAL '24 hours'
+                  (SELECT COUNT(*) FROM strand.tasks
+                   WHERE namespace_id = \(ns)
+                     AND state = 'COMPLETED'
+                     AND completed_at >= NOW() - INTERVAL '24 hours') AS completed,
+
+                  (SELECT COUNT(*) FROM strand.tasks
+                   WHERE namespace_id = \(ns)
+                     AND state = 'FAILED'
+                     AND created_at >= NOW() - INTERVAL '24 hours') AS failed,
+
+                  (SELECT COUNT(*) FROM strand.tasks
+                   WHERE namespace_id = \(ns)
+                     AND state = 'CANCELLED'
+                     AND cancelled_at >= NOW() - INTERVAL '24 hours') AS cancelled,
+
+                  (SELECT AVG(EXTRACT(EPOCH FROM (completed_at - created_at)) * 1000)::bigint
+                   FROM strand.tasks
+                   WHERE namespace_id = \(ns)
+                     AND state = 'COMPLETED'
+                     AND completed_at >= NOW() - INTERVAL '24 hours') AS avg_ms
                 """,
                 logger: self.logger
             )
@@ -59,29 +146,29 @@ struct MetricsRoutes {
             var completed = 0
             var failed = 0
             var cancelled = 0
-            var pending = 0
-            var running = 0
             var avgDurationMs: Int? = nil
             if let row = try await summaryStream.first(where: { _ in true }) {
                 var col = row.makeIterator()
                 completed = try col.next()!.decode(Int.self, context: .default)
                 failed = try col.next()!.decode(Int.self, context: .default)
                 cancelled = try col.next()!.decode(Int.self, context: .default)
-                pending = try col.next()!.decode(Int.self, context: .default)
-                running = try col.next()!.decode(Int.self, context: .default)
                 avgDurationMs = try col.next()!.decode(Int?.self, context: .default)
             }
 
-            // ── Hourly throughput (completed tasks) ───────────────────────────
+            // ── Hourly throughput (completed tasks) ───────────────────────────────────────
+            //
+            // Bucket by completed_at (not created_at) so the partial index is
+            // usable and so the bucket represents when tasks *finished*, not
+            // when they were enqueued.
             let throughputStream = try await self.postgres.query(
                 """
                 SELECT
-                  date_trunc('hour', created_at) AS hour,
+                  date_trunc('hour', completed_at) AS hour,
                   COUNT(*) AS cnt
                 FROM strand.tasks
                 WHERE namespace_id = \(ns)
                   AND state = 'COMPLETED'
-                  AND created_at >= NOW() - INTERVAL '24 hours'
+                  AND completed_at >= NOW() - INTERVAL '24 hours'
                 GROUP BY 1
                 ORDER BY 1
                 """,
@@ -95,7 +182,11 @@ struct MetricsRoutes {
                 throughput.append(.init(hour: hour.ISO8601Format(), count: cnt))
             }
 
-            // ── Hourly error rate (failed tasks) ──────────────────────────────
+            // ── Hourly error rate (failed tasks) ────────────────────────────────────────────
+            //
+            // FAILED tasks have no failed_at column so created_at is used;
+            // strand_tasks_failed_idx covers (namespace_id, queue, created_at DESC)
+            // WHERE state = 'FAILED' so this is index-bound.
             let errorStream = try await self.postgres.query(
                 """
                 SELECT
@@ -118,6 +209,63 @@ struct MetricsRoutes {
                 errors.append(.init(hour: hour.ISO8601Format(), count: cnt))
             }
 
+            // ── DDSketch percentiles ────────────────────────────────────────────────────────
+            //
+            // Present only when the broadcast includes timing snapshots from
+            // the AggregatedMetricsBuffer.  Each snapshot carries a serialised
+            // DDSketch; we compute p50/p95/p99 inline (microseconds of CPU).
+            // ── avgDurationMs from DDSketch (gap 3) ──────────────────────────────
+            // When the cache has fresh timing data use weighted p50 across all
+            // completed tasks rather than the DB AVG (which is for last 24h).
+            // DB avgDurationMs is already computed above but may be overridden here.
+            if let broadcast = self.cache?.current(),
+                broadcast.namespace == ns,
+                let timings = broadcast.timings
+            {
+                let completedTimings = timings.filter { $0.state == .completed }
+                let totalCount = completedTimings.reduce(0) { $0 + $1.count }
+                if totalCount > 0 {
+                    let weightedSum = completedTimings.reduce(0.0) { sum, t in
+                        sum + (t.execTime.quantile(0.50) ?? 0) * Double(t.count)
+                    }
+                    avgDurationMs = Int(weightedSum / Double(totalCount))
+                }
+            }
+
+            // ── Throughput rate + DDSketch percentiles ────────────────────────
+            // Both sourced from the broadcast cache so there are zero extra
+            // DB queries when the cache is warm.
+            var throughputPerSec: Double? = nil
+            let taskTimings: [MetricsResponse.TaskTiming]?
+            if let broadcast = self.cache?.current(),
+                broadcast.namespace == ns
+            {
+                // Namespace-wide throughput: sum queue-level rates from the broadcast.
+                let total = broadcast.queues.compactMap(\.throughputPerSec).reduce(0, +)
+                throughputPerSec = total > 0 ? total : nil
+
+                if let timings = broadcast.timings, !timings.isEmpty {
+                    taskTimings = timings.map { t in
+                        MetricsResponse.TaskTiming(
+                            queue: t.queue,
+                            taskName: t.taskName,
+                            state: t.state,
+                            count: t.count,
+                            ratePerSec: t.ratePerSec,
+                            p50Ms: t.execTime.quantile(0.50),
+                            p95Ms: t.execTime.quantile(0.95),
+                            p99Ms: t.execTime.quantile(0.99),
+                            p50WaitMs: t.waitTime?.quantile(0.50),
+                            p95WaitMs: t.waitTime?.quantile(0.95)
+                        )
+                    }
+                } else {
+                    taskTimings = nil
+                }
+            } else {
+                taskTimings = nil
+            }
+
             return MetricsResponse(
                 completed: completed,
                 failed: failed,
@@ -125,8 +273,10 @@ struct MetricsRoutes {
                 pending: pending,
                 running: running,
                 avgDurationMs: avgDurationMs,
+                throughputPerSec: throughputPerSec,
                 throughputPerHour: throughput,
-                errorRatePerHour: errors
+                errorRatePerHour: errors,
+                taskTimings: taskTimings
             )
         }
     }

--- a/Sources/StrandServer/Routes/WorkerRoutes.swift
+++ b/Sources/StrandServer/Routes/WorkerRoutes.swift
@@ -10,19 +10,25 @@ import Foundation
 
 struct WorkerResponse: Codable, Sendable {
     let workerID: String
+    let queue: String
+    let concurrency: Int
     let runningTasks: Int
     let completedRecently: Int
+    let startedAt: Date?
     let lastSeenAt: Date?
     let leaseExpiresAt: Date?
-    let isHealthy: Bool  // true if leaseExpiresAt is in the future
+    let isHealthy: Bool
 
     init(from row: WorkerRow) {
         workerID = row.workerID
+        queue = row.queue
+        concurrency = row.concurrency
         runningTasks = row.runningTasks
         completedRecently = row.completedRecently
+        startedAt = row.startedAt
         lastSeenAt = row.lastSeenAt
         leaseExpiresAt = row.leaseExpiresAt
-        isHealthy = row.leaseExpiresAt.map { $0 > Date.now } ?? false
+        isHealthy = row.leaseExpiresAt.map { $0 > Date.now } ?? (row.lastSeenAt.map { Date.now.timeIntervalSince($0) < 30 } ?? false)
     }
 }
 extension WorkerResponse: ResponseCodable {}
@@ -61,11 +67,14 @@ struct WorkerRoutes {
             guard let s = summary else { return nil }
             return WorkerDetailResponse(
                 workerID: s.workerID,
+                queue: s.queue,
+                concurrency: s.concurrency,
                 runningTasks: s.runningTasks,
                 completedRecently: s.completedRecently,
+                startedAt: s.startedAt,
                 lastSeenAt: s.lastSeenAt,
                 leaseExpiresAt: s.leaseExpiresAt,
-                isHealthy: s.leaseExpiresAt.map { $0 > Date.now } ?? false,
+                isHealthy: s.leaseExpiresAt.map { $0 > Date.now } ?? (s.lastSeenAt.map { Date.now.timeIntervalSince($0) < 30 } ?? false),
                 recentTasks: tasks.map(WorkerTaskResponse.init)
             )
         }

--- a/Sources/StrandServer/StrandServer.swift
+++ b/Sources/StrandServer/StrandServer.swift
@@ -2,7 +2,7 @@ public import Hummingbird
 import Logging
 public import PostgresNIO
 public import ServiceLifecycle
-@_spi(Internal) public import Strand
+public import Strand
 
 /// A self-contained Hummingbird application that exposes the Strand dashboard
 /// REST API and manages the `PostgresClient` lifecycle internally.
@@ -47,16 +47,29 @@ public struct StrandServer: Service {
     // MARK: - Service
 
     public func run() async throws {
+        let metricsCache = MetricsCache()
+        // StrandServer.run() is the *standalone* entry point (no shared notifier).
+        // MetricsBroadcastListener opens its own LISTEN connection here, which is
+        // correct: standalone server = no worker = one connection total.
+        //
+        // When embedding StrandServer in a larger application alongside a worker,
+        // create ONE StrandNotifier at the application level, share it with both
+        // StrandWorker and MetricsBroadcastListener, and pass the MetricsCache to
+        // buildRouter.  The notifier then holds the single connection for all
+        // LISTEN/NOTIFY across the entire process.
+        let metricsListener = MetricsBroadcastListener(
+            postgres: postgres,
+            cache: metricsCache,
+            logger: configuration.logger
+        )
         var app = Application(
-            router: Self.buildRouter(client: client, postgres: postgres),
+            router: Self.buildRouter(client: client, postgres: postgres, metricsCache: metricsCache),
             configuration: .init(
                 address: .hostname(configuration.host, port: configuration.port)
             ),
             logger: configuration.logger
         )
-        // postgres must be a service so its connection pool starts before
-        // any route handler tries to borrow a connection.
-        app.addServices(postgres)
+        app.addServices(postgres, metricsListener)
         // Verify the Strand schema before the HTTP server begins accepting
         // requests — prevents 500s during a cold start against a blank DB.
         //let client = self.client
@@ -74,7 +87,8 @@ public struct StrandServer: Service {
     /// Hummingbird `Application` (e.g. alongside workers in a DevServer).
     public static func buildRouter(
         client: StrandClient,
-        postgres: PostgresClient
+        postgres: PostgresClient,
+        metricsCache: MetricsCache? = nil
     ) -> Router<StrandRequestContext> {
         let router = Router(context: StrandRequestContext.self)
 
@@ -105,7 +119,8 @@ public struct StrandServer: Service {
         MetricsRoutes(
             postgres: postgres,
             defaultNamespaceID: client.namespaceID,
-            logger: client.logger
+            logger: client.logger,
+            cache: metricsCache
         ).register(on: nsGroup)
 
         return router

--- a/Tests/StrandTests/DDSketchTests.swift
+++ b/Tests/StrandTests/DDSketchTests.swift
@@ -1,0 +1,168 @@
+import Testing
+
+@testable import Strand
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+@Suite("DDSketch")
+struct DDSketchTests {
+
+    // ── 1. Empty sketch ───────────────────────────────────────────────────
+
+    @Test("quantile returns nil for an empty sketch")
+    func emptySketchReturnsNil() {
+        let sketch = DDSketch()
+        #expect(sketch.quantile(0.50) == nil)
+        #expect(sketch.quantile(0.99) == nil)
+        #expect(sketch.count == 0)
+    }
+
+    // ── 2. Single value ───────────────────────────────────────────────────
+
+    @Test("any quantile of a single-value sketch returns approximately that value")
+    func singleValueAllQuanntiles() {
+        var sketch = DDSketch()
+        sketch.insert(42.0)  // 42 ms
+
+        for q in [0.0, 0.25, 0.50, 0.75, 0.95, 0.99, 1.0] {
+            let estimate = sketch.quantile(q)
+            #expect(estimate != nil)
+            if let v = estimate {
+                // Midpoint estimate: symmetric ±2% error.
+                // max over  = γ^0.5 − 1 ≈ 2 %
+                // max under = 1 − γ^(−0.5) ≈ 2 %
+                #expect(
+                    v >= 42.0 * 0.98 && v <= 42.0 * 1.02,
+                    "q=\(q): estimate \(v) outside [42×0.98, 42×1.02]"
+                )
+            }
+        }
+    }
+
+    // ── 3. Accuracy on uniform distribution ────────────────────────────────
+    //
+    // Insert 1000 values uniformly from 1 ms to 1000 ms.
+    //
+    // The ceiling-binning variant of DDSketch always maps v to γ^k ≥ v, so
+    // estimates are in [true, true × γ].  The one-sided relative overestimate
+    // is bounded by γ - 1 = (1+ε)/(1-ε) - 1 = 2ε/(1-ε) ≈ 4.1 % for ε=0.02.
+    // Tests use [true, true × 1.05] with 1 % float headroom.
+
+    @Test("quantile estimates on uniform 1–1000 ms distribution are within ±2% relative error")
+    func uniformDistributionAccuracy() {
+        var sketch = DDSketch()
+        for i in 1...1000 {
+            sketch.insert(Double(i))
+        }
+        #expect(sketch.count == 1000)
+
+        let cases: [(q: Double, trueMs: Double)] = [
+            (0.50, 500.0),
+            (0.90, 900.0),
+            (0.95, 950.0),
+            (0.99, 990.0),
+        ]
+        for (q, trueMs) in cases {
+            let estimate = sketch.quantile(q)
+            #expect(estimate != nil, "q=\(q) returned nil")
+            if let v = estimate {
+                // Midpoint estimate: symmetric ±2% bound.
+                #expect(
+                    v >= trueMs * 0.98 && v <= trueMs * 1.02,
+                    "q=\(q): estimate \(v) outside [\(trueMs*0.98), \(trueMs*1.02)]"
+                )
+            }
+        }
+    }
+
+    // ── 4. Merge ──────────────────────────────────────────────────────────
+    //
+    // Merging two sketches of [1…500] and [501…1000] should give the same
+    // result as inserting all 1000 values into one sketch.
+
+    @Test("merge produces the same quantiles as inserting all values directly")
+    func mergeEquivalence() {
+        var full = DDSketch()
+        for i in 1...1000 { full.insert(Double(i)) }
+
+        var a = DDSketch()
+        var b = DDSketch()
+        for i in 1...500 { a.insert(Double(i)) }
+        for i in 501...1000 { b.insert(Double(i)) }
+        a.merge(b)
+
+        #expect(a.count == full.count)
+
+        for q in [0.25, 0.50, 0.75, 0.95, 0.99] {
+            let merged = a.quantile(q)!
+            let direct = full.quantile(q)!
+            // The two should be equal (same bins, same counts)
+            #expect(
+                merged == direct,
+                "q=\(q): merged=\(merged) != direct=\(direct)"
+            )
+        }
+    }
+
+    // ── 5. Serialisation round-trip ───────────────────────────────────────
+    //
+    // DDSketch.Serialized must preserve quantile estimates within floating-point
+    // precision (the serialised form carries the exact bin counts).
+
+    @Test("Serialized round-trip preserves quantile estimates")
+    func serialisedRoundTrip() throws {
+        var sketch = DDSketch()
+        for i in stride(from: 1.0, through: 500.0, by: 1.0) {
+            sketch.insert(i)
+        }
+
+        let serialized = DDSketch.Serialized(from: sketch)
+        #expect(serialized.size == sketch.count)
+
+        for q in [0.50, 0.95, 0.99] {
+            let fromSketch = sketch.quantile(q)!
+            let fromSerialized = serialized.quantile(q)!
+            #expect(
+                fromSketch == fromSerialized,
+                "q=\(q): sketch=\(fromSketch) != serialized=\(fromSerialized)"
+            )
+        }
+    }
+
+    // ── 6. Serialised quantile accuracy ───────────────────────────────────────────────
+    //
+    // Verify that the Serialized.quantile path also honours the symmetric ±2% guarantee.
+
+    @Test("Serialized.quantile estimates are within ±2% error")
+    func serialisedAccuracy() {
+        var sketch = DDSketch()
+        for i in 1...1000 { sketch.insert(Double(i)) }
+        let s = DDSketch.Serialized(from: sketch)
+
+        let cases: [(q: Double, trueMs: Double)] = [
+            (0.50, 500.0), (0.95, 950.0), (0.99, 990.0),
+        ]
+        for (q, trueMs) in cases {
+            let v = s.quantile(q)!
+            #expect(
+                v >= trueMs && v <= trueMs * 1.05,
+                "q=\(q): estimate \(v) outside [\(trueMs), \(trueMs*1.05)]"
+            )
+        }
+    }
+
+    // ── 7. Correctness constants ──────────────────────────────────────────
+
+    @Test("gamma and invLogGamma constants are consistent")
+    func constantsConsistency() {
+        // invLogGamma must equal 1/log(gamma)
+        let recomputed = 1.0 / log(DDSketch.gamma)
+        #expect(abs(DDSketch.invLogGamma - recomputed) < 1e-10)
+        // gamma > 1 (otherwise log would be <= 0)
+        #expect(DDSketch.gamma > 1.0)
+    }
+}

--- a/Tests/StrandTests/DDSketchTests.swift
+++ b/Tests/StrandTests/DDSketchTests.swift
@@ -2,10 +2,12 @@ import Testing
 
 @testable import Strand
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
-import Foundation
+#if canImport(Darwin)
+import Darwin  // For macOS, iOS, watchOS, tvOS
+#elseif canImport(Glibc)
+import Glibc  // For Linux
+#elseif os(Windows)
+import ucrt  // For Windows
 #endif
 
 @Suite("DDSketch")
@@ -157,12 +159,35 @@ struct DDSketchTests {
 
     // ── 7. Correctness constants ──────────────────────────────────────────
 
-    @Test("gamma and invLogGamma constants are consistent")
+    @Test("DDSketch constants satisfy the algebraic invariants of the 2% error specification")
     func constantsConsistency() {
-        // invLogGamma must equal 1/log(gamma)
-        let recomputed = 1.0 / log(DDSketch.gamma)
-        #expect(abs(DDSketch.invLogGamma - recomputed) < 1e-10)
-        // gamma > 1 (otherwise log would be <= 0)
-        #expect(DDSketch.gamma > 1.0)
+        // ── 1. gamma encodes the claimed error rate ───────────────────────
+        // For gamma = (1+ε)/(1-ε), algebra gives (γ-1)/(γ+1) = ε.
+        // Checking this avoids restating the formula while still verifying
+        // that gamma is tuned to the right error bound.
+        let derivedError = (DDSketch.gamma - 1.0) / (DDSketch.gamma + 1.0)
+        #expect(abs(derivedError - DDSketch.errorRate) < 1e-14)
+        #expect(DDSketch.gamma > 1.0)  // log(γ) must be positive
+
+        // ── 2. Cross-constant identity (independent of source formulas) ───
+        // invLogGamma × log2gamma = 1/log(γ) × log₂(γ)
+        //                         = log₂(γ)/log(γ)  (change of base)
+        //                         = 1/log(2)           = log₂(e)
+        // This holds for any γ > 1 and is derivable from mathematics alone,
+        // not by reading the source code.
+        let log2e = 1.0 / log(2.0)  // ≈ 1.4426950408889634
+        #expect(abs(DDSketch.invLogGamma * DDSketch.log2gamma - log2e) < 1e-10)
+
+        // ── 3. exp2 optimisation is numerically equivalent to pow ────────
+        // The quantile path uses exp2((k-0.5) × log2gamma) instead of
+        // pow(gamma, k-0.5). Test several bin indices to confirm equivalence.
+        for k in [1, 10, 50, 100, 500] {
+            let exp2val = exp2((Double(k) - 0.5) * DDSketch.log2gamma)
+            let powval = pow(DDSketch.gamma, Double(k) - 0.5)
+            #expect(
+                abs(exp2val - powval) / powval < 1e-10,
+                "exp2 and pow diverge at bin \(k)"
+            )
+        }
     }
 }

--- a/Tests/StrandTests/TestHelpers.swift
+++ b/Tests/StrandTests/TestHelpers.swift
@@ -141,6 +141,41 @@ func withTestEnvironment<T: Sendable>(
 
     try await Task.sleep(for: .milliseconds(100))
     try await client.verifySchema()
+
+    // ── Stale-queue sweep ─────────────────────────────────────────────────
+    // Test queues follow the pattern "t" + 12 lowercase hex chars.  If a
+    // previous `swift test` run was killed (^C, crash, timeout) before its
+    // withTestEnvironment cleanup ran, those queues accumulate tasks in the
+    // dev DB — especially scheduler tests whose StrandScheduler keeps firing
+    // every second until the connection pool eventually collapses.
+    //
+    // On every new test environment we sweep queues matching the pattern that
+    // are older than 30 minutes, deleting schedules, tasks, and the queue row.
+    // 30 min is well above the longest single test suite runtime (~10 min) so
+    // concurrent test runs on slow CI machines won’t accidentally nuke each other.
+    // This is a best-effort fire-and-forget; errors are logged, not thrown.
+    try? await postgres.query(
+        """
+        DO $$
+        DECLARE q TEXT;
+        BEGIN
+          FOR q IN
+            SELECT name FROM strand.queues
+            WHERE name ~ '^t[0-9a-f]{12}$'
+              AND created_at < NOW() - INTERVAL '30 minutes'
+          LOOP
+            DELETE FROM strand.schedules   WHERE queue = q;
+            DELETE FROM strand.events      WHERE queue = q;
+            DELETE FROM strand.event_waits WHERE queue = q;
+            DELETE FROM strand.tasks       WHERE queue = q;
+            DELETE FROM strand.queues      WHERE name  = q;
+          END LOOP;
+        END;
+        $$
+        """,
+        logger: logger
+    )
+
     try await client.createQueue(queueName)
 
     // Shared teardown: remove all test artefacts so they don't accumulate in
@@ -200,25 +235,41 @@ func startWorker(
     activities: [any ActivityBox] = [],
     metricsFactory: (any MetricsFactory)? = nil
 ) -> Task<Void, Never> {
-    let worker = StrandWorker(
-        postgres: postgres,
-        options: WorkerOptions(
-            queue: queueName,
-            workflowConcurrency: concurrency,
-            activityConcurrency: concurrency * 2,
-            pollInterval: .milliseconds(20),
-            fatalOnLeaseTimeout: false,
-            // No jitter in tests: single worker per queue, no thundering herd,
-            // and jitter would add up to 50 ms latency per task step.
-            notifyJitter: .zero
-        ),
-        workflows: workflows,
-        activityContainers: activityContainers,
-        activities: activities,
-        logger: logger,
-        metricsFactory: metricsFactory
-    )
-    return Task { try? await worker.run() }
+    // Each test worker gets its own StrandNotifier so tests remain independent.
+    // The notifier and worker run concurrently inside the same Task; cancelling
+    // the returned task shuts down both.
+    Task {
+        let notifier = StrandNotifier(
+            postgres: postgres,
+            channels: [StrandNotifier.tasksChannel],
+            logger: logger
+        )
+        let worker = StrandWorker(
+            postgres: postgres,
+            options: WorkerOptions(
+                queue: queueName,
+                workflowConcurrency: concurrency,
+                activityConcurrency: concurrency * 2,
+                pollInterval: .milliseconds(20),
+                fatalOnLeaseTimeout: false,
+                // No jitter in tests: single worker per queue, no thundering herd,
+                // and jitter would add up to 50 ms latency per task step.
+                notifyJitter: .zero
+            ),
+            notifier: notifier,
+            workflows: workflows,
+            activityContainers: activityContainers,
+            activities: activities,
+            logger: logger,
+            metricsFactory: metricsFactory
+        )
+        try? await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { try await notifier.run() }
+            group.addTask { try await worker.run() }
+            try await group.next()
+            group.cancelAll()
+        }
+    }
 }
 
 /// Polls `fetchTaskResult` until the task reaches a terminal state or `timeout` elapses.

--- a/Tests/StrandTests/TestHelpers.swift
+++ b/Tests/StrandTests/TestHelpers.swift
@@ -153,8 +153,7 @@ func withTestEnvironment<T: Sendable>(
     // are older than 30 minutes, deleting schedules, tasks, and the queue row.
     // 30 min is well above the longest single test suite runtime (~10 min) so
     // concurrent test runs on slow CI machines won’t accidentally nuke each other.
-    // This is a best-effort fire-and-forget; errors are logged, not thrown.
-    try? await postgres.query(
+    _ = try await postgres.query(
         """
         DO $$
         DECLARE q TEXT;

--- a/Tests/StrandTests/WorkerLifecycleTests.swift
+++ b/Tests/StrandTests/WorkerLifecycleTests.swift
@@ -204,18 +204,31 @@ struct WorkerLifecycleTests {
 
             // 6. Start worker 2 with a short leaseExpiryInterval so the
             //    sweep fires within ~1 second instead of the 5-second default.
-            let worker2 = StrandWorker(
-                postgres: client.postgres,
-                options: WorkerOptions(
-                    queue: client.queueName,
-                    pollInterval: .milliseconds(20),
-                    fatalOnLeaseTimeout: false,
-                    leaseExpiryInterval: .seconds(1)
-                ),
-                activities: [WltHungActivity(executionCount: counter)],
-                logger: client.logger
-            )
-            let worker2Task = Task { try? await worker2.run() }
+            let worker2Task = Task {
+                let notifier2 = StrandNotifier(
+                    postgres: client.postgres,
+                    channels: [StrandNotifier.tasksChannel],
+                    logger: client.logger
+                )
+                let worker2 = StrandWorker(
+                    postgres: client.postgres,
+                    options: WorkerOptions(
+                        queue: client.queueName,
+                        pollInterval: .milliseconds(20),
+                        fatalOnLeaseTimeout: false,
+                        leaseExpiryInterval: .seconds(1)
+                    ),
+                    notifier: notifier2,
+                    activities: [WltHungActivity(executionCount: counter)],
+                    logger: client.logger
+                )
+                try? await withThrowingTaskGroup(of: Void.self) { group in
+                    group.addTask { try await notifier2.run() }
+                    group.addTask { try await worker2.run() }
+                    try await group.next()
+                    group.cancelAll()
+                }
+            }
             defer { worker2Task.cancel() }
 
             // 7-8. Wait for terminal state.
@@ -404,6 +417,11 @@ struct WorkerLifecycleTests {
             // Start worker B — auto-registers namespace B and its queue,
             // then polls exclusively for namespace B tasks.
             let workerBTask = Task {
+                let notifierB = StrandNotifier(
+                    postgres: clientA.postgres,
+                    channels: [StrandNotifier.tasksChannel],
+                    logger: clientA.logger
+                )
                 let w = StrandWorker(
                     postgres: clientA.postgres,
                     options: WorkerOptions(
@@ -412,10 +430,16 @@ struct WorkerLifecycleTests {
                         pollInterval: .milliseconds(20),
                         fatalOnLeaseTimeout: false
                     ),
+                    notifier: notifierB,
                     workflows: [WltEchoWorkflow.self],
                     logger: clientA.logger
                 )
-                try? await w.run()
+                try? await withThrowingTaskGroup(of: Void.self) { group in
+                    group.addTask { try await notifierB.run() }
+                    group.addTask { try await w.run() }
+                    try await group.next()
+                    group.cancelAll()
+                }
             }
             defer { workerBTask.cancel() }
 

--- a/loom/src/api/metrics.ts
+++ b/loom/src/api/metrics.ts
@@ -1,20 +1,40 @@
 import { api } from "./client";
 
 export interface MetricsBucket {
-  hour: string;
-  count: number;
+    hour: string;
+    count: number;
+}
+
+export interface TaskTiming {
+    queue: string;
+    taskName: string;
+    /** Terminal state — always one of the TaskState uppercase values. */
+    state: "COMPLETED" | "FAILED";
+    count: number;
+    /** Executions per second for this (queue, task, state) in the last broadcast cycle. */
+    ratePerSec: number | null;
+    p50Ms: number | null;
+    p95Ms: number | null;
+    p99Ms: number | null;
+    /** p50 queue-wait time — time from PENDING to when a worker claimed the task */
+    p50WaitMs: number | null;
+    /** p95 queue-wait time */
+    p95WaitMs: number | null;
 }
 
 export interface MetricsData {
-  completed: number;
-  failed: number;
-  cancelled: number;
-  pending: number;
-  running: number;
-  avgDurationMs: number | null;
-  throughputPerHour: MetricsBucket[];
-  errorRatePerHour: MetricsBucket[];
+    completed: number;
+    failed: number;
+    cancelled: number;
+    pending: number;
+    running: number;
+    avgDurationMs: number | null;
+    /** Total tasks/sec across all queues in the last broadcast cycle. Null when no metrics buffer is wired. */
+    throughputPerSec: number | null;
+    throughputPerHour: MetricsBucket[];
+    errorRatePerHour: MetricsBucket[];
+    taskTimings: TaskTiming[] | null;
 }
 
 export const getMetrics = (namespace: string): Promise<MetricsData> =>
-  api.get<MetricsData>(`/api/${namespace}/metrics`).then((r) => r.data);
+    api.get<MetricsData>(`/api/${namespace}/metrics`).then((r) => r.data);

--- a/loom/src/api/types.ts
+++ b/loom/src/api/types.ts
@@ -15,7 +15,10 @@ export type TaskState =
 export interface QueueStats {
     pending: number;
     running: number;
+    /** Workflows suspended on ctx.sleep(for:) — waiting for a timer. */
     sleeping: number;
+    /** Workflows suspended waiting for an activity, child workflow, or named event. */
+    waiting: number;
     completed: number;
     failed: number;
     cancelled: number;
@@ -53,6 +56,12 @@ export interface TaskSummary {
     kind: TaskKind;
     /** UUID of the parent workflow that spawned this task, null for root tasks. */
     parentTaskId: string | null;
+    /**
+     * Human-readable workflow ID — the value passed to WorkflowOptions.id at enqueue
+     * time, or the auto-generated "WorkflowName-<ms>" string.
+     * null for activity tasks (spawned internally, not via startWorkflow).
+     */
+    workflowId: string | null;
     /** Schedule name when triggered by StrandScheduler, null for manual enqueues. */
     scheduleName: string | null;
 }
@@ -72,6 +81,7 @@ export interface TaskDetail {
     cancelledAt: string | null;
     kind: TaskKind;
     parentTaskId: string | null;
+    workflowId: string | null;
     scheduling: {
         scheduleName: string | null;
         scheduleId: string | null;

--- a/loom/src/routes/metrics.tsx
+++ b/loom/src/routes/metrics.tsx
@@ -11,6 +11,7 @@ import {
     CartesianGrid,
 } from "recharts";
 import { getMetrics } from "@/api/metrics";
+import type { TaskTiming } from "@/api/metrics";
 import { qk } from "@/lib/queryKeys";
 
 // ── Helpers ───────────────────────────────────────────────────────────────
@@ -28,8 +29,17 @@ function fmtHour(iso: string): string {
     }
 }
 
-function fmtDuration(ms: number): string {
-    if (!isFinite(ms) || ms < 0) return "—";
+function fmtRate(ratePerSec: number | null | undefined): string {
+    if (ratePerSec == null || !isFinite(ratePerSec) || ratePerSec < 0)
+        return "—";
+    const perMin = ratePerSec * 60;
+    if (perMin < 1) return "< 1/min";
+    if (ratePerSec < 1) return `${perMin.toFixed(perMin < 10 ? 1 : 0)}/min`;
+    return `${ratePerSec >= 10 ? ratePerSec.toFixed(0) : ratePerSec.toFixed(1)}/s`;
+}
+
+function fmtDuration(ms: number | null | undefined): string {
+    if (ms == null || !isFinite(ms) || ms < 0) return "—";
     if (ms < 1000) return `${Math.round(ms)}ms`;
     if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
     const m = Math.floor(ms / 60_000);
@@ -139,6 +149,105 @@ function ChartSection({ title, data, fill }: ChartSectionProps) {
     );
 }
 
+// ── Latency table ──────────────────────────────────────────────────────────
+
+function LatencyTable({ timings }: { timings: TaskTiming[] }) {
+    // Sort completed first, then by count descending
+    const sorted = [...timings].sort((a, b) => {
+        if (a.state !== b.state) return a.state === "COMPLETED" ? -1 : 1;
+        return b.count - a.count;
+    });
+
+    const headers = [
+        "Queue",
+        "Task",
+        "State",
+        "Count",
+        "Rate",
+        "exec p50",
+        "exec p95",
+        "exec p99",
+        "wait p50",
+        "wait p95",
+    ];
+
+    return (
+        <section className="rounded-lg border border-border bg-card/40 overflow-hidden">
+            <div className="px-4 py-3 border-b border-border/50 flex items-center justify-between">
+                <h2 className="text-sm font-medium text-foreground">
+                    Task latency
+                </h2>
+                <span className="text-xs text-muted-foreground">
+                    exec = run duration · wait = queue time · ±2% error
+                </span>
+            </div>
+            <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                    <thead>
+                        <tr className="border-b border-border bg-secondary/20">
+                            {headers.map((h) => (
+                                <th
+                                    key={h}
+                                    className="text-left px-4 py-2.5 text-[11px] font-medium text-muted-foreground uppercase tracking-wide whitespace-nowrap"
+                                >
+                                    {h}
+                                </th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {sorted.map((t) => (
+                            <tr
+                                key={`${t.queue}/${t.taskName}/${t.state}`}
+                                className="border-b border-border/40 last:border-0 hover:bg-secondary/10 transition-colors"
+                            >
+                                <td className="px-4 py-3 font-mono text-xs text-muted-foreground whitespace-nowrap">
+                                    {t.queue}
+                                </td>
+                                <td className="px-4 py-3 font-mono text-xs text-foreground whitespace-nowrap">
+                                    {t.taskName}
+                                </td>
+                                <td className="px-4 py-3">
+                                    <span
+                                        className={`inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-medium ${
+                                            t.state === "COMPLETED"
+                                                ? "bg-green-500/15 text-green-300 border-green-500/25"
+                                                : "bg-red-500/15 text-red-300 border-red-500/25"
+                                        }`}
+                                    >
+                                        {t.state}
+                                    </span>
+                                </td>
+                                <td className="px-4 py-3 text-muted-foreground tabular-nums">
+                                    {t.count.toLocaleString()}
+                                </td>
+                                <td className="px-4 py-3 tabular-nums text-violet-400 whitespace-nowrap">
+                                    {fmtRate(t.ratePerSec)}
+                                </td>
+                                <td className="px-4 py-3 tabular-nums text-green-400">
+                                    {fmtDuration(t.p50Ms)}
+                                </td>
+                                <td className="px-4 py-3 tabular-nums text-yellow-400">
+                                    {fmtDuration(t.p95Ms)}
+                                </td>
+                                <td className="px-4 py-3 tabular-nums text-orange-400">
+                                    {fmtDuration(t.p99Ms)}
+                                </td>
+                                <td className="px-4 py-3 tabular-nums text-sky-400">
+                                    {fmtDuration(t.p50WaitMs)}
+                                </td>
+                                <td className="px-4 py-3 tabular-nums text-blue-400">
+                                    {fmtDuration(t.p95WaitMs)}
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    );
+}
+
 // ── Page ───────────────────────────────────────────────────────────────────
 
 export function MetricsPage() {
@@ -152,7 +261,15 @@ export function MetricsPage() {
 
     return (
         <div className="px-6 py-5 space-y-5">
-            <h1 className="text-base font-semibold text-foreground">Metrics</h1>
+            <div>
+                <h1 className="text-base font-semibold text-foreground mb-0.5">
+                    Metrics
+                </h1>
+                <p className="text-xs text-muted-foreground">
+                    All queues in this namespace · completed/failed/cancelled
+                    counts are last 24 h
+                </p>
+            </div>
 
             {isLoading && (
                 <p className="text-sm text-muted-foreground">Loading…</p>
@@ -162,19 +279,19 @@ export function MetricsPage() {
             {data && (
                 <>
                     {/* Summary stat cards */}
-                    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+                    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
                         <StatCard
-                            label="Completed"
+                            label="Completed (24h)"
                             value={data.completed}
                             colorClass="text-green-400"
                         />
                         <StatCard
-                            label="Failed"
+                            label="Failed (24h)"
                             value={data.failed}
                             colorClass="text-red-400"
                         />
                         <StatCard
-                            label="Cancelled"
+                            label="Cancelled (24h)"
                             value={data.cancelled}
                             colorClass="text-muted-foreground"
                         />
@@ -188,6 +305,21 @@ export function MetricsPage() {
                             value={data.running}
                             colorClass="text-blue-400"
                         />
+                        {/* Throughput card — only rendered when the broadcast
+                             cache is warm (AggregatedMetricsBuffer wired in). */}
+                        <div className="rounded-lg border border-border bg-card/40 p-4 flex flex-col gap-1">
+                            <span className="text-2xl font-bold tabular-nums text-violet-400">
+                                {data.throughputPerSec != null
+                                    ? fmtRate(data.throughputPerSec)
+                                    : "—"}
+                            </span>
+                            <span className="text-xs text-muted-foreground font-medium uppercase tracking-wide">
+                                Throughput
+                            </span>
+                            <span className="text-[10px] text-muted-foreground/60">
+                                live · last 5 s window
+                            </span>
+                        </div>
                     </div>
 
                     {/* Avg duration */}
@@ -202,6 +334,11 @@ export function MetricsPage() {
                                 </span>
                             </div>
                         )}
+
+                    {/* Task latency percentiles (DDSketch) */}
+                    {data.taskTimings && data.taskTimings.length > 0 && (
+                        <LatencyTable timings={data.taskTimings} />
+                    )}
 
                     {/* Charts */}
                     <ChartSection

--- a/loom/src/routes/tasks.tsx
+++ b/loom/src/routes/tasks.tsx
@@ -33,6 +33,7 @@ const ZERO_STATS: QueueStats = {
     pending: 0,
     running: 0,
     sleeping: 0,
+    waiting: 0,
     completed: 0,
     failed: 0,
     cancelled: 0,
@@ -89,6 +90,11 @@ const STATE_CONFIG = [
         state: "SLEEPING",
         countKey: "sleeping" as const,
         accent: "bg-slate-500/20  text-slate-300",
+    },
+    {
+        state: "WAITING",
+        countKey: "waiting" as const,
+        accent: "bg-violet-500/20 text-violet-300",
     },
     {
         state: "COMPLETED",
@@ -280,6 +286,7 @@ export function TasksPage() {
                 pending: acc.pending + q.stats.pending,
                 running: acc.running + q.stats.running,
                 sleeping: acc.sleeping + q.stats.sleeping,
+                waiting: acc.waiting + q.stats.waiting,
                 completed: acc.completed + q.stats.completed,
                 failed: acc.failed + q.stats.failed,
                 cancelled: acc.cancelled + q.stats.cancelled,
@@ -485,9 +492,17 @@ export function TasksPage() {
                                                         search={{
                                                             queue: task.queue,
                                                         }}
-                                                        className="font-medium text-foreground hover:text-brand transition-colors"
+                                                        className="group block"
                                                     >
-                                                        {task.name}
+                                                        <span className="font-medium text-foreground group-hover:text-brand transition-colors">
+                                                            {task.name}
+                                                        </span>
+                                                        <span className="block font-mono text-[10px] text-muted-foreground/50 mt-0.5">
+                                                            {task.workflowId ??
+                                                                task.id.split(
+                                                                    "-",
+                                                                )[0]}
+                                                        </span>
                                                     </Link>
                                                 </td>
                                                 <td className="px-4 py-2.5">

--- a/loom/src/routes/workers.tsx
+++ b/loom/src/routes/workers.tsx
@@ -7,8 +7,11 @@ import { EmptyState } from "@/components/EmptyState";
 
 interface Worker {
     workerID: string;
+    queue: string;
+    concurrency: number;
     runningTasks: number;
     completedRecently: number;
+    startedAt: string | null;
     lastSeenAt: string | null;
     leaseExpiresAt: string | null;
     isHealthy: boolean;
@@ -55,6 +58,8 @@ export function WorkersPage() {
                             <tr className="border-b border-border bg-secondary/20">
                                 {[
                                     "Worker ID",
+                                    "Queue",
+                                    "Concurrency",
                                     "Running",
                                     "Completed (5 min)",
                                     "Last Seen",
@@ -73,7 +78,7 @@ export function WorkersPage() {
                         <tbody>
                             {workers.map((w) => (
                                 <tr
-                                    key={w.workerID}
+                                    key={`${w.workerID}:${w.queue}`}
                                     className="border-b border-border/40 last:border-0 hover:bg-secondary/10 transition-colors"
                                 >
                                     <td className="px-4 py-2.5 font-mono text-xs max-w-xs truncate">
@@ -91,6 +96,12 @@ export function WorkersPage() {
                                             {w.workerID.split(":").pop() ??
                                                 w.workerID}
                                         </Link>
+                                    </td>
+                                    <td className="px-4 py-2.5 font-mono text-xs text-muted-foreground">
+                                        {w.queue}
+                                    </td>
+                                    <td className="px-4 py-2.5">
+                                        {w.concurrency}
                                     </td>
                                     <td className="px-4 py-2.5">
                                         {w.runningTasks > 0 ? (

--- a/loom/src/routes/workers_/$workerId.tsx
+++ b/loom/src/routes/workers_/$workerId.tsx
@@ -24,8 +24,11 @@ interface WorkerTask {
 
 interface WorkerDetail {
     workerID: string;
+    queue: string;
+    concurrency: number;
     runningTasks: number;
     completedRecently: number;
+    startedAt: string | null;
     lastSeenAt: string | null;
     leaseExpiresAt: string | null;
     isHealthy: boolean;
@@ -152,7 +155,7 @@ export function WorkerDetailPage() {
             {data && (
                 <>
                     {/* ── Stats strip ────────────────────────────────────────────── */}
-                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
                         {[
                             {
                                 label: "Running",
@@ -161,6 +164,20 @@ export function WorkerDetailPage() {
                                     data.runningTasks > 0
                                         ? "text-yellow-300"
                                         : "text-foreground",
+                            },
+                            {
+                                label: "Queue",
+                                value: (
+                                    <span className="font-mono text-xs">
+                                        {data.queue}
+                                    </span>
+                                ),
+                                accent: "text-foreground",
+                            },
+                            {
+                                label: "Concurrency",
+                                value: data.concurrency,
+                                accent: "text-foreground",
                             },
                             {
                                 label: "Completed (5 min)",

--- a/strand.sql
+++ b/strand.sql
@@ -133,6 +133,47 @@ CREATE INDEX IF NOT EXISTS strand_tasks_deadline_idx
     ON strand.tasks (namespace_id, queue, deadline_at)
     WHERE deadline_at IS NOT NULL AND state = 'PENDING';
 
+-- ── Historic / metrics queries on terminal states ────────────────────────────
+--
+-- Partial indexes scoped to each terminal state so historic queries (dashboard
+-- metrics, task list, cleanup) never touch live-task pages. Each index is
+-- ordered by its natural completion timestamp so range scans are efficient.
+--
+-- Without these, every MetricsRoutes or ManagementQueries call that filters on
+-- a terminal state must scan the full strand.tasks table.
+
+CREATE INDEX IF NOT EXISTS strand_tasks_completed_at_idx
+    ON strand.tasks (namespace_id, queue, completed_at DESC)
+    WHERE state = 'COMPLETED' AND completed_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS strand_tasks_cancelled_at_idx
+    ON strand.tasks (namespace_id, queue, cancelled_at DESC)
+    WHERE state = 'CANCELLED' AND cancelled_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS strand_tasks_failed_idx
+    ON strand.tasks (namespace_id, queue, created_at DESC)
+    WHERE state = 'FAILED';
+
+-- ── Storage / autovacuum tuning ───────────────────────────────────────────────
+--
+-- fillfactor = 85: reserves 15 % of each heap page for in-place rewrites.
+-- When `state` changes (PENDING → RUNNING → COMPLETED) Postgres performs a
+-- HOT (Heap-Only Tuple) update — the new row version stays on the same page,
+-- no index entries are rewritten, and index bloat is prevented.
+--
+-- Aggressive autovacuum: the state column changes on every task execution, so
+-- dead tuples accumulate quickly. A 2 % scale factor and 1 ms cost delay keep
+-- the table lean without holding back normal work.
+ALTER TABLE strand.tasks SET (
+    fillfactor                          = 85,
+    autovacuum_vacuum_scale_factor      = 0.02,
+    autovacuum_vacuum_threshold         = 50,
+    autovacuum_analyze_scale_factor     = 0.02,
+    autovacuum_analyze_threshold        = 100,
+    autovacuum_vacuum_cost_limit        = 2000,
+    autovacuum_vacuum_cost_delay        = 1
+);
+
 -- ─────────────────────────────────────────────────────────────────────────────
 -- Runs — individual execution attempts.
 -- High churn: rows transition through states frequently.
@@ -179,13 +220,17 @@ CREATE TABLE IF NOT EXISTS strand.runs (
     ))
 );
 
--- Aggressive autovacuum: runs accumulate many dead tuples from frequent updates.
+-- strand.runs is the highest-churn table: attempt, state, lease_expires_at,
+-- started_at and finished_at all change on every execution. fillfactor = 80
+-- gives extra headroom for HOT updates. autovacuum is more aggressive than the
+-- Postgres default (5 % scale factor) to keep dead-tuple accumulation in check.
 ALTER TABLE strand.runs SET (
-    autovacuum_vacuum_scale_factor  = '0.05',
-    autovacuum_analyze_scale_factor = '0.02',
-    autovacuum_vacuum_threshold     = '50',
-    autovacuum_analyze_threshold    = '50',
-    autovacuum_vacuum_cost_delay    = '2'
+    fillfactor                      = 80,
+    autovacuum_vacuum_scale_factor  = 0.05,
+    autovacuum_analyze_scale_factor = 0.02,
+    autovacuum_vacuum_threshold     = 50,
+    autovacuum_analyze_threshold    = 50,
+    autovacuum_vacuum_cost_delay    = 2
 );
 
 -- Hot claim path: namespace_id first, then priority ASC so critical tasks are never starved.
@@ -401,3 +446,68 @@ CREATE TABLE IF NOT EXISTS strand.schedules (
 CREATE INDEX IF NOT EXISTS strand_schedules_due_idx
     ON strand.schedules (namespace_id, next_run_at)
     WHERE is_active = TRUE AND next_run_at IS NOT NULL;
+
+-- ───────────────────────────────────────────────────────────────────────────────
+-- Workers — ephemeral runtime heartbeat table.
+--
+-- Each StrandWorker instance upserts one row per queue on startup and
+-- refreshes updated_at on every heartbeat cycle. A background sweeper deletes
+-- rows older than 2×heartbeat_interval so stale entries are self-cleaning.
+--
+-- UNLOGGED: no WAL writes at all — as fast as writing to a local file.
+-- On crash the table is truncated, which is fine: workers re-register on the
+-- next startup. This table is never replicated to standbys.
+--
+-- Dashboard and management queries read from here to show live queue health
+-- (running, concurrency, paused) without scanning strand.runs.
+-- ───────────────────────────────────────────────────────────────────────────────
+
+CREATE UNLOGGED TABLE IF NOT EXISTS strand.workers (
+    id           TEXT        NOT NULL,    -- "<hostname>:<pid>"
+    namespace_id TEXT        NOT NULL DEFAULT 'default',
+    queue        TEXT        NOT NULL,
+    concurrency  INTEGER     NOT NULL,    -- configured workflowConcurrency + activityConcurrency
+    running      INTEGER     NOT NULL DEFAULT 0,   -- currently executing tasks
+    paused       BOOLEAN     NOT NULL DEFAULT FALSE,
+    started_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT strand_workers_pkey PRIMARY KEY (id, namespace_id, queue)
+);
+
+-- Live queue health lookup from the Workers dashboard page.
+CREATE INDEX IF NOT EXISTS strand_workers_ns_queue_idx
+    ON strand.workers (namespace_id, queue);
+
+-- ───────────────────────────────────────────────────────────────────────────────
+-- Count estimate — fast approximate row counts for large tables.
+--
+-- Uses the query planner’s own statistics (updated by autovacuum ANALYZE) to
+-- return an estimate in sub-millisecond time without a sequential scan.
+-- The planner estimate is typically within 5–10 % of the real count once
+-- autovacuum has run; for dashboard displays this is more than accurate enough.
+--
+-- Usage:
+--   SELECT strand.count_estimate('default', 'reports', 'PENDING');
+--
+-- Complement with exact COUNT(*) when the estimate returns < 50,000
+-- (planner statistics are less reliable for small tables).
+-- ───────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION strand.count_estimate(
+    ns   TEXT,
+    q    TEXT,
+    st   TEXT
+) RETURNS BIGINT AS $$
+DECLARE
+    plan JSONB;
+BEGIN
+    EXECUTE 'EXPLAIN (FORMAT JSON)
+        SELECT id FROM strand.tasks
+        WHERE namespace_id = $1
+          AND queue        = $2
+          AND state        = $3'
+        INTO plan
+        USING ns, q, st;
+    RETURN (plan -> 0 -> 'Plan' ->> 'Plan Rows')::BIGINT;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

Introduce several dev-facing workflows and supporting infra, plus metrics and notifier plumbing.

## Changes

- Add three example domains with workflows, activities and types: MonthlyBilling, PodcastTranscription, TrainVoiceAssistant (many new activity and workflow sources under Examples/Sources/DevServer).
- Enhance DevServer: increase Postgres pool, add periodic seeding (billing, voice training, podcasts), graceful shutdown-aware seeder loop, and register a shared StrandNotifier to multiplex LISTEN/NOTIFY.
- Add runtime metrics support: AggregatedMetricsBuffer, StrandMetricsLoop, MetricsCache, MetricsBroadcastListener and related server/client integration; workers now accept a metrics buffer and notifier.
- Change Activity execution span handling to avoid duplicate OTel spans; update DB query/row types to include workflowId and more queue stats (sleeping/waiting).
- Add internal utilities (DDSketch, payload compression) and tests for sketching; update server routes and frontend metric pages to surface the new metrics cache.

These changes make the dev server produce richer, realistic workloads and enable efficient broadcasted metrics for the dashboard and fewer dedicated LISTEN connections.

## Testing

<!-- How did you verify this works? Did you run `swift test`? -->

- [x] `swift test` passes locally

## AI Disclosure

<!--
  REQUIRED if any AI assistance was used — see CONTRIBUTING.md.
  Delete this section entirely if no AI was involved.
-->

- [ ] I used AI assistance while working on this PR

**Tool(s) used:** <!-- e.g. Claude, Copilot, ChatGPT -->

**Extent of use:**
<!-- Describe honestly. Examples:
  - Generated first draft of WorkflowDag.tsx, reviewed and edited manually.
  - Used for commit message suggestions only.
  - Pair-programmed the entire feature; all output was reviewed.
-->

**Was the PR description itself AI-generated?** No
