### PR TITLE
Finish continuations outside lock

### DIFF
--- a/Sources/Strand/StrandNotifier.swift
+++ b/Sources/Strand/StrandNotifier.swift
@@ -134,12 +134,15 @@ public final class StrandNotifier: Service, Sendable {
         defer {
             // Finish every active stream so consumer for-await loops exit cleanly
             // rather than blocking indefinitely.
-            _state.withLock { s in
-                for conts in s.subscriptions.values {
-                    for (_, cont) in conts { cont.finish() }
-                }
+            //
+            // collect continuations and clear subscriptions under the
+            // lock, then call finish() OUTSIDE the lock.
+            let pending = _state.withLock { s -> [AsyncStream<String>.Continuation] in
+                let all = s.subscriptions.values.flatMap(\.values)
                 s.subscriptions.removeAll()
+                return all
             }
+            for cont in pending { cont.finish() }
             logger.info("notifier stopped")
         }
 


### PR DESCRIPTION
## Summary

Fixed crash on linux

## Changes

Avoid calling AsyncStream.Continuation.finish() while holding the internal lock. Collect continuations under _state.withLock, clear subscriptions, and then call finish() outside the lock to prevent recursive-lock/assertion failures. 

## Testing

<!-- How did you verify this works? Did you run `swift test`? -->

- [x] `swift test` passes locally

## AI Disclosure

<!--
  REQUIRED if any AI assistance was used — see CONTRIBUTING.md.
  Delete this section entirely if no AI was involved.
-->

- [ ] I used AI assistance while working on this PR

**Tool(s) used:** <!-- e.g. Claude, Copilot, ChatGPT -->

**Extent of use:**
<!-- Describe honestly. Examples:
  - Generated first draft of WorkflowDag.tsx, reviewed and edited manually.
  - Used for commit message suggestions only.
  - Pair-programmed the entire feature; all output was reviewed.
-->

**Was the PR description itself AI-generated?** No
