### PR TITLE
Fairness workflow and DB refactor

### DIFF
--- a/Sources/Strand/Client.swift
+++ b/Sources/Strand/Client.swift
@@ -245,10 +245,10 @@ public struct StrandClient: Sendable {
             maxAttempts: options.maxAttempts ?? self.options.defaultMaxAttempts,
             cancellationBuffer: nil,
             idempotencyKey: resolvedID,  // always set — enables client.workflow(id:) lookup
-            priority: options.priority.rawValue,
+            priority: options.priority,
             scheduledAt: options.delayUntil,
-            fairnessKey: nil,
-            fairnessWeight: 1.0,
+            fairnessKey: options.fairnessKey,
+            fairnessWeight: options.fairnessWeight,
             kind: .workflow,
             parentTaskID: nil,
             logger: logger
@@ -415,7 +415,7 @@ public struct StrandClient: Sendable {
                 maxAttempts: maxAttempts,
                 cancellationBuffer: try cancellation.map { try JSON.encode($0) },
                 idempotencyKey: idempotencyKey,
-                priority: priority.rawValue,
+                priority: priority,
                 scheduledAt: delayUntil,
                 deadlineAt: deadlineAt,
                 fairnessKey: fairnessKey,
@@ -476,6 +476,23 @@ public struct StrandClient: Sendable {
             on: postgres,
             namespaceID: namespaceID,
             taskID: taskID,
+            logger: logger
+        )
+    }
+
+    /// Cancels multiple tasks atomically.
+    ///
+    /// Each task’s descendants are also cancelled. Any `awaitTaskResult`
+    /// calls waiting on these tasks are unblocked with a `.cancelled` state.
+    ///
+    /// For cancelling a single task prefer ``cancelTask(id:)``.
+    /// For a large batch consider chunking into groups of 500–1000.
+    @discardableResult
+    public func cancelTasks(_ taskIDs: [UUID]) async throws -> Int {
+        try await Queries.cancelTasksBatch(
+            on: postgres,
+            namespaceID: namespaceID,
+            taskIDs: taskIDs,
             logger: logger
         )
     }

--- a/Sources/Strand/DB/Queries.swift
+++ b/Sources/Strand/DB/Queries.swift
@@ -57,16 +57,29 @@ enum Queries {
 
     // MARK: - Queues
 
+    /// Connection-level implementation — the single source of truth for queue registration.
+    static func createQueue(
+        on conn: PostgresConnection,
+        namespaceID: String,
+        name: String,
+        logger: Logger
+    ) async throws {
+        try await conn.query(
+            "INSERT INTO strand.queues (namespace_id, name) VALUES (\(namespaceID), \(name)) ON CONFLICT (namespace_id, name) DO NOTHING",
+            logger: logger
+        )
+    }
+
+    /// Pool-level overload — acquires a connection then delegates to the connection overload.
     static func createQueue(
         on client: PostgresClient,
         namespaceID: String,
         name: String,
         logger: Logger
     ) async throws {
-        try await client.query(
-            "INSERT INTO strand.queues (namespace_id, name) VALUES (\(namespaceID), \(name)) ON CONFLICT (namespace_id, name) DO NOTHING",
-            logger: logger
-        )
+        try await client.withConnection { conn in
+            try await createQueue(on: conn, namespaceID: namespaceID, name: name, logger: logger)
+        }
     }
 
     static func dropQueue(
@@ -141,7 +154,7 @@ enum Queries {
         maxAttempts: Int?,
         cancellationBuffer: ByteBuffer?,
         idempotencyKey: String?,
-        priority: Int = 3,
+        priority: TaskPriority = .normal,
         scheduledAt: Date? = nil,
         timeoutSeconds: Int? = nil,
         deadlineAt: Date? = nil,
@@ -155,11 +168,7 @@ enum Queries {
             let taskID = UUID.v7()
             let runID = UUID.v7()
             // Auto-register the queue so strand.queues always reflects active queues.
-            // ON CONFLICT DO NOTHING makes this safe for concurrent enqueues.
-            try await conn.query(
-                "INSERT INTO strand.queues (namespace_id, name) VALUES (\(namespaceID), \(queue)) ON CONFLICT (namespace_id, name) DO NOTHING",
-                logger: logger
-            )
+            try await createQueue(on: conn, namespaceID: namespaceID, name: queue, logger: logger)
             try await conn.query(
                 """
                 INSERT INTO strand.tasks
@@ -202,14 +211,8 @@ enum Queries {
                         "strand.kind": .string(kind.rawValue),
                     ]
                 )
-                // Notify any listening workers that a new task is available for this queue.
-                // pg_notify is transactional — the notification is only delivered after this
-                // transaction commits, so listeners always see a task that can be claimed.
-                let notification = StrandChannels.Notification(namespace: namespaceID, queue: queue)
-                try await conn.query(
-                    "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
-                    logger: logger
-                )
+                // pg_notify is transactional — delivered only after this transaction commits.
+                try await conn.notifyWorkers(namespace: namespaceID, queue: queue, logger: logger)
                 return EnqueueRow(taskID: taskID, runID: runID, attempt: 1, created: true)
             } else {
                 let existStream = try await conn.query(
@@ -233,6 +236,301 @@ enum Queries {
                 let eAttempt = try col.next()!.decode(Int.self, context: .default)
                 return EnqueueRow(taskID: eTaskID, runID: eRunID, attempt: eAttempt, created: false)
             }
+        }
+    }
+
+    // MARK: - ChildEnqueueSpec
+
+    /// One child task to enqueue as part of a batch spawned by a single workflow activation.
+    ///
+    /// Pre-generate `taskID` and `runID` (both UUIDv7) at the call site; they are used as
+    /// the "new row" probe and discarded on an idempotency-key conflict.
+    struct ChildEnqueueSpec: Sendable {
+        let seqNum: Int
+        let taskID: UUID  // pre-generated UUIDv7; used as new-row probe
+        let runID: UUID  // pre-generated UUIDv7 for the first run row
+        let queue: String
+        let taskName: String
+        let paramsBuffer: ByteBuffer
+        let headersBuffer: ByteBuffer?
+        let retryStrategyBuffer: ByteBuffer?
+        let maxAttempts: Int?
+        let idempotencyKey: String  // always set for workflow-spawned children
+        let priority: TaskPriority
+        let scheduledAt: Date?
+        let timeoutSeconds: Int?
+        let deadlineAt: Date?
+        let fairnessKey: String?
+        let fairnessWeight: Float
+        let kind: TaskKind  // .activity or .workflow
+    }
+
+    // MARK: - enqueueChildTasksBatch
+
+    /// Batch-enqueue every child task (activity or child workflow) spawned by one workflow
+    /// activation in a **single Postgres transaction** using true batch SQL — O(1)
+    /// round-trips regardless of how many children are scheduled.
+    ///
+    /// The following all happen atomically inside one transaction:
+    ///   1. Queue auto-registration (one per distinct child queue, idempotent)
+    ///   2. One multi-row `VALUES` INSERT for all tasks (idempotent via `ON CONFLICT DO NOTHING`)
+    ///   3. One multi-row `VALUES` INSERT for genuinely new runs
+    ///   4. `pg_notify` per distinct new child queue (via `notifyWorkers`)
+    ///   5. One `unnest`-based INSERT for all `event_waits` (idempotent)
+    ///   6. `task_completions` count — if any child already done: delete its `event_wait`,
+    ///      set parent to PENDING + notify; otherwise set parent to WAITING.
+    ///
+    /// - Returns: `(seqNum, taskID)` pairs in the same order as `children`.
+    @discardableResult
+    static func enqueueChildTasksBatch(
+        on client: PostgresClient,
+        namespaceID: String,
+        parentTaskID: UUID,
+        parentRunID: UUID,
+        parentQueue: String,
+        children: [ChildEnqueueSpec],
+        logger: Logger
+    ) async throws -> [(seqNum: Int, taskID: UUID)] {
+        guard !children.isEmpty else { return [] }
+
+        return try await client.withTransaction(logger: logger) { conn in
+            // ── 1. Register all distinct child queues ────────────────────────────────
+            var seenQueues: Set<String> = []
+            for child in children {
+                guard seenQueues.insert(child.queue).inserted else { continue }
+                try await createQueue(on: conn, namespaceID: namespaceID, name: child.queue, logger: logger)
+            }
+
+            // ── 2. Insert all task rows — one multi-row VALUES statement ──────────────
+            // Built via PostgresQuery.StringInterpolation so every field, including
+            // nullable BYTEAs (headers, retry_strategy), is bound as an individual
+            // typed parameter — one round-trip for all N tasks.
+            var taskInterp = PostgresQuery.StringInterpolation(
+                literalCapacity: 300 + children.count * 256,
+                interpolationCount: children.count * 17
+            )
+            taskInterp.appendLiteral(
+                "INSERT INTO strand.tasks "
+                    + "(namespace_id, id, queue, name, params, headers, "
+                    + "retry_strategy, max_attempts, timeout_seconds, "
+                    + "idempotency_key, priority, fairness_key, fairness_weight, "
+                    + "state, kind, parent_task_id, deadline_at) VALUES "
+            )
+            for (i, child) in children.enumerated() {
+                if i > 0 { taskInterp.appendLiteral(", ") }
+                taskInterp.appendLiteral("(")
+                taskInterp.appendInterpolation(namespaceID)
+                taskInterp.appendLiteral(", ")
+                taskInterp.appendInterpolation(child.taskID)
+                taskInterp.appendLiteral(", ")
+                taskInterp.appendInterpolation(child.queue)
+                taskInterp.appendLiteral(", ")
+                taskInterp.appendInterpolation(child.taskName)
+                taskInterp.appendLiteral(", ")
+                taskInterp.appendInterpolation(child.paramsBuffer)
+                taskInterp.appendLiteral(", ")
+                taskInterp.appendInterpolation(child.headersBuffer)
+                taskInterp.appendLiteral(", ")
+                taskInterp.appendInterpolation(child.retryStrategyBuffer)
+                taskInterp.appendLiteral(", ")
+                taskInterp.appendInterpolation(child.maxAttempts)
+                taskInterp.appendLiteral(", ")
+                taskInterp.appendInterpolation(child.timeoutSeconds)
+                taskInterp.appendLiteral(", ")
+                taskInterp.appendInterpolation(child.idempotencyKey)
+                taskInterp.appendLiteral(", ")
+                try taskInterp.appendInterpolation(child.priority)
+                taskInterp.appendLiteral(", ")
+                taskInterp.appendInterpolation(child.fairnessKey)
+                taskInterp.appendLiteral(", ")
+                taskInterp.appendInterpolation(child.fairnessWeight)
+                taskInterp.appendLiteral(", ")
+                try taskInterp.appendInterpolation(TaskState.pending)
+                taskInterp.appendLiteral(", ")
+                try taskInterp.appendInterpolation(child.kind)
+                taskInterp.appendLiteral(", ")
+                taskInterp.appendInterpolation(parentTaskID)
+                taskInterp.appendLiteral(", ")
+                taskInterp.appendInterpolation(child.deadlineAt)
+                taskInterp.appendLiteral(")")
+            }
+            taskInterp.appendLiteral(" ON CONFLICT (namespace_id, queue, idempotency_key) DO NOTHING")
+            try await conn.query(PostgresQuery(stringInterpolation: taskInterp), logger: logger)
+
+            // ── 3. Identify which tasks were genuinely inserted ──────────────────────
+            // A generated taskID present in the DB means the INSERT succeeded (new row).
+            // An absent generated taskID means the conflict clause fired (idempotency hit).
+            let generatedIDs = children.map { $0.taskID }
+            let newIDsStream = try await conn.query(
+                "SELECT id FROM strand.tasks WHERE namespace_id = \(namespaceID) AND id = ANY(\(generatedIDs))",
+                logger: logger
+            )
+            var newIDSet: Set<UUID> = []
+            for try await row in newIDsStream {
+                var col = row.makeIterator()
+                newIDSet.insert(try col.next()!.decode(UUID.self, context: .default))
+            }
+
+            // ── 4. Insert runs for genuinely new tasks — one multi-row VALUES statement ──
+            let newChildren = children.filter { newIDSet.contains($0.taskID) }
+            if !newChildren.isEmpty {
+                var runInterp = PostgresQuery.StringInterpolation(
+                    literalCapacity: 220 + newChildren.count * 160,
+                    interpolationCount: newChildren.count * 11
+                )
+                runInterp.appendLiteral(
+                    "INSERT INTO strand.runs "
+                        + "(namespace_id, id, task_id, queue, attempt, state, "
+                        + "available_at, priority, fairness_key, fairness_weight, kind) VALUES "
+                )
+                for (i, child) in newChildren.enumerated() {
+                    if i > 0 { runInterp.appendLiteral(", ") }
+                    runInterp.appendLiteral("(")
+                    runInterp.appendInterpolation(namespaceID)
+                    runInterp.appendLiteral(", ")
+                    runInterp.appendInterpolation(child.runID)
+                    runInterp.appendLiteral(", ")
+                    runInterp.appendInterpolation(child.taskID)
+                    runInterp.appendLiteral(", ")
+                    runInterp.appendInterpolation(child.queue)
+                    runInterp.appendLiteral(", 1, ")
+                    try runInterp.appendInterpolation(TaskState.pending)
+                    runInterp.appendLiteral(", COALESCE(")
+                    runInterp.appendInterpolation(child.scheduledAt)
+                    runInterp.appendLiteral(", NOW()), ")
+                    try runInterp.appendInterpolation(child.priority)
+                    runInterp.appendLiteral(", ")
+                    runInterp.appendInterpolation(child.fairnessKey)
+                    runInterp.appendLiteral(", ")
+                    runInterp.appendInterpolation(child.fairnessWeight)
+                    runInterp.appendLiteral(", ")
+                    try runInterp.appendInterpolation(child.kind)
+                    runInterp.appendLiteral(")")
+                }
+                try await conn.query(PostgresQuery(stringInterpolation: runInterp), logger: logger)
+            }
+
+            // ── 5. Notify workers — one pg_notify per distinct new child queue ────────
+            var notifiedQueues: Set<String> = []
+            for child in newChildren {
+                guard notifiedQueues.insert(child.queue).inserted else { continue }
+                try await conn.notifyWorkers(namespace: namespaceID, queue: child.queue, logger: logger)
+            }
+
+            // ── 6. Resolve final taskID for every child ───────────────────────────────
+            // New tasks: keep the pre-generated taskID.
+            // Idempotency hits: query the DB by idempotency_key to find the original taskID.
+            var idKeyToTaskID: [String: UUID] = [:]
+            for child in children where newIDSet.contains(child.taskID) {
+                idKeyToTaskID[child.idempotencyKey] = child.taskID
+            }
+            let hitSpecs = children.filter { !newIDSet.contains($0.taskID) }
+            if !hitSpecs.isEmpty {
+                let hitKeys = hitSpecs.map { $0.idempotencyKey }
+                let hitStream = try await conn.query(
+                    """
+                    SELECT id, idempotency_key FROM strand.tasks
+                    WHERE namespace_id    = \(namespaceID)
+                      AND idempotency_key = ANY(\(hitKeys))
+                    """,
+                    logger: logger
+                )
+                for try await row in hitStream {
+                    var col = row.makeIterator()
+                    let existID = try col.next()!.decode(UUID.self, context: .default)
+                    let existKey = try col.next()!.decode(String.self, context: .default)
+                    idKeyToTaskID[existKey] = existID
+                }
+            }
+            let result: [(seqNum: Int, taskID: UUID)] = try children.map { child in
+                guard let taskID = idKeyToTaskID[child.idempotencyKey] else {
+                    throw StrandError.database(
+                        underlying: QueryError(
+                            "enqueueChildTasksBatch: no taskID for idempotency_key \(child.idempotencyKey)"
+                        )
+                    )
+                }
+                return (seqNum: child.seqNum, taskID: taskID)
+            }
+
+            // ── 7. Register event_waits for all children — one unnest statement ─────────
+            // unnest zips the two arrays row-by-row: one INSERT for all N children.
+            // [Int] encodes as int8[]; Postgres silently casts to the int4 column.
+            let ewSeqNums = result.map { $0.seqNum }
+            let ewChildIDs = result.map { $0.taskID }
+            try await conn.query(
+                """
+                INSERT INTO strand.event_waits
+                    (task_id, run_id, queue, seq_num, child_task_id, timeout_at)
+                SELECT \(parentTaskID), \(parentRunID), \(parentQueue),
+                       u.seq_num, u.child_task_id, NULL
+                FROM unnest(\(ewSeqNums), \(ewChildIDs)) AS u(seq_num, child_task_id)
+                ON CONFLICT (run_id, seq_num) DO UPDATE
+                    SET child_task_id = EXCLUDED.child_task_id,
+                        timeout_at    = NULL
+                """,
+                logger: logger
+            )
+
+            // ── 8. Atomic completion-check + parent-run state transition ─────────────
+            // If ANY child has already completed, delete its event_wait and go PENDING
+            // immediately.  Otherwise park the parent as WAITING.
+            let childTaskIDs = result.map { $0.taskID }
+            let completedStream = try await conn.query(
+                "SELECT COUNT(*) FROM strand.task_completions WHERE task_id = ANY(\(childTaskIDs))",
+                logger: logger
+            )
+            var completedCount = 0
+            for try await row in completedStream {
+                var col = row.makeIterator()
+                completedCount = try col.next()!.decode(Int.self, context: .default)
+            }
+
+            if completedCount > 0 {
+                try await conn.query(
+                    """
+                    WITH
+                    del_orphans AS (
+                        DELETE FROM strand.event_waits ew
+                        USING strand.task_completions tc
+                        WHERE ew.run_id        = \(parentRunID)
+                          AND ew.child_task_id = tc.task_id
+                          AND tc.task_id       = ANY(\(childTaskIDs))
+                    ),
+                    r AS (
+                        UPDATE strand.runs
+                        SET state        = \(TaskState.pending),
+                            available_at = NOW(),
+                            worker_id    = NULL,
+                            lease_expires_at = NULL
+                        WHERE id = \(parentRunID)
+                        RETURNING id
+                    )
+                    UPDATE strand.tasks SET state = \(TaskState.pending)
+                    WHERE id = \(parentTaskID)
+                    """,
+                    logger: logger
+                )
+                try await conn.notifyWorkers(namespace: namespaceID, queue: parentQueue, logger: logger)
+            } else {
+                try await conn.query(
+                    """
+                    WITH r AS (
+                        UPDATE strand.runs
+                        SET state = \(TaskState.waiting),
+                            worker_id = NULL,
+                            lease_expires_at = NULL
+                        WHERE id = \(parentRunID)
+                        RETURNING id
+                    )
+                    UPDATE strand.tasks SET state = \(TaskState.waiting)
+                    WHERE id = \(parentTaskID)
+                    """,
+                    logger: logger
+                )
+            }
+
+            return result
         }
     }
 
@@ -534,11 +832,7 @@ enum Queries {
                 if let qRow = try await qStream.first(where: { _ in true }) {
                     var qCol = qRow.makeIterator()
                     let q = try qCol.next()!.decode(String.self, context: .default)
-                    let notification = StrandChannels.Notification(namespace: namespaceID, queue: q)
-                    try await conn.query(
-                        "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
-                        logger: logger
-                    )
+                    try await conn.notifyWorkers(namespace: namespaceID, queue: q, logger: logger)
                 }
             }
         }
@@ -571,24 +865,7 @@ enum Queries {
 
     /// Extends the claim lease. Throws ``InternalError/cancelled`` if the run
     /// is no longer in 'running' state (task was cancelled or failed externally).
-    static func extendClaim(
-        on client: PostgresClient,
-        namespaceID: String,
-        runID: UUID,
-        extendBySeconds: Int,
-        logger: Logger
-    ) async throws {
-        let stream = try await client.query(
-            "UPDATE strand.runs SET lease_expires_at = NOW() + \(extendBySeconds) * INTERVAL '1 second' WHERE id = \(runID) AND state = \(TaskState.running) AND namespace_id = \(namespaceID) RETURNING id",
-            logger: logger
-        )
-        if try await stream.first(where: { _ in true }) == nil {
-            throw InternalError.cancelled
-        }
-    }
-
-    /// `PostgresConnection` overload — used inside an open transaction (e.g. ``batchSetCheckpoints``).
-    /// Semantics are identical to the `PostgresClient` variant.
+    /// Connection-level implementation — the single source of truth for claim extension.
     static func extendClaim(
         on conn: PostgresConnection,
         namespaceID: String,
@@ -602,6 +879,25 @@ enum Queries {
         )
         if try await stream.first(where: { _ in true }) == nil {
             throw InternalError.cancelled
+        }
+    }
+
+    /// Pool-level overload — acquires a connection then delegates to the connection overload.
+    static func extendClaim(
+        on client: PostgresClient,
+        namespaceID: String,
+        runID: UUID,
+        extendBySeconds: Int,
+        logger: Logger
+    ) async throws {
+        try await client.withConnection { conn in
+            try await extendClaim(
+                on: conn,
+                namespaceID: namespaceID,
+                runID: runID,
+                extendBySeconds: extendBySeconds,
+                logger: logger
+            )
         }
     }
 
@@ -703,6 +999,129 @@ enum Queries {
             "task cancelled",
             metadata: ["strand.task_id": .stringConvertible(taskID)]
         )
+    }
+
+    // MARK: - Batch cancel
+
+    /// Cancels a batch of tasks in one transaction.
+    ///
+    /// Compared to calling `cancelTask` N times (N×5 queries), this runs:
+    ///   - 1 task UPDATE (bulk)
+    ///   - 1 descendant task UPDATE (recursive CTE, bulk)
+    ///   - 1 run UPDATE (bulk)
+    ///   - 1 descendant run UPDATE (bulk)
+    ///   - N calls to emitTaskCompletionSignal (one per task — needed so any
+    ///     `awaitTaskResult` callers are unblocked)
+    ///
+    /// Returns the number of tasks that were actually cancelled (i.e. were not
+    /// already terminal before this call).
+    @discardableResult
+    static func cancelTasksBatch(
+        on client: PostgresClient,
+        namespaceID: String,
+        taskIDs: [UUID],
+        logger: Logger
+    ) async throws -> Int {
+        guard !taskIDs.isEmpty else { return 0 }
+
+        let count: Int = try await client.withTransaction(logger: logger) { conn in
+            // ── Step 1: Cancel root task rows, collect IDs actually updated ────────────────
+            var cancelledIDs: [UUID] = []
+            let cancelStream = try await conn.query(
+                """
+                UPDATE strand.tasks
+                SET state = \(TaskState.cancelled), cancelled_at = NOW()
+                WHERE id = ANY(\(taskIDs))
+                  AND namespace_id = \(namespaceID)
+                  AND state NOT IN (\(TaskState.completed), \(TaskState.failed), \(TaskState.cancelled))
+                RETURNING id
+                """,
+                logger: logger
+            )
+            for try await row in cancelStream {
+                var col = row.makeIterator()
+                cancelledIDs.append(try col.next()!.decode(UUID.self, context: .default))
+            }
+
+            guard !cancelledIDs.isEmpty else { return 0 }
+
+            // ── Step 2: Cancel/interrupt run rows for root tasks ────────────────────────
+            try await conn.query(
+                """
+                UPDATE strand.runs
+                SET state = \(TaskState.cancelled)
+                WHERE task_id = ANY(\(cancelledIDs))
+                  AND namespace_id = \(namespaceID)
+                  AND state IN (\(TaskState.pending), \(TaskState.sleeping),
+                                \(TaskState.waiting), \(TaskState.running))
+                """,
+                logger: logger
+            )
+
+            // ── Step 3: Cascade to all descendant tasks (recursive CTE, bulk) ────────
+            try await conn.query(
+                """
+                WITH RECURSIVE descendants AS (
+                    SELECT id FROM strand.tasks
+                    WHERE parent_task_id = ANY(\(cancelledIDs))
+                      AND namespace_id   = \(namespaceID)
+                    UNION ALL
+                    SELECT t.id
+                    FROM strand.tasks t
+                    JOIN descendants d ON t.parent_task_id = d.id
+                    WHERE t.namespace_id = \(namespaceID)
+                )
+                UPDATE strand.tasks
+                SET state = \(TaskState.cancelled), cancelled_at = NOW()
+                WHERE id IN (SELECT id FROM descendants)
+                  AND state NOT IN (\(TaskState.completed), \(TaskState.failed), \(TaskState.cancelled))
+                """,
+                logger: logger
+            )
+
+            // ── Step 4: Cancel/interrupt all descendant runs (bulk) ────────────────
+            try await conn.query(
+                """
+                WITH RECURSIVE descendants AS (
+                    SELECT id FROM strand.tasks
+                    WHERE parent_task_id = ANY(\(cancelledIDs))
+                      AND namespace_id   = \(namespaceID)
+                    UNION ALL
+                    SELECT t.id
+                    FROM strand.tasks t
+                    JOIN descendants d ON t.parent_task_id = d.id
+                    WHERE t.namespace_id = \(namespaceID)
+                )
+                UPDATE strand.runs
+                SET state = \(TaskState.cancelled)
+                WHERE task_id IN (SELECT id FROM descendants)
+                  AND namespace_id = \(namespaceID)
+                  AND state IN (\(TaskState.pending), \(TaskState.sleeping),
+                                \(TaskState.waiting), \(TaskState.running))
+                """,
+                logger: logger
+            )
+
+            // ── Step 5: Wake any awaitTaskResult callers (one signal per root task) ─
+            for taskID in cancelledIDs {
+                try await emitTaskCompletionSignal(
+                    conn: conn,
+                    namespaceID: namespaceID,
+                    taskID: taskID,
+                    state: .cancelled,
+                    resultBuffer: nil,
+                    logger: logger
+                )
+            }
+
+            return cancelledIDs.count
+        }
+
+        logger.debug(
+            "tasks cancelled (batch)",
+            metadata: ["strand.cancelled_count": .stringConvertible(count)]
+        )
+        return count
     }
 
     /// Returns the current state and result of a task.
@@ -982,11 +1401,7 @@ enum Queries {
             )
             if !waits.isEmpty {
                 // Wake workers: runs transitioned to PENDING above.
-                let notification = StrandChannels.Notification(namespace: namespaceID, queue: queue)
-                try await conn.query(
-                    "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
-                    logger: logger
-                )
+                try await conn.notifyWorkers(namespace: namespaceID, queue: queue, logger: logger)
             }
         }
     }
@@ -1059,11 +1474,7 @@ enum Queries {
                 "re-queued \(count) run(s) with expired lease—worker was likely restarted",
                 metadata: ["queue": "\(queue)"]
             )
-            let notification = StrandChannels.Notification(namespace: namespaceID, queue: queue)
-            try await client.query(
-                "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
-                logger: logger
-            )
+            try await client.notifyWorkers(namespace: namespaceID, queue: queue, logger: logger)
         }
     }
 
@@ -1329,11 +1740,7 @@ enum Queries {
             if let qRow = try await qStream.first(where: { _ in true }) {
                 var qCol = qRow.makeIterator()
                 let q = try qCol.next()!.decode(String.self, context: .default)
-                let notification = StrandChannels.Notification(namespace: namespaceID, queue: q)
-                try await conn.query(
-                    "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
-                    logger: logger
-                )
+                try await conn.notifyWorkers(namespace: namespaceID, queue: q, logger: logger)
             }
             return (newRunID, nextAttempt)
         }
@@ -1376,7 +1783,7 @@ enum Queries {
             let retryStrategy = try col.next()!.decode(ByteBuffer?.self, context: .default)
             let maxAttempts = try col.next()!.decode(Int?.self, context: .default)
             let cancellation = try col.next()!.decode(ByteBuffer?.self, context: .default)
-            let priority = try col.next()!.decode(Int.self, context: .default)
+            let priority = try col.next()!.decode(TaskPriority.self, context: .default)
             let fairnessKey = try col.next()!.decode(String?.self, context: .default)
             let fairnessWeight = try col.next()!.decode(Float.self, context: .default)
             let kind = try col.next()!.decode(TaskKind.self, context: .default)
@@ -1385,10 +1792,7 @@ enum Queries {
             let newRunID = UUID.v7()
 
             // Create the queue row if not present (idempotent).
-            try await conn.query(
-                "INSERT INTO strand.queues (namespace_id, name) VALUES (\(namespaceID), \(queue)) ON CONFLICT DO NOTHING",
-                logger: logger
-            )
+            try await createQueue(on: conn, namespaceID: namespaceID, name: queue, logger: logger)
 
             try await conn.query(
                 """
@@ -1413,11 +1817,7 @@ enum Queries {
                 """,
                 logger: logger
             )
-            let notification = StrandChannels.Notification(namespace: namespaceID, queue: queue)
-            try await conn.query(
-                "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
-                logger: logger
-            )
+            try await conn.notifyWorkers(namespace: namespaceID, queue: queue, logger: logger)
             return EnqueueRow(taskID: newTaskID, runID: newRunID, attempt: 1, created: true)
         }
     }
@@ -1511,4 +1911,31 @@ private func retryDelay(strategy buf: ByteBuffer?, attempt: Int) -> TimeInterval
 private struct QueryError: Error, CustomStringConvertible {
     let description: String
     init(_ msg: String) { self.description = msg }
+}
+
+// MARK: - Worker notification helpers
+
+extension PostgresConnection {
+    /// Sends a `pg_notify` on `strand_tasks` for the given `(namespace, queue)` pair.
+    ///
+    /// `pg_notify` is transactional — the notification is delivered only after the
+    /// enclosing transaction commits, so callers inside a `withTransaction` block
+    /// never produce phantom wakeups for tasks that haven't landed yet.
+    func notifyWorkers(namespace: String, queue: String, logger: Logger) async throws {
+        let notification = StrandChannels.Notification(namespace: namespace, queue: queue)
+        try await query(
+            "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
+            logger: logger
+        )
+    }
+}
+
+extension PostgresClient {
+    /// Pool-level convenience — acquires a connection then delegates to
+    /// ``PostgresConnection/notifyWorkers(namespace:queue:logger:)``.
+    func notifyWorkers(namespace: String, queue: String, logger: Logger) async throws {
+        try await withConnection { conn in
+            try await conn.notifyWorkers(namespace: namespace, queue: queue, logger: logger)
+        }
+    }
 }

--- a/Sources/Strand/DB/WorkflowStateQueries.swift
+++ b/Sources/Strand/DB/WorkflowStateQueries.swift
@@ -145,12 +145,8 @@ package enum WorkflowStateQueries {
         logger: Logger
     ) async throws {
         guard !ids.isEmpty else { return }
-        // Convert UUIDs to their canonical string form and let Postgres cast the
-        // text array to uuid[] via `::uuid[]`. This avoids any dependency on a
-        // hypothetical [UUID]: PostgresEncodable conformance in PostgresNIO.
-        let idStrings = ids.map { $0.uuidString }
         try await postgres.query(
-            "DELETE FROM strand.workflow_signals WHERE id = ANY(\(idStrings)::uuid[])",
+            "DELETE FROM strand.workflow_signals WHERE id = ANY(\(ids))",
             logger: logger
         )
     }
@@ -199,7 +195,7 @@ package enum WorkflowStateQueries {
         seqNum: Int, result: ByteBuffer?, failureReason: ByteBuffer?,
         state: TaskState, kind: TaskKind, name: String
     )] {
-        let prefix = "\(parentTaskID.uuidString):"
+        let prefix = "\(parentTaskID):"
         let prefixPattern = prefix + "%"
         let stream = try await postgres.query(
             """
@@ -286,6 +282,86 @@ package enum WorkflowStateQueries {
         case eventReceived = "EVENT_RECEIVED"
         case childWorkflowStarted = "CHILD_WORKFLOW_STARTED"
         case childWorkflowCompleted = "CHILD_WORKFLOW_COMPLETED"
+    }
+
+    // MARK: - History event data payloads
+
+    /// Payload for `ACTIVITY_SCHEDULED`.
+    ///
+    /// JSON shape: `{"activity":"MyActivity","seq_num":"5"}`.
+    /// `seq_num` is written as a string to match the existing wire format that the
+    /// Loom dashboard reads (it accepts both `string` and `number` but the current
+    /// writer always emits a string).
+    package struct ActivityScheduledData: Encodable {
+        package let activity: String
+        package let seqNum: Int
+
+        private enum CodingKeys: String, CodingKey {
+            case activity
+            case seqNum = "seq_num"
+        }
+
+        package func encode(to encoder: any Encoder) throws {
+            var c = encoder.container(keyedBy: CodingKeys.self)
+            try c.encode(activity, forKey: .activity)
+            try c.encode(String(seqNum), forKey: .seqNum)
+        }
+    }
+
+    /// Payload for `CHILD_WORKFLOW_STARTED` and `CHILD_WORKFLOW_COMPLETED`.
+    ///
+    /// JSON shape: `{"workflow":"OrderWorkflow","seq_num":"3"}`.
+    package struct ChildWorkflowData: Encodable {
+        package let workflow: String
+        package let seqNum: Int
+
+        private enum CodingKeys: String, CodingKey {
+            case workflow
+            case seqNum = "seq_num"
+        }
+
+        package func encode(to encoder: any Encoder) throws {
+            var c = encoder.container(keyedBy: CodingKeys.self)
+            try c.encode(workflow, forKey: .workflow)
+            try c.encode(String(seqNum), forKey: .seqNum)
+        }
+    }
+
+    /// Payload for `EVENT_WAIT_STARTED` and `EVENT_RECEIVED`.
+    ///
+    /// JSON shape: `{"event_name":"order.approved"}`.
+    package struct NamedEventData: Encodable {
+        package let eventName: String
+
+        private enum CodingKeys: String, CodingKey {
+            case eventName = "event_name"
+        }
+    }
+
+    /// Payload for `TIMER_STARTED`.
+    ///
+    /// JSON shape: `{"duration_ms":5000}` — stored as a JSON number so the
+    /// dashboard can display it without parsing.
+    package struct TimerStartedData: Encodable {
+        package let durationMs: Int
+
+        private enum CodingKeys: String, CodingKey {
+            case durationMs = "duration_ms"
+        }
+    }
+
+    /// Payload for `SIGNAL_RECEIVED`.
+    ///
+    /// JSON shape: `{"name":"pause"}`.
+    package struct SignalReceivedData: Encodable {
+        package let name: String
+    }
+
+    /// Payload for `WORKFLOW_FAILED`.
+    ///
+    /// JSON shape: `{"error":"..."}`.
+    package struct WorkflowFailedData: Encodable {
+        package let error: String
     }
 
     /// Appends a single event to this workflow's history log.

--- a/Sources/Strand/Enqueue.swift
+++ b/Sources/Strand/Enqueue.swift
@@ -108,7 +108,6 @@ public struct EnqueueOptions: Sendable {
 // MARK: - EnqueueResult
 
 /// Result returned after successfully enqueuing a task.
-/// `taskID` and `runID` are `UUID` — use `.uuidString` if a `String` is needed.
 public struct EnqueueResult: Sendable {
     public let taskID: UUID
     public let runID: UUID
@@ -201,6 +200,34 @@ extension ScheduleAccuracy: PostgresCodable {
         // Unknown / future values fall back to .latest so old rows stay safe.
         let raw = try String(from: &byteBuffer, type: type, format: format, context: context)
         self.init(dbString: raw)
+    }
+}
+
+extension TaskPriority: PostgresCodable {
+    public static var psqlType: PostgresDataType { .int8 }
+    public static var psqlFormat: PostgresFormat { .binary }
+
+    public func encode<E: PostgresJSONEncoder>(
+        into byteBuffer: inout ByteBuffer,
+        context: PostgresEncodingContext<E>
+    ) throws {
+        // Delegate to Int's encoding so the wire format matches what
+        // PostgresNIO uses for bare Int parameters (bigint / int8).
+        // Postgres implicitly casts int8 → int4 for the INTEGER column.
+        rawValue.encode(into: &byteBuffer, context: context)
+    }
+
+    public init<D: PostgresJSONDecoder>(
+        from byteBuffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PostgresDecodingContext<D>
+    ) throws {
+        let raw = try Int(from: &byteBuffer, type: type, format: format, context: context)
+        guard let priority = TaskPriority(rawValue: raw) else {
+            throw PostgresDecodingError.Code.typeMismatch
+        }
+        self = priority
     }
 }
 

--- a/Sources/Strand/Internal/StrandMetrics.swift
+++ b/Sources/Strand/Internal/StrandMetrics.swift
@@ -52,7 +52,8 @@ public enum StrandMetrics {
 
 /// Internal PostgreSQL channel names and payload type for LISTEN/NOTIFY wakeups.
 package enum StrandChannels {
-    /// Channel on which workers LISTEN and `enqueueTask` sends NOTIFY.
+    /// Channel on which workers LISTEN for new work.
+    /// All NOTIFY calls go through `PostgresConnection.notifyWorkers(namespace:queue:logger:)`.
     package static let tasks = "strand_tasks"
 
     /// Channel on which `StrandMetricsLoop` broadcasts pre-computed queue counts

--- a/Sources/Strand/Internal/WorkflowExecutor.swift
+++ b/Sources/Strand/Internal/WorkflowExecutor.swift
@@ -54,7 +54,13 @@ enum WorkflowCommand: Sendable {
         queue: String?,  // nil = inherit orchestrator's queue
         input: ByteBuffer,
         seqNum: Int,  // monotonic activation counter — unique per command within this activation
-        idempotencyKey: String
+        idempotencyKey: String,
+        priority: TaskPriority,  // .normal when unspecified
+        maxAttempts: Int?,  // nil = worker default
+        fairnessKey: String?,  // nil = no per-tenant isolation
+        fairnessWeight: Float,  // 1.0 = default weight
+        retryStrategy: RetryStrategy?,  // nil = worker default
+        scheduledAt: Date?  // nil = immediately
     )
 }
 

--- a/Sources/Strand/Internal/WorkflowRegistration.swift
+++ b/Sources/Strand/Internal/WorkflowRegistration.swift
@@ -206,43 +206,7 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
         }
 
         // ── 3. Signals ────────────────────────────────────────────────────────────
-        let signals = try await WorkflowStateQueries.loadPendingSignals(
-            on: exec.postgres,
-            taskID: claimed.taskID,
-            namespaceID: exec.namespace,
-            logger: exec.logger
-        )
-        for signal in signals {
-            try workflowState.handleSignal(name: signal.name, payload: signal.payload)
-        }
-        if !signals.isEmpty {
-            for signal in signals {
-                let sigData = try? JSON.encode(["name": signal.name])
-                try await WorkflowStateQueries.appendHistory(
-                    on: exec.postgres,
-                    namespaceID: exec.namespace,
-                    taskID: claimed.taskID,
-                    seq: historySeq,
-                    eventType: .signalReceived,
-                    eventData: sigData,
-                    logger: exec.logger
-                )
-                historySeq += 1
-            }
-            let postSignalBuf = try JSON.encode(workflowState)
-            try await WorkflowStateQueries.saveState(
-                on: exec.postgres,
-                taskID: claimed.taskID,
-                namespaceID: exec.namespace,
-                stateBuffer: postSignalBuf,
-                logger: exec.logger
-            )
-            try await WorkflowStateQueries.deleteSignals(
-                on: exec.postgres,
-                ids: signals.map { $0.id },
-                logger: exec.logger
-            )
-        }
+        try await applyAndPersistSignals(to: &workflowState, exec: exec, claimed: claimed, historySeq: &historySeq)
 
         // ── 4. Pre-load results the executor needs for fast-path replay ───────────
         let executor = StrandWorkflowExecutor()
@@ -255,20 +219,7 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
             logger: exec.logger
         )
         executor.resolveCompleted(completedChildren)
-        for (seqNum, _, _, state, kind, name) in completedChildren
-        where kind == .workflow && state == .completed {
-            try await WorkflowStateQueries.appendHistory(
-                on: exec.postgres,
-                namespaceID: exec.namespace,
-                taskID: claimed.taskID,
-                seq: historySeq,
-                eventType: .childWorkflowCompleted,
-                // seq_num is a String for consistency with CHILD_WORKFLOW_STARTED
-                eventData: try? JSON.encode(["workflow": name, "seq_num": String(seqNum)]),
-                logger: exec.logger
-            )
-            historySeq += 1
-        }
+        try await appendChildWorkflowCompletedHistory(completedChildren: completedChildren, exec: exec, claimed: claimed, historySeq: &historySeq)
 
         // ── 5. Build activation context ────────────────────────────────────────────
         // Capture wall-clock time once here so WorkflowContext.activationTime
@@ -333,42 +284,15 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
         }
 
         // ── Local activity execution loop ─────────────────
-        // Local activities run in-process with no DB task row or queue dispatch.
-        // After each batch the executor flushes buffered commands and re-evaluates
-        // any pending conditions; break early if the handler has already finished.
-        localActivityLoop: while !executor.localActivityEntries.isEmpty {
-            let entries = executor.localActivityEntries  // snapshot
-            for (id, entry) in entries {
-                guard let runner = exec.localActivityLookup[entry.name] else {
-                    executor.failLocalActivity(
-                        id: id,
-                        error: StrandError.unknownTask(name: entry.name)
-                    )
-                    continue
-                }
-                do {
-                    let result = try await runner(entry.input, exec, claimed.taskID)
-                    try await Queries.setCheckpointState(
-                        on: exec.postgres,
-                        namespaceID: exec.namespace,
-                        taskID: claimed.taskID,
-                        seqNum: entry.seqNum,
-                        name: entry.name,
-                        stateBuffer: result,
-                        runID: claimed.runID,
-                        extendClaimBySeconds: claimTimeoutSecs,
-                        logger: exec.logger
-                    )
-                    activation.cacheCheckpoint(seqNum: entry.seqNum, buffer: result)
-                    executor.resolveLocalActivity(id: id, result: result)
-                } catch {
-                    executor.failLocalActivity(id: id, error: error)
-                }
-            }
-            executor.drain()
-            while executor.evaluateAndResumeFirstSatisfiedCondition() { executor.drain() }
-            if handlerResult.value != nil { break localActivityLoop }
-        }
+        try await runLocalActivities(
+            exec: exec,
+            claimed: claimed,
+            executor: executor,
+            activation: activation,
+            handlerResult: handlerResult,
+            claimTimeoutSecs: claimTimeoutSecs,
+            expireConditions: false
+        )
 
         // ── 7. Apply commands, handle result, suspend or complete ─────────────────
         return try await applyScheduleCommands(
@@ -438,45 +362,7 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
         }
 
         // ── Signals ──────────────────────────────────────────────────────────
-        // Apply directly to the live stateBox — no need to reload from DB.
-        let signals = try await WorkflowStateQueries.loadPendingSignals(
-            on: exec.postgres,
-            taskID: claimed.taskID,
-            namespaceID: exec.namespace,
-            logger: exec.logger
-        )
-        for signal in signals {
-            try stateBox.value.handleSignal(name: signal.name, payload: signal.payload)
-        }
-        if !signals.isEmpty {
-            for signal in signals {
-                let sigData = try? JSON.encode(["name": signal.name])
-                try await WorkflowStateQueries.appendHistory(
-                    on: exec.postgres,
-                    namespaceID: exec.namespace,
-                    taskID: claimed.taskID,
-                    seq: historySeq,
-                    eventType: .signalReceived,
-                    eventData: sigData,
-                    logger: exec.logger
-                )
-                historySeq += 1
-            }
-            let postSignalBuf = try JSON.encode(stateBox.value)
-            try await WorkflowStateQueries.saveState(
-                on: exec.postgres,
-                taskID: claimed.taskID,
-                namespaceID: exec.namespace,
-                stateBuffer: postSignalBuf,
-                logger: exec.logger
-            )
-            try await WorkflowStateQueries.deleteSignals(
-                on: exec.postgres,
-                ids: signals.map { $0.id },
-                logger: exec.logger
-            )
-
-        }
+        try await applyAndPersistSignals(to: &stateBox.value, exec: exec, claimed: claimed, historySeq: &historySeq)
 
         // ── Completed children ──────────────────────────────────────────────────
         let completedChildren = try await WorkflowStateQueries.loadCompletedChildActivities(
@@ -500,19 +386,7 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
             )
         }
 
-        for (seqNum, _, _, state, kind, name) in completedChildren
-        where kind == .workflow && state == .completed {
-            try await WorkflowStateQueries.appendHistory(
-                on: exec.postgres,
-                namespaceID: exec.namespace,
-                taskID: claimed.taskID,
-                seq: historySeq,
-                eventType: .childWorkflowCompleted,
-                eventData: try? JSON.encode(["workflow": name, "seq_num": String(seqNum)]),
-                logger: exec.logger
-            )
-            historySeq += 1
-        }
+        try await appendChildWorkflowCompletedHistory(completedChildren: completedChildren, exec: exec, claimed: claimed, historySeq: &historySeq)
 
         // ── Event/timer checkpoint (before resuming, for durability) ──────────
         if let eventName = claimed.wakeEvent,
@@ -585,7 +459,7 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
                     taskID: claimed.taskID,
                     seq: historySeq,
                     eventType: .eventReceived,
-                    eventData: try? JSON.encode(["event_name": eventName]),
+                    eventData: try? JSON.encode(WorkflowStateQueries.NamedEventData(eventName: eventName)),
                     logger: exec.logger
                 )
                 historySeq += 1
@@ -603,6 +477,119 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
         while executor.evaluateAndResumeFirstSatisfiedCondition() { executor.drain() }
 
         // ── Local activity execution loop ─────────────────────────────────────
+        try await runLocalActivities(
+            exec: exec,
+            claimed: claimed,
+            executor: executor,
+            activation: activation,
+            handlerResult: handlerResult,
+            claimTimeoutSecs: claimTimeoutSecs,
+            expireConditions: true
+        )
+
+        // ── Apply commands, handle result, suspend or complete ─────────────────
+        return try await applyScheduleCommands(
+            commands: executor.pendingCommands,
+            executor: executor,
+            claimed: claimed,
+            exec: exec,
+            activation: activation,
+            cache: cache,
+            handlerResult: handlerResult,
+            handlerTask: handlerTask,
+            stateBox: stateBox,
+            historySeq: &historySeq,
+            claimTimeoutSecs: claimTimeoutSecs
+        )
+    }
+
+    // MARK: - Shared activation helpers
+
+    /// Loads all pending signals, applies them to `state`, appends `SIGNAL_RECEIVED`
+    /// history events, persists the updated state, and deletes the processed signal rows.
+    /// No-op when no signals are pending.
+    private func applyAndPersistSignals(
+        to state: inout W,
+        exec: _WorkerExec,
+        claimed: ClaimedTask,
+        historySeq: inout Int
+    ) async throws {
+        let signals = try await WorkflowStateQueries.loadPendingSignals(
+            on: exec.postgres,
+            taskID: claimed.taskID,
+            namespaceID: exec.namespace,
+            logger: exec.logger
+        )
+        for signal in signals {
+            try state.handleSignal(name: signal.name, payload: signal.payload)
+        }
+        guard !signals.isEmpty else { return }
+        for signal in signals {
+            let sigData = try? JSON.encode(WorkflowStateQueries.SignalReceivedData(name: signal.name))
+            try await WorkflowStateQueries.appendHistory(
+                on: exec.postgres,
+                namespaceID: exec.namespace,
+                taskID: claimed.taskID,
+                seq: historySeq,
+                eventType: .signalReceived,
+                eventData: sigData,
+                logger: exec.logger
+            )
+            historySeq += 1
+        }
+        let stateBuf = try JSON.encode(state)
+        try await WorkflowStateQueries.saveState(
+            on: exec.postgres,
+            taskID: claimed.taskID,
+            namespaceID: exec.namespace,
+            stateBuffer: stateBuf,
+            logger: exec.logger
+        )
+        try await WorkflowStateQueries.deleteSignals(
+            on: exec.postgres,
+            ids: signals.map { $0.id },
+            logger: exec.logger
+        )
+    }
+
+    /// Appends a `CHILD_WORKFLOW_COMPLETED` history event for every completed child
+    /// workflow in `completedChildren`. Activities and non-completed children are skipped.
+    private func appendChildWorkflowCompletedHistory(
+        completedChildren: [(seqNum: Int, result: ByteBuffer?, failureReason: ByteBuffer?, state: TaskState, kind: TaskKind, name: String)],
+        exec: _WorkerExec,
+        claimed: ClaimedTask,
+        historySeq: inout Int
+    ) async throws {
+        for (seqNum, _, _, state, kind, name) in completedChildren
+        where kind == .workflow && state == .completed {
+            try await WorkflowStateQueries.appendHistory(
+                on: exec.postgres,
+                namespaceID: exec.namespace,
+                taskID: claimed.taskID,
+                seq: historySeq,
+                eventType: .childWorkflowCompleted,
+                eventData: try? JSON.encode(WorkflowStateQueries.ChildWorkflowData(workflow: name, seqNum: seqNum)),
+                logger: exec.logger
+            )
+            historySeq += 1
+        }
+    }
+
+    /// Runs all queued local activities to completion, draining the executor after each
+    /// batch. Broken early if the handler finishes during a batch.
+    ///
+    /// - Parameter expireConditions: when `true` (cached/resume path), expired condition
+    ///   deadlines are processed after each drain — matching the behaviour of
+    ///   `resumeActivation`. Pass `false` on the fresh path (`_activate`).
+    private func runLocalActivities(
+        exec: _WorkerExec,
+        claimed: ClaimedTask,
+        executor: StrandWorkflowExecutor,
+        activation: _WorkflowActivation<W>,
+        handlerResult: ArcBox<Result<W.Output, Error>?>,
+        claimTimeoutSecs: Int,
+        expireConditions: Bool
+    ) async throws {
         localActivityLoop: while !executor.localActivityEntries.isEmpty {
             let entries = executor.localActivityEntries
             for (id, entry) in entries {
@@ -630,25 +617,12 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
                 }
             }
             executor.drain()
-            while executor.resumeExpiredConditions() { executor.drain() }
+            if expireConditions {
+                while executor.resumeExpiredConditions() { executor.drain() }
+            }
             while executor.evaluateAndResumeFirstSatisfiedCondition() { executor.drain() }
             if handlerResult.value != nil { break localActivityLoop }
         }
-
-        // ── Apply commands, handle result, suspend or complete ─────────────────
-        return try await applyScheduleCommands(
-            commands: executor.pendingCommands,
-            executor: executor,
-            claimed: claimed,
-            exec: exec,
-            activation: activation,
-            cache: cache,
-            handlerResult: handlerResult,
-            handlerTask: handlerTask,
-            stateBox: stateBox,
-            historySeq: &historySeq,
-            claimTimeoutSecs: claimTimeoutSecs
-        )
     }
 
 }

--- a/Sources/Strand/Internal/WorkflowScheduling.swift
+++ b/Sources/Strand/Internal/WorkflowScheduling.swift
@@ -1,4 +1,5 @@
 import NIOCore
+import PostgresNIO
 import Tracing
 
 #if canImport(FoundationEssentials)
@@ -430,44 +431,92 @@ extension WorkflowRegistration {
         if executor.hasUnsatisfiedConditions && scheduleCommands.isEmpty {
             let condTaskID = claimed.taskID
             let condRunID = claimed.runID
+
+            // Both branches use the same post-CTE logic: read the final state from
+            // RETURNING, then notify only if PENDING and write history only if
+            // the run actually parked (SLEEPING or WAITING).
+            //
+            // If a signal arrived while the run was RUNNING it couldn't flip the run
+            // directly (the signal UPDATE only matches SLEEPING/WAITING). The
+            // pending_sigs CTE catches that race: if workflow_signals already has rows
+            // for this task we go straight to PENDING rather than parking.
+            let condStateStream: PostgresRowSequence
             if let wakeAt = executor.conditionMinWakeAt {
-                // At least one condition has a deadline — sleep until the earliest one.
-                try await exec.postgres.query(
+                condStateStream = try await exec.postgres.query(
                     """
-                    WITH r AS (
+                    WITH
+                    pending_sigs AS (
+                        SELECT COUNT(*) AS cnt FROM strand.workflow_signals
+                        WHERE task_id = \(condTaskID) AND namespace_id = \(exec.namespace)
+                    ),
+                    run_upd AS (
                         UPDATE strand.runs
-                        SET state = \(TaskState.sleeping), available_at = \(wakeAt),
+                        SET state        = CASE WHEN (SELECT cnt FROM pending_sigs) > 0
+                                               THEN \(TaskState.pending)
+                                               ELSE \(TaskState.sleeping) END,
+                            available_at = CASE WHEN (SELECT cnt FROM pending_sigs) > 0
+                                               THEN NOW()
+                                               ELSE \(wakeAt) END,
                             worker_id = NULL, lease_expires_at = NULL
                         WHERE id = \(condRunID)
+                        RETURNING state
                     )
-                    UPDATE strand.tasks SET state = \(TaskState.sleeping) WHERE id = \(condTaskID)
+                    UPDATE strand.tasks
+                    SET state = (SELECT state FROM run_upd)
+                    WHERE id = \(condTaskID)
+                    RETURNING state
                     """,
                     logger: exec.logger
                 )
             } else {
-                // All conditions are indefinite — wait for a signal.
-                try await exec.postgres.query(
+                condStateStream = try await exec.postgres.query(
                     """
-                    WITH r AS (
+                    WITH
+                    pending_sigs AS (
+                        SELECT COUNT(*) AS cnt FROM strand.workflow_signals
+                        WHERE task_id = \(condTaskID) AND namespace_id = \(exec.namespace)
+                    ),
+                    run_upd AS (
                         UPDATE strand.runs
-                        SET state = \(TaskState.waiting), worker_id = NULL, lease_expires_at = NULL
+                        SET state        = CASE WHEN (SELECT cnt FROM pending_sigs) > 0
+                                               THEN \(TaskState.pending)
+                                               ELSE \(TaskState.waiting) END,
+                            available_at = CASE WHEN (SELECT cnt FROM pending_sigs) > 0
+                                               THEN NOW()
+                                               ELSE available_at END,
+                            worker_id = NULL, lease_expires_at = NULL
                         WHERE id = \(condRunID)
+                        RETURNING state
                     )
-                    UPDATE strand.tasks SET state = \(TaskState.waiting) WHERE id = \(condTaskID)
+                    UPDATE strand.tasks
+                    SET state = (SELECT state FROM run_upd)
+                    WHERE id = \(condTaskID)
+                    RETURNING state
                     """,
                     logger: exec.logger
                 )
             }
-            try await WorkflowStateQueries.appendHistory(
-                on: exec.postgres,
-                namespaceID: exec.namespace,
-                taskID: claimed.taskID,
-                seq: historySeq,
-                eventType: .conditionWaiting,
-                eventData: nil,
-                logger: exec.logger
-            )
-            historySeq += 1
+
+            // Read the state the CTE actually wrote.
+            var conditionState: TaskState = .waiting
+            for try await row in condStateStream {
+                var col = row.makeIterator()
+                conditionState = try col.next()!.decode(TaskState.self, context: .default)
+            }
+
+            // Notify only when the run went PENDING (signals were waiting).
+            // SLEEPING/WAITING runs don't need a notify — they wake via timer or
+            // the next _sendSignal call.
+            if conditionState == .pending {
+                try await exec.postgres.notifyWorkers(namespace: exec.namespace, queue: exec.queue, logger: exec.logger)
+            }
+
+            // Only record CONDITION_WAITING when the run actually parked.
+            // If pending signals sent us straight to PENDING the workflow never
+            // entered a wait — recording the event would mislead the history view.
+            if conditionState != .pending {
+                try await record(.conditionWaiting, nil)
+            }
         }
         // No else branch: if scheduleCommands is empty and no conditions remain,
         // suspension came from sleep/waitForEvent which already wrote its own DB update.

--- a/Sources/Strand/Internal/WorkflowScheduling.swift
+++ b/Sources/Strand/Internal/WorkflowScheduling.swift
@@ -41,6 +41,24 @@ extension WorkflowRegistration {
     ) async throws -> ByteBuffer? {
 
         // ── 1. Persist checkpoints ────────────────────────────────────────────────────
+
+        // Local helper — captures the five fixed appendHistory parameters so each
+        // call site only specifies the two that vary (eventType, eventData).
+        // A nested `func` (not a stored closure) is used because it can capture
+        // the `inout historySeq` parameter directly.
+        func record(_ type: WorkflowStateQueries.HistoryEventType, _ data: ByteBuffer?) async throws {
+            try await WorkflowStateQueries.appendHistory(
+                on: exec.postgres,
+                namespaceID: exec.namespace,
+                taskID: claimed.taskID,
+                seq: historySeq,
+                eventType: type,
+                eventData: data,
+                logger: exec.logger
+            )
+            historySeq += 1
+        }
+
         // Non-suspending writes first — durable regardless of what follows.
         let checkpointWrites = commands.compactMap {
             cmd -> (seqNum: Int, name: String?, state: ByteBuffer)? in
@@ -68,27 +86,9 @@ extension WorkflowRegistration {
         for cmd in commands {
             switch cmd {
             case .timerFired:
-                try await WorkflowStateQueries.appendHistory(
-                    on: exec.postgres,
-                    namespaceID: exec.namespace,
-                    taskID: claimed.taskID,
-                    seq: historySeq,
-                    eventType: .timerFired,
-                    eventData: nil,
-                    logger: exec.logger
-                )
-                historySeq += 1
+                try await record(.timerFired, nil)
             case .eventReceived(let eventName):
-                try await WorkflowStateQueries.appendHistory(
-                    on: exec.postgres,
-                    namespaceID: exec.namespace,
-                    taskID: claimed.taskID,
-                    seq: historySeq,
-                    eventType: .eventReceived,
-                    eventData: try? JSON.encode(["event_name": eventName]),
-                    logger: exec.logger
-                )
-                historySeq += 1
+                try await record(.eventReceived, try? JSON.encode(WorkflowStateQueries.NamedEventData(eventName: eventName)))
             default:
                 break
             }
@@ -100,10 +100,7 @@ extension WorkflowRegistration {
         case .success(let output):
             // Handler completed — persist final state and return the encoded result.
             // The caller (runTask) writes COMPLETED to the run.
-            cache.remove(claimed.taskID)
-            handlerTask.cancel()
-            executor.cancelPending()
-            executor.drain()  // flush any residual jobs from cancelPending()
+            teardownHandler(cache: cache, taskID: claimed.taskID, handlerTask: handlerTask, executor: executor)
             let finalStateBuf = try JSON.encode(stateBox.value)
             try await WorkflowStateQueries.saveState(
                 on: exec.postgres,
@@ -112,15 +109,7 @@ extension WorkflowRegistration {
                 stateBuffer: finalStateBuf,
                 logger: exec.logger
             )
-            try await WorkflowStateQueries.appendHistory(
-                on: exec.postgres,
-                namespaceID: exec.namespace,
-                taskID: claimed.taskID,
-                seq: historySeq,
-                eventType: .workflowCompleted,
-                eventData: nil,
-                logger: exec.logger
-            )
+            try await record(.workflowCompleted, nil)
             return try JSON.encode(output)
 
         case .failure(let error):
@@ -133,26 +122,12 @@ extension WorkflowRegistration {
             // CallSiteAnnotatedError to wrap the signal — defeating the
             // `catch let signal as _ContinueAsNewSignal` in runTask.
             if let signal = error as? _ContinueAsNewSignal {
-                cache.remove(claimed.taskID)
-                handlerTask.cancel()
-                executor.cancelPending()
-                executor.drain()  // flush residual jobs from cancelPending()
+                teardownHandler(cache: cache, taskID: claimed.taskID, handlerTask: handlerTask, executor: executor)
                 throw signal
             }
-            cache.remove(claimed.taskID)
-            handlerTask.cancel()
-            executor.cancelPending()
-            executor.drain()  // flush residual jobs from cancelPending()
-            let errData = try? JSON.encode(["error": String(describing: error)])
-            try await WorkflowStateQueries.appendHistory(
-                on: exec.postgres,
-                namespaceID: exec.namespace,
-                taskID: claimed.taskID,
-                seq: historySeq,
-                eventType: .workflowFailed,
-                eventData: errData,
-                logger: exec.logger
-            )
+            teardownHandler(cache: cache, taskID: claimed.taskID, handlerTask: handlerTask, executor: executor)
+            let errData = try? JSON.encode(WorkflowStateQueries.WorkflowFailedData(error: String(describing: error)))
+            try await record(.workflowFailed, errData)
             // Stamp the last WorkflowContext call site onto the error.
             if let site = activation.lastCallSite {
                 throw CallSiteAnnotatedError(
@@ -197,8 +172,11 @@ extension WorkflowRegistration {
             let childHeadersBuf: ByteBuffer? =
                 _spanHeaders.isEmpty ? nil : try? JSON.encode(_spanHeaders)
 
-            // Enqueue activities / child workflows (idempotent — safe if row exists).
-            var enqueued: [(seqNum: Int, taskID: UUID)] = []
+            // Collect child specs — activities and child workflows enqueued in one batch
+            // transaction after the loop.  Timer and named-event commands continue to write
+            // to the DB inline; their state transitions are independent of the child batch.
+            var pendingChildren: [Queries.ChildEnqueueSpec] = []
+            var childHistoryItems: [(eventType: WorkflowStateQueries.HistoryEventType, eventData: ByteBuffer?)] = []
             for cmd in scheduleCommands {
                 switch cmd {
                 case .scheduleActivity(
@@ -208,45 +186,41 @@ extension WorkflowRegistration {
                     let seqNum,
                     let idKey
                 ):
-                    let row = try await Queries.enqueueTask(
-                        on: exec.postgres,
-                        namespaceID: exec.namespace,
-                        queue: options.queue ?? exec.queue,
-                        taskName: name,
-                        paramsBuffer: actInput,
-                        headersBuffer: childHeadersBuf,
-                        retryStrategyBuffer: options.retryStrategy.flatMap { try? JSON.encode($0) },
-                        maxAttempts: options.maxAttempts,
-                        cancellationBuffer: nil,
-                        idempotencyKey: idKey,
-                        priority: options.priority.rawValue,
-                        scheduledAt: options.delayUntil,
-                        timeoutSeconds: options.timeout.map { Int($0.components.seconds) },
-                        deadlineAt: options.maxDuration.map {
-                            Date.now.addingTimeInterval(
-                                Double($0.components.seconds)
-                                    + Double($0.components.attoseconds)
-                                    / 1_000_000_000_000_000_000
+                    pendingChildren.append(
+                        Queries.ChildEnqueueSpec(
+                            seqNum: seqNum,
+                            taskID: UUID.v7(),
+                            runID: UUID.v7(),
+                            queue: options.queue ?? exec.queue,
+                            taskName: name,
+                            paramsBuffer: actInput,
+                            headersBuffer: childHeadersBuf,
+                            retryStrategyBuffer: options.retryStrategy.flatMap { try? JSON.encode($0) },
+                            maxAttempts: options.maxAttempts,
+                            idempotencyKey: idKey,
+                            priority: options.priority,
+                            scheduledAt: options.delayUntil,
+                            timeoutSeconds: options.timeout.map { Int($0.components.seconds) },
+                            deadlineAt: options.maxDuration.map {
+                                Date.now.addingTimeInterval(
+                                    Double($0.components.seconds)
+                                        + Double($0.components.attoseconds)
+                                        / 1_000_000_000_000_000_000
+                                )
+                            },
+                            fairnessKey: options.fairnessKey,
+                            fairnessWeight: options.fairnessWeight,
+                            kind: .activity
+                        )
+                    )
+                    childHistoryItems.append(
+                        (
+                            eventType: .activityScheduled,
+                            eventData: try? JSON.encode(
+                                WorkflowStateQueries.ActivityScheduledData(activity: name, seqNum: seqNum)
                             )
-                        },
-                        fairnessKey: options.fairnessKey,
-                        fairnessWeight: options.fairnessWeight,
-                        kind: .activity,
-                        parentTaskID: claimed.taskID,
-                        logger: exec.logger
+                        )
                     )
-                    enqueued.append((seqNum: seqNum, taskID: row.taskID))
-                    let actData = try? JSON.encode(["activity": name, "seq_num": String(seqNum)])
-                    try await WorkflowStateQueries.appendHistory(
-                        on: exec.postgres,
-                        namespaceID: exec.namespace,
-                        taskID: claimed.taskID,
-                        seq: historySeq,
-                        eventType: .activityScheduled,
-                        eventData: actData,
-                        logger: exec.logger
-                    )
-                    historySeq += 1
 
                 case .startTimer(let wakeAt, _):
                     // Transition run to SLEEPING. Both UPDATEs are one SQL statement
@@ -266,19 +240,10 @@ extension WorkflowRegistration {
                         """,
                         logger: exec.logger
                     )
-                    let timerData = try? JSON.encode([
-                        "duration_ms": Int(wakeAt.timeIntervalSinceNow * 1000)
-                    ])
-                    try await WorkflowStateQueries.appendHistory(
-                        on: exec.postgres,
-                        namespaceID: exec.namespace,
-                        taskID: claimed.taskID,
-                        seq: historySeq,
-                        eventType: .timerStarted,
-                        eventData: timerData,
-                        logger: exec.logger
+                    let timerData = try? JSON.encode(
+                        WorkflowStateQueries.TimerStartedData(durationMs: Int(wakeAt.timeIntervalSinceNow * 1000))
                     )
-                    historySeq += 1
+                    try await record(.timerStarted, timerData)
 
                 case .awaitEvent(let eventName, let seqNum, let timeoutAt):
                     // Atomic check-or-wait: prevents the lost-wakeup race where the
@@ -345,11 +310,7 @@ extension WorkflowRegistration {
                                 logger: exec.logger
                             )
                             // Run is PENDING — notify workers to claim immediately.
-                            let notification = StrandChannels.Notification(namespace: exec.namespace, queue: queueName)
-                            try await conn.query(
-                                "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
-                                logger: exec.logger
-                            )
+                            try await conn.notifyWorkers(namespace: exec.namespace, queue: queueName, logger: exec.logger)
                         } else {
                             // Event not yet emitted — set run to WAITING (or SLEEPING for timed waits).
                             let availableAt =
@@ -374,166 +335,87 @@ extension WorkflowRegistration {
                             )
                         }
                     }
-                    let eventWaitData = try? JSON.encode(["event_name": eventName])
-                    try await WorkflowStateQueries.appendHistory(
-                        on: exec.postgres,
-                        namespaceID: exec.namespace,
-                        taskID: claimed.taskID,
-                        seq: historySeq,
-                        eventType: .eventWaitStarted,
-                        eventData: eventWaitData,
-                        logger: exec.logger
-                    )
-                    historySeq += 1
+                    let eventWaitData = try? JSON.encode(WorkflowStateQueries.NamedEventData(eventName: eventName))
+                    try await record(.eventWaitStarted, eventWaitData)
 
                 case .scheduleChildWorkflow(
                     let name,
                     let childQueue,
                     let wfInput,
                     let seqNum,
-                    let idKey
+                    let idKey,
+                    let childPriority,
+                    let childMaxAttempts,
+                    let childFairnessKey,
+                    let childFairnessWeight,
+                    let childRetryStrategy,
+                    let childScheduledAt
                 ):
-                    let targetQueue = childQueue ?? exec.queue  // use child's queue or inherit
-                    let row = try await Queries.enqueueTask(
-                        on: exec.postgres,
-                        namespaceID: exec.namespace,
-                        queue: targetQueue,
-                        taskName: name,
-                        paramsBuffer: wfInput,
-                        headersBuffer: childHeadersBuf,
-                        retryStrategyBuffer: nil,
-                        maxAttempts: nil,
-                        cancellationBuffer: nil,
-                        idempotencyKey: idKey,
-                        priority: TaskPriority.normal.rawValue,
-                        scheduledAt: nil,
-                        fairnessKey: nil,
-                        fairnessWeight: 1.0,
-                        kind: .workflow,
-                        parentTaskID: claimed.taskID,
-                        logger: exec.logger
+                    let targetQueue = childQueue ?? exec.queue
+                    pendingChildren.append(
+                        Queries.ChildEnqueueSpec(
+                            seqNum: seqNum,
+                            taskID: UUID.v7(),
+                            runID: UUID.v7(),
+                            queue: targetQueue,
+                            taskName: name,
+                            paramsBuffer: wfInput,
+                            headersBuffer: childHeadersBuf,
+                            retryStrategyBuffer: childRetryStrategy.flatMap { try? JSON.encode($0) },
+                            maxAttempts: childMaxAttempts,
+                            idempotencyKey: idKey,
+                            priority: childPriority,
+                            scheduledAt: childScheduledAt,
+                            timeoutSeconds: nil,
+                            deadlineAt: nil,
+                            fairnessKey: childFairnessKey,
+                            fairnessWeight: childFairnessWeight,
+                            kind: .workflow
+                        )
                     )
-                    enqueued.append((seqNum: seqNum, taskID: row.taskID))
-                    let childData = try? JSON.encode([
-                        "workflow": name, "seq_num": String(seqNum),
-                    ])
-                    try await WorkflowStateQueries.appendHistory(
-                        on: exec.postgres,
-                        namespaceID: exec.namespace,
-                        taskID: claimed.taskID,
-                        seq: historySeq,
-                        eventType: .childWorkflowStarted,
-                        eventData: childData,
-                        logger: exec.logger
+                    childHistoryItems.append(
+                        (
+                            eventType: .childWorkflowStarted,
+                            eventData: try? JSON.encode(
+                                WorkflowStateQueries.ChildWorkflowData(workflow: name, seqNum: seqNum)
+                            )
+                        )
                     )
-                    historySeq += 1
 
                 case .writeCheckpoint, .timerFired, .eventReceived:
                     break  // already handled above
                 }
             }
 
-            // ── 5. Register event_waits + atomic completion check ──────────────────────
-            // Atomic check-or-wait: prevents the lost-wakeup race where a child
-            // task completes between enqueueTask() committing and this transaction
-            // committing.
-            //
-            // Without this check:
-            //   1. enqueueTask() commits — child task visible to activity workers
-            //   2. Activity worker claims, runs, and completes it immediately
-            //   3. emitTaskCompletionSignal finds no event_wait — parent not woken
-            //   4. This transaction commits — run goes WAITING and stalls forever
-            //
-            // Both the event_wait inserts and a task_completions count live in the
-            // same transaction. If all children are already done, go PENDING immediately;
-            // the next poll re-activates the workflow. Remaining event_waits fire normally.
-            if !enqueued.isEmpty {
-                try await exec.postgres.withTransaction(logger: exec.logger) { conn in
-                    // TODO: optimize this path
-                    for item in enqueued {
-                        try await conn.query(
-                            """
-                            INSERT INTO strand.event_waits
-                                (task_id, run_id, queue, seq_num, child_task_id, timeout_at)
-                            VALUES (\(claimed.taskID), \(claimed.runID), \(exec.queue),
-                                    \(item.seqNum), \(item.taskID), NULL)
-                            ON CONFLICT (run_id, seq_num) DO UPDATE
-                                SET child_task_id = EXCLUDED.child_task_id,
-                                    timeout_at    = NULL
-                            """,
-                            logger: exec.logger
-                        )
-                    }
-
-                    // Atomically check whether any child tasks already completed
-                    // (i.e. are present in task_completions) before we park the run.
-                    let childTaskIDs = enqueued.map { $0.taskID }
-                    let completedStream = try await conn.query(
-                        """
-                        SELECT COUNT(*) FROM strand.task_completions
-                        WHERE task_id = ANY(\(childTaskIDs))
-                        """,
+            // ── 5. Batch-enqueue all children + event_waits + run-state transition ──────────
+            // One Postgres transaction for N children using true batch SQL:
+            //   • multi-row VALUES INSERT for tasks (one round-trip)
+            //   • multi-row VALUES INSERT for runs (one round-trip)
+            //   • unnest-based INSERT for event_waits (one round-trip)
+            //   • pg_notify per distinct child queue (new tasks only)
+            //   • atomic task_completions count → PENDING or WAITING
+            if !pendingChildren.isEmpty {
+                try await Queries.enqueueChildTasksBatch(
+                    on: exec.postgres,
+                    namespaceID: exec.namespace,
+                    parentTaskID: claimed.taskID,
+                    parentRunID: claimed.runID,
+                    parentQueue: exec.queue,
+                    children: pendingChildren,
+                    logger: exec.logger
+                )
+                // Append workflow history for all children (preserves submission order).
+                for historyItem in childHistoryItems {
+                    try await WorkflowStateQueries.appendHistory(
+                        on: exec.postgres,
+                        namespaceID: exec.namespace,
+                        taskID: claimed.taskID,
+                        seq: historySeq,
+                        eventType: historyItem.eventType,
+                        eventData: historyItem.eventData,
                         logger: exec.logger
                     )
-                    var completedCount = 0
-                    for try await row in completedStream {
-                        var col = row.makeIterator()
-                        completedCount = try col.next()!.decode(Int.self, context: .default)
-                    }
-
-                    // Go PENDING if ANY child has already completed, not just ALL.
-                    // The `for try await r in group` loop delivers results one at a time,
-                    // so even a single completion requires a re-activation to make progress.
-                    //
-                    // The del_orphans CTE deletes event_waits for the completed children
-                    // in the same atomic operation.  Without this, the partial-completion
-                    // re-wait in step 7 would find them on every subsequent activation and
-                    // repeatedly go PENDING for no-op deliveries (spin loop).
-                    if completedCount > 0 {
-                        try await conn.query(
-                            """
-                            WITH
-                            del_orphans AS (
-                                DELETE FROM strand.event_waits ew
-                                USING strand.task_completions tc
-                                WHERE ew.run_id        = \(claimed.runID)
-                                  AND ew.child_task_id = tc.task_id
-                                  AND tc.task_id       = ANY(\(childTaskIDs))
-                            ),
-                            r AS (
-                                UPDATE strand.runs
-                                SET state        = \(TaskState.pending),
-                                    available_at = NOW(),
-                                    worker_id    = NULL,
-                                    lease_expires_at = NULL
-                                WHERE id = \(claimed.runID)
-                                RETURNING id
-                            )
-                            UPDATE strand.tasks SET state = \(TaskState.pending)
-                            WHERE id = \(claimed.taskID)
-                            """,
-                            logger: exec.logger
-                        )
-                        let notification = StrandChannels.Notification(namespace: exec.namespace, queue: exec.queue)
-                        try await conn.query(
-                            "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
-                            logger: exec.logger
-                        )
-                    } else {
-                        try await conn.query(
-                            """
-                            WITH r AS (
-                                UPDATE strand.runs
-                                SET state = \(TaskState.waiting), worker_id = NULL, lease_expires_at = NULL
-                                WHERE id = \(claimed.runID)
-                                RETURNING id
-                            )
-                            UPDATE strand.tasks SET state = \(TaskState.waiting)
-                            WHERE id = \(claimed.taskID)
-                            """,
-                            logger: exec.logger
-                        )
-                    }
+                    historySeq += 1
                 }
             }
         }
@@ -652,11 +534,7 @@ extension WorkflowRegistration {
             // Notify speculatively: if the run went PENDING (missed > 0) workers should
             // claim it immediately. If it went WAITING the notification is a spurious
             // wakeup that costs at most one empty poll — acceptable.
-            let notification = StrandChannels.Notification(namespace: exec.namespace, queue: exec.queue)
-            try await exec.postgres.query(
-                "SELECT pg_notify(\(StrandChannels.tasks), \(notification.payload))",
-                logger: exec.logger
-            )
+            try await exec.postgres.notifyWorkers(namespace: exec.namespace, queue: exec.queue, logger: exec.logger)
 
             // ── 7B. Post-wait snapshot-isolation recovery ───────────────────────────────
             // Step 7's CTE runs under Postgres snapshot isolation: it cannot see
@@ -715,11 +593,7 @@ extension WorkflowRegistration {
                         "strand.run_id": .stringConvertible(claimed.runID),
                     ]
                 )
-                let recoveryNote = StrandChannels.Notification(namespace: exec.namespace, queue: exec.queue)
-                try await exec.postgres.query(
-                    "SELECT pg_notify(\(StrandChannels.tasks), \(recoveryNote.payload))",
-                    logger: exec.logger
-                )
+                try await exec.postgres.notifyWorkers(namespace: exec.namespace, queue: exec.queue, logger: exec.logger)
             }
         }
 
@@ -742,5 +616,22 @@ extension WorkflowRegistration {
         )
 
         return nil
+    }
+
+    /// Tears down the cached handler Task when a workflow reaches a terminal result
+    /// (completed, failed, or continuing-as-new).
+    ///
+    /// Order matters: remove from cache first so no other activation can race with
+    /// the `cancelPending` + `drain` that follows.
+    private func teardownHandler(
+        cache: _WorkflowTaskCache<W>,
+        taskID: UUID,
+        handlerTask: Task<Void, Never>,
+        executor: StrandWorkflowExecutor
+    ) {
+        cache.remove(taskID)
+        handlerTask.cancel()
+        executor.cancelPending()
+        executor.drain()
     }
 }

--- a/Sources/Strand/Schedule/StrandScheduler.swift
+++ b/Sources/Strand/Schedule/StrandScheduler.swift
@@ -312,7 +312,6 @@ public struct StrandScheduler: Service {
         }
 
         // Build scheduling metadata. Passed directly to enqueueTask as SchedulingMetadata?
-        // (PostgresCodable conformance handles the BYTEA encoding inside the query binding).
         let schedulingMeta = SchedulingMetadata(
             executionTime: now,
             partitionTime: partitionTime,
@@ -325,7 +324,7 @@ public struct StrandScheduler: Service {
         // Idempotency key: schedule_id + scheduled fire time.
         // Safe across multiple scheduler instances and restarts.
         let idempotencyKey =
-            "$schedule:\(row.id.uuidString):\(row.scheduledAt.timeIntervalSince1970)"
+            "$schedule:\(row.id):\(row.scheduledAt.timeIntervalSince1970)"
 
         _ = try await Queries.enqueueTask(
             on: postgres,

--- a/Sources/Strand/Worker.swift
+++ b/Sources/Strand/Worker.swift
@@ -971,7 +971,7 @@ public struct StrandWorker: Service {
                         maxAttempts: nil,
                         cancellationBuffer: nil,
                         idempotencyKey: nil,
-                        priority: TaskPriority.normal.rawValue,
+                        priority: .normal,
                         scheduledAt: nil,
                         fairnessKey: nil,
                         fairnessWeight: 1.0,
@@ -993,57 +993,64 @@ public struct StrandWorker: Service {
             }
         } catch let typed as _TypedActivityFailure {
             // Pre-encoded failure reason from ActivityDefinition._run — use verbatim.
-            _metrics.value.makeCounter(label: StrandMetrics.tasksFailed, dimensions: taskDims)
-                .increment(by: 1)
-            metricsBuffer?.record(
-                queue: options.queue,
-                taskName: claimed.taskName,
-                state: .failed,
-                execMs: Double((ContinuousClock.now - taskStart).nanoseconds) / 1_000_000.0,
-                waitMs: max(0, taskStartWall.timeIntervalSince(claimed.availableAt) * 1000)
+            await failAndRecord(
+                reasonBuffer: typed.reasonBuffer,
+                claimed: claimed,
+                taskDims: taskDims,
+                taskStart: taskStart,
+                taskStartWall: taskStartWall,
+                logger: taskLogger
             )
-            do {
-                try await Queries.failRun(
-                    on: postgres,
-                    namespaceID: namespace,
-                    runID: claimed.runID,
-                    reasonBuffer: typed.reasonBuffer,
-                    logger: logger
-                )
-            } catch {
-                taskLogger.error(
-                    "failRun DB call failed — run will be swept by leaseExpiryLoop",
-                    metadata: .forError(error)
-                )
-            }
         } catch {
-            _metrics.value.makeCounter(label: StrandMetrics.tasksFailed, dimensions: taskDims)
-                .increment(by: 1)
-            metricsBuffer?.record(
-                queue: options.queue,
-                taskName: claimed.taskName,
-                state: .failed,
-                execMs: Double((ContinuousClock.now - taskStart).nanoseconds) / 1_000_000.0,
-                waitMs: max(0, taskStartWall.timeIntervalSince(claimed.availableAt) * 1000)
-            )
             let reason = FailureReason(error: error)
-            do {
-                let buf =
-                    (try? JSON.encode(reason))
-                    ?? ByteBuffer(string: #"{"name":"unknown","message":"encoding failed"}"#)
-                try await Queries.failRun(
-                    on: postgres,
-                    namespaceID: namespace,
-                    runID: claimed.runID,
-                    reasonBuffer: buf,
-                    logger: logger
-                )
-            } catch {
-                taskLogger.error(
-                    "failRun DB call failed — run will be swept by leaseExpiryLoop",
-                    metadata: .forError(error)
-                )
-            }
+            let buf =
+                (try? JSON.encode(reason))
+                ?? ByteBuffer(string: #"{"name":"unknown","message":"encoding failed"}"#)
+            await failAndRecord(
+                reasonBuffer: buf,
+                claimed: claimed,
+                taskDims: taskDims,
+                taskStart: taskStart,
+                taskStartWall: taskStartWall,
+                logger: taskLogger
+            )
+        }
+    }
+
+    /// Records a task failure in metrics and persists it via `Queries.failRun`.
+    ///
+    /// Shared by the typed-failure catch (`_TypedActivityFailure`) and the generic
+    /// catch in `runTask` — only `reasonBuffer` differs between the two.
+    private func failAndRecord(
+        reasonBuffer: ByteBuffer,
+        claimed: ClaimedTask,
+        taskDims: [(String, String)],
+        taskStart: ContinuousClock.Instant,
+        taskStartWall: Date,
+        logger: Logger
+    ) async {
+        _metrics.value.makeCounter(label: StrandMetrics.tasksFailed, dimensions: taskDims)
+            .increment(by: 1)
+        metricsBuffer?.record(
+            queue: options.queue,
+            taskName: claimed.taskName,
+            state: .failed,
+            execMs: Double((ContinuousClock.now - taskStart).nanoseconds) / 1_000_000.0,
+            waitMs: max(0, taskStartWall.timeIntervalSince(claimed.availableAt) * 1000)
+        )
+        do {
+            try await Queries.failRun(
+                on: postgres,
+                namespaceID: namespace,
+                runID: claimed.runID,
+                reasonBuffer: reasonBuffer,
+                logger: logger
+            )
+        } catch {
+            logger.error(
+                "failRun DB call failed — run will be swept by leaseExpiryLoop",
+                metadata: .forError(error)
+            )
         }
     }
 }

--- a/Sources/Strand/Workflow.swift
+++ b/Sources/Strand/Workflow.swift
@@ -308,6 +308,13 @@ public struct WorkflowOptions: Sendable {
     public var retryStrategy: RetryStrategy?
     /// Key-value metadata forwarded with the task.
     public var headers: [String: String]
+    /// Fairness group key — e.g. a tenant ID or customer name (max 64 bytes).
+    /// Tasks sharing a key are FIFO within that key; keys compete via weighted dispatch.
+    public var fairnessKey: String?
+    /// Relative throughput weight for this fairness key. Default `1.0`.
+    /// A key with weight `5.0` is dispatched approximately 5× more often than a key with `1.0`.
+    /// Only meaningful when `fairnessKey` is set.
+    public var fairnessWeight: Float
 
     public init(
         id: String? = nil,
@@ -316,7 +323,9 @@ public struct WorkflowOptions: Sendable {
         delayUntil: Date? = nil,
         maxAttempts: Int? = nil,
         retryStrategy: RetryStrategy? = nil,
-        headers: [String: String] = [:]
+        headers: [String: String] = [:],
+        fairnessKey: String? = nil,
+        fairnessWeight: Float = 1.0
     ) {
         self.id = id
         self.queue = queue
@@ -325,6 +334,8 @@ public struct WorkflowOptions: Sendable {
         self.maxAttempts = maxAttempts
         self.retryStrategy = retryStrategy
         self.headers = headers
+        self.fairnessKey = fairnessKey
+        self.fairnessWeight = max(fairnessWeight, 0.001)
     }
 }
 
@@ -332,20 +343,41 @@ public struct WorkflowOptions: Sendable {
 
 /// Options for ``WorkflowContext/runChildWorkflow(_:options:input:)``.
 public struct ChildWorkflowOptions: Sendable {
+    /// Target queue for this child workflow. `nil` inherits the parent’s queue.
     public var queue: String?
+    /// Dispatch priority. Default: `.normal`.
     public var priority: TaskPriority
+    /// Maximum activation attempts before the child is marked FAILED.
+    /// `nil` inherits the worker default.
     public var maxAttempts: Int?
+    /// Key-value metadata forwarded with the child workflow task.
     public var headers: [String: String]
+    /// Fairness group key for this child workflow. See ``WorkflowOptions/fairnessKey``.
+    public var fairnessKey: String?
+    /// Relative throughput weight for this child's fairness key. Default `1.0`.
+    public var fairnessWeight: Float
+    /// Retry policy on failure. `nil` inherits the worker default.
+    public var retryStrategy: RetryStrategy?
+    /// Earliest time this child workflow may be claimed. `nil` = immediately.
+    public var delayUntil: Date?
 
     public init(
         queue: String? = nil,
         priority: TaskPriority = .normal,
         maxAttempts: Int? = nil,
-        headers: [String: String] = [:]
+        headers: [String: String] = [:],
+        fairnessKey: String? = nil,
+        fairnessWeight: Float = 1.0,
+        retryStrategy: RetryStrategy? = nil,
+        delayUntil: Date? = nil
     ) {
         self.queue = queue
         self.priority = priority
         self.maxAttempts = maxAttempts
         self.headers = headers
+        self.fairnessKey = fairnessKey
+        self.fairnessWeight = max(fairnessWeight, 0.001)
+        self.retryStrategy = retryStrategy
+        self.delayUntil = delayUntil
     }
 }

--- a/Sources/Strand/WorkflowContext.swift
+++ b/Sources/Strand/WorkflowContext.swift
@@ -348,7 +348,7 @@ public struct WorkflowContext<W: Workflow>: Sendable {
 
         // ── Slow path: activity not yet complete — emit command and suspend ─────────────
         let inputBuffer = try JSON.encode(input)
-        let idempotencyKey = "\(_impl.taskUUID.uuidString):\(seqNum)"
+        let idempotencyKey = "\(_impl.taskUUID):\(seqNum)"
 
         _impl.executor.emit(
             .scheduleActivity(
@@ -928,17 +928,23 @@ public struct WorkflowContext<W: Workflow>: Sendable {
 
         // Slow path: child not yet complete — emit command and suspend via continuation.
         let inputBuffer = try JSON.encode(input)
-        let idempotencyKey = "\(_impl.taskUUID.uuidString):\(seqNum)"
+        let idempotencyKey = "\(_impl.taskUUID):\(seqNum)"
         // Note: options.headers forwarding intentionally omitted from the command —
         // the worker injects parent context headers when enqueuing the child task.
 
         _impl.executor.emit(
             .scheduleChildWorkflow(
                 name: CW.workflowName,
-                queue: options.queue,  // nil = inherit orchestrator's queue at dispatch time
+                queue: options.queue,
                 input: inputBuffer,
                 seqNum: seqNum,
-                idempotencyKey: idempotencyKey
+                idempotencyKey: idempotencyKey,
+                priority: options.priority,
+                maxAttempts: options.maxAttempts,
+                fairnessKey: options.fairnessKey,
+                fairnessWeight: options.fairnessWeight,
+                retryStrategy: options.retryStrategy,
+                scheduledAt: options.delayUntil
             )
         )
 

--- a/Sources/Strand/WorkflowHandle.swift
+++ b/Sources/Strand/WorkflowHandle.swift
@@ -298,16 +298,25 @@ extension StrandClient {
                 """,
                 logger: logger
             )
-            try await conn.query(
+            // RETURNING queue so we can notify the correct worker channel
+            // without an extra round-trip — and only when a row was actually
+            // updated (no spurious notifies for RUNNING/PENDING runs).
+            let wakeStream = try await conn.query(
                 """
                 UPDATE strand.runs
                 SET state = 'PENDING', available_at = NOW(),
                     wake_event = NULL, event_payload = NULL,
                     worker_id = NULL, lease_expires_at = NULL
                 WHERE task_id = \(taskID) AND state IN ('SLEEPING', 'WAITING')
+                RETURNING queue
                 """,
                 logger: logger
             )
+            var wokeQueue: String? = nil
+            for try await row in wakeStream {
+                var col = row.makeIterator()
+                wokeQueue = try col.next()!.decode(String.self, context: .default)
+            }
             try await conn.query(
                 """
                 UPDATE strand.tasks SET state = 'PENDING'
@@ -315,6 +324,12 @@ extension StrandClient {
                 """,
                 logger: logger
             )
+            // Wake the worker if a run was actually transitioned to PENDING.
+            // Without this notify the worker only discovers the PENDING run on
+            // the next pollInterval tick — which is correct but needlessly slow.
+            if let queue = wokeQueue {
+                try await conn.notifyWorkers(namespace: ns, queue: queue, logger: logger)
+            }
         }
     }
 }

--- a/Sources/StrandServer/Routes/ScheduleRoutes.swift
+++ b/Sources/StrandServer/Routes/ScheduleRoutes.swift
@@ -159,7 +159,7 @@ struct ScheduleRoutes {
             let scheduleID = try ctx.parameters.require("id", as: UUID.self)
             let limit = req.uri.queryParameters.get("limit").flatMap(Int.init) ?? 20
 
-            let prefix = "$schedule:\(scheduleID.uuidString):"
+            let prefix = "$schedule:\(scheduleID):"
             let stream = try await self.client.postgres.query(
                 """
                 SELECT id, state, attempt, created_at, completed_at

--- a/Tests/StrandTests/ChildWorkflowTests.swift
+++ b/Tests/StrandTests/ChildWorkflowTests.swift
@@ -130,7 +130,7 @@ struct ChildWorkflowTests {
     func childWorkflowOnDifferentQueue() async throws {
         try await withTestEnvironment { client in
             let childQueue =
-                "t\(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(12).lowercased())"
+                "t\(UUID().uuidString.replacing("-", with: "").prefix(12).lowercased())"
             try await client.createQueue(childQueue)
 
             var workerTask1: Task<Void, Never>? = nil

--- a/Tests/StrandTests/ConditionTests.swift
+++ b/Tests/StrandTests/ConditionTests.swift
@@ -165,8 +165,13 @@ struct ConditionTests {
                 input: "start"
             )
 
-            // Wait for the workflow to reach and enter the condition suspension.
-            try await Task.sleep(for: .milliseconds(400))
+            // Poll until the workflow enters condition suspension (WAITING state).
+            // A fixed sleep is not reliable on CI where DB round-trips can be
+            // 50 ms+ each, making the first activation exceed any fixed bound.
+            for _ in 0..<50 {
+                if let snap = try await handle.snapshot(), snap.state == .waiting { break }
+                try await Task.sleep(for: .milliseconds(100))
+            }
 
             // Deliver the signal that sets `unpaused = true`.
             try await handle.signal(name: "unpause")
@@ -197,8 +202,15 @@ struct ConditionTests {
                 input: "start"
             )
 
-            // Give the workflow time to start and enter the condition suspension.
-            try await Task.sleep(for: .milliseconds(400))
+            // Poll until the workflow enters condition suspension (SLEEPING/WAITING state).
+            for _ in 0..<50 {
+                if let snap = try await handle.snapshot(),
+                    snap.state == .waiting || snap.state == .sleeping
+                {
+                    break
+                }
+                try await Task.sleep(for: .milliseconds(100))
+            }
 
             // Send the signal — well within the 10 s deadline.
             try await handle.signal(name: "unpause")

--- a/Tests/StrandTests/FairnessTests.swift
+++ b/Tests/StrandTests/FairnessTests.swift
@@ -1,0 +1,371 @@
+import Logging
+import NIOCore
+import PostgresNIO
+import Synchronization
+import Testing
+
+@testable import Strand
+
+// MARK: - Shared workflow fixture
+
+/// Minimal workflow used by the workflow-fairness test.
+/// Runs one `TenantSlotActivity` then returns, so the completion log captures
+/// which tenant's workflow got a slot — not which activity got a slot.
+private struct FairnessTrackingWorkflow: Workflow {
+    typealias Input = TenantSlotActivity.Input
+    typealias Output = StrandVoid
+
+    mutating func run(
+        context: WorkflowContext<Self>,
+        input: TenantSlotActivity.Input
+    ) async throws -> StrandVoid {
+        try await context.runActivity(
+            TenantSlotActivity.self,
+            input: input,
+            options: ActivityOptions(maxAttempts: 1)
+        )
+    }
+}
+
+/// Parent workflow used by the child-workflow fairness test.
+/// Fans out to N children for "heavy" and 1 child for "light" using
+/// `ChildWorkflowOptions(fairnessKey:)`, then waits for all to complete.
+private struct ChildFairnessParentWorkflow: Workflow {
+    struct Input: Codable, Sendable {
+        let heavyCount: Int
+    }
+    typealias Output = StrandVoid
+
+    mutating func run(
+        context: WorkflowContext<Self>,
+        input: Input
+    ) async throws -> StrandVoid {
+        try await withThrowingTaskGroup(of: StrandVoid.self) { group in
+            // Heavy children: all enqueued together with fairness key "heavy".
+            for _ in 0..<input.heavyCount {
+                group.addTask {
+                    try await context.runChildWorkflow(
+                        FairnessTrackingWorkflow.self,
+                        options: ChildWorkflowOptions(fairnessKey: "heavy"),
+                        input: .init(tenantKey: "heavy")
+                    )
+                }
+            }
+            // One light child: queued after heavy children but
+            // fairness ensures it’s never starved to the end.
+            group.addTask {
+                try await context.runChildWorkflow(
+                    FairnessTrackingWorkflow.self,
+                    options: ChildWorkflowOptions(fairnessKey: "light"),
+                    input: .init(tenantKey: "light")
+                )
+            }
+            try await group.waitForAll()
+        }
+        return .done
+    }
+}
+
+// MARK: - Shared activity fixture
+
+/// Append-only log used to capture activity completion order.
+/// Implemented as a class so it can be stored in a `struct` without violating
+/// the `Copyable` requirement (Mutex<T> is ~Copyable).
+private final class CompletionLog: Sendable {
+    private let _log: Mutex<[String]> = Mutex([])
+    func append(_ key: String) { _log.withLock { $0.append(key) } }
+    var value: [String] { _log.withLock { $0 } }
+}
+
+/// Records which `tenantKey` completed each slot and optionally fires a
+/// `TestExpectation` when a specific key is seen.
+///
+/// Must be defined at file scope so `ActivityDefinition.name` (the Swift type
+/// name) is stable — the registry looks up handlers by this string.
+private struct TenantSlotActivity: ActivityDefinition {
+    struct Input: Codable, Sendable { let tenantKey: String }
+    typealias Output = StrandVoid
+
+    /// Append-only log of tenant keys in completion order.
+    let log: CompletionLog
+    /// Called synchronously after the slot is recorded.
+    let onComplete: @Sendable (String) -> Void
+
+    func run(input: Input, context: ActivityContext) async throws -> StrandVoid {
+        log.append(input.tenantKey)
+        onComplete(input.tenantKey)
+        return .done
+    }
+}
+
+// MARK: - Suite
+
+@Suite("Integration — Fairness", .tags(.integration), .serialized)
+struct FairnessTests {
+
+    // ── 1. Activity-level fairness key ───────────────────────────────────────
+    //
+    // `claimTasks` uses a frontier query: only the highest-priority / oldest run
+    // per `fairness_key` is eligible.  With two fairness keys and enough free
+    // slots, both frontiers are claimed in the very first poll — so a "light"
+    // tenant's ACTIVITY is never starved behind 20 "heavy" tenant activities.
+    //
+    // Without fairness keys all 21 tasks compete in FIFO order; "light" (enqueued
+    // last) would appear at the very end of the completion log.
+    @Test("[activity] fairness key ensures a light tenant is never starved by a heavy tenant")
+    func activityFairnessKeyInterleavesTenants() async throws {
+        let log = CompletionLog()
+        let heavyCount = 20
+        let total = heavyCount + 1
+
+        try await withTestEnvironment { client in
+            // Enqueue ALL tasks BEFORE starting the worker so the entire batch
+            // is visible in the first claimTasks call. If the worker starts first
+            // it would claim tasks one-by-one as they arrive (FIFO), defeating
+            // the fairness test.
+
+            // Heavy tenant: 20 tasks enqueued first (they fill the queue).
+            for _ in 0..<heavyCount {
+                _ = try await client.enqueueActivity(
+                    TenantSlotActivity.self,
+                    input: .init(tenantKey: "heavy"),
+                    options: ActivityOptions(fairnessKey: "heavy")
+                )
+            }
+
+            // Light tenant: 1 task enqueued AFTER all heavy tasks.
+            // In a plain FIFO queue this would be position 20 (last).
+            _ = try await client.enqueueActivity(
+                TenantSlotActivity.self,
+                input: .init(tenantKey: "light"),
+                options: ActivityOptions(fairnessKey: "light")
+            )
+
+            // NOW start the worker — it sees all 21 tasks at once.
+            // concurrency: 1  →  workflowConcurrency=1, activityConcurrency=2
+            // maxConcurrency = 3, so the first claimTasks call requests qty=3.
+            // With 2 fairness keys both frontiers are eligible; LIMIT 3 claims both
+            // in one shot regardless of queue depth.
+            try await confirmation("all \(total) activities complete", expectedCount: total) { confirmed in
+                let allDone = TestExpectation()
+                let activity = TenantSlotActivity(log: log) { _ in
+                    confirmed()
+                    allDone.trigger()
+                }
+                let workerTask = startWorker(
+                    postgres: client.postgres,
+                    queueName: client.queueName,
+                    logger: client.logger,
+                    concurrency: 1,
+                    activities: [activity]
+                )
+                defer { workerTask.cancel() }
+                try await allDone.wait(for: "all \(total) activities", count: total, timeout: .seconds(10))
+            }
+
+            // Both heavy-frontier and light-frontier are claimed in the first poll.
+            // "light" MUST appear at index 0 or 1 in the completion log.
+            // In a FIFO queue it would appear at index 20.
+            let seq = log.value
+            let lightIndex = seq.firstIndex(of: "light") ?? seq.count
+            #expect(
+                lightIndex <= 1,
+                "light tenant must land in the first claim batch (index ≤ 1); got \(lightIndex); order: \(seq)"
+            )
+        }
+    }
+
+    // ── 2. Activity-level priority ──────────────────────────────────────────
+    //
+    // `claimTasks` orders candidates by `priority ASC` before any other key.
+    // A critical task (rawValue 1) therefore always sorts ahead of minimal tasks
+    // (rawValue 5) regardless of enqueue order.
+    //
+    // Without priority the ACTIVITY would appear last since it was enqueued after
+    // the 10 minimal tasks.
+    @Test("[activity] critical-priority task is claimed before minimal-priority backlog")
+    func activityPriorityOrdersDispatch() async throws {
+        let log = CompletionLog()
+        let minimalCount = 10
+        let total = minimalCount + 1
+
+        try await withTestEnvironment { client in
+            // Enqueue all tasks BEFORE starting the worker (same reasoning as
+            // the fairness test — the full batch must be visible at first claim).
+
+            // 10 minimal-priority tasks enqueued first (no fairness key — all in
+            // the same FIFO pool so priority is the only differentiator).
+            for _ in 0..<minimalCount {
+                _ = try await client.enqueueActivity(
+                    TenantSlotActivity.self,
+                    input: .init(tenantKey: "minimal"),
+                    options: ActivityOptions(priority: .minimal)
+                )
+            }
+
+            // 1 critical task enqueued LAST.  Without priority ordering it would
+            // sit at the back of the queue; with priority it jumps to the front.
+            _ = try await client.enqueueActivity(
+                TenantSlotActivity.self,
+                input: .init(tenantKey: "critical"),
+                options: ActivityOptions(priority: .critical)
+            )
+
+            // `ORDER BY priority ASC` puts critical (1) before minimal (5), so
+            // critical is always in the first claim batch.
+            // maxConcurrency = workflowConcurrency + activityConcurrency = 1+2 = 3,
+            // so the first claim picks 3 tasks: critical + two minimal.  All three
+            // are instant, making intra-batch completion order indeterminate.
+            // critIdx ≤ 2 proves critical was in the first 3-task batch.
+            // In a FIFO queue (no priority) critical would appear at index 10.
+            try await confirmation("all \(total) activities complete", expectedCount: total) { confirmed in
+                let allDone = TestExpectation()
+                let activity = TenantSlotActivity(log: log) { _ in
+                    confirmed()
+                    allDone.trigger()
+                }
+                let workerTask = startWorker(
+                    postgres: client.postgres,
+                    queueName: client.queueName,
+                    logger: client.logger,
+                    concurrency: 1,
+                    activities: [activity]
+                )
+                defer { workerTask.cancel() }
+                try await allDone.wait(for: "all \(total) activities", count: total, timeout: .seconds(10))
+            }
+
+            let seq = log.value
+            let critIdx = seq.firstIndex(of: "critical") ?? seq.count
+            #expect(
+                critIdx <= 2,
+                "critical task must be in the first claim batch (index ≤ 2); got \(critIdx); order: \(seq)"
+            )
+        }
+    }
+
+    // ── 3. Workflow-level fairness key ──────────────────────────────────────
+    //
+    // Same frontier-based guarantee as test 1, but now the competing tasks are
+    // WORKFLOW runs (kind='WORKFLOW'), not standalone activities.  This validates
+    // that `WorkflowOptions(fairnessKey:)` flows through `startWorkflow` →
+    // `enqueueTask` → `strand.runs.fairness_key` and that `claimTasks` respects
+    // it for workflow activations exactly as it does for activities.
+    //
+    // `FairnessTrackingWorkflow` runs one `TenantSlotActivity` internally so the
+    // completion log records which tenant's WORKFLOW got a slot first.
+    @Test("[workflow] fairness key on WorkflowOptions prevents heavy tenant from starving light tenant")
+    func workflowFairnessKeyInterleavesTenants() async throws {
+        let log = CompletionLog()
+        let heavyCount = 20
+        let total = heavyCount + 1  // 21 activity completions (one per workflow)
+
+        try await withTestEnvironment { client in
+            // Enqueue all workflows BEFORE starting the worker.
+
+            // 20 heavy-tenant workflows: fairnessKey is on the WORKFLOW, not the activity.
+            for _ in 0..<heavyCount {
+                _ = try await client.startWorkflow(
+                    FairnessTrackingWorkflow.self,
+                    options: WorkflowOptions(fairnessKey: "heavy"),
+                    input: .init(tenantKey: "heavy")
+                )
+            }
+
+            // 1 light-tenant workflow enqueued AFTER all heavy workflows.
+            // Without fairness the heavy tenant's 20 workflow activations would
+            // run first; with fairness both frontiers are claimed together.
+            _ = try await client.startWorkflow(
+                FairnessTrackingWorkflow.self,
+                options: WorkflowOptions(fairnessKey: "light"),
+                input: .init(tenantKey: "light")
+            )
+
+            try await confirmation("all \(total) activities complete", expectedCount: total) { confirmed in
+                let allDone = TestExpectation()
+                let activity = TenantSlotActivity(log: log) { _ in
+                    confirmed()
+                    allDone.trigger()
+                }
+                let workerTask = startWorker(
+                    postgres: client.postgres,
+                    queueName: client.queueName,
+                    logger: client.logger,
+                    concurrency: 1,
+                    workflows: [FairnessTrackingWorkflow.self],
+                    activities: [activity]
+                )
+                defer { workerTask.cancel() }
+                try await allDone.wait(for: "all \(total) activities", count: total, timeout: .seconds(15))
+            }
+
+            // The light-tenant workflow's activity must appear in the first few slots.
+            // lightIndex ≤ 5 proves fairness is working without being brittle under
+            // parallel test load — without fairness, light would always appear at index 20.
+            let seq = log.value
+            let lightIndex = seq.firstIndex(of: "light") ?? seq.count
+            #expect(
+                lightIndex <= 5,
+                "light workflow must not be starved (index ≤ 5); got \(lightIndex); order: \(seq)"
+            )
+        }
+    }
+
+    // ── 4. Child-workflow fairness key ──────────────────────────────────────
+    //
+    // Exercises the `ChildWorkflowOptions(fairnessKey:)` path specifically:
+    //   WorkflowContext.runChildWorkflow → scheduleChildWorkflow command
+    //   → applyScheduleCommands → enqueueChildTasksBatch(fairnessKey:)
+    //
+    // A parent workflow fans out 20 heavy children + 1 light child via
+    // `withThrowingTaskGroup`.  `applyScheduleCommands` enqueues all 21 atomically
+    // so the worker sees both fairness frontiers in one poll.  The light child
+    // must not be starved behind the heavy children.
+    @Test("[child workflow] ChildWorkflowOptions fairnessKey prevents heavy children from starving light child")
+    func childWorkflowFairnessKeyInterleavesTenants() async throws {
+        let log = CompletionLog()
+        let total = 21  // 21 FairnessTrackingWorkflow children, each runs 1 TenantSlotActivity
+
+        try await withTestEnvironment { client in
+            // Start the parent FIRST — it fans out children atomically in one
+            // applyScheduleCommands call, so all children are in the DB together
+            // before the worker's first poll.
+            _ = try await client.startWorkflow(
+                ChildFairnessParentWorkflow.self,
+                input: .init(heavyCount: 20)
+            )
+
+            try await confirmation("all \(total) activities complete", expectedCount: total) { confirmed in
+                let allDone = TestExpectation()
+                let activity = TenantSlotActivity(log: log) { _ in
+                    confirmed()
+                    allDone.trigger()
+                }
+                let workerTask = startWorker(
+                    postgres: client.postgres,
+                    queueName: client.queueName,
+                    logger: client.logger,
+                    concurrency: 1,
+                    workflows: [
+                        ChildFairnessParentWorkflow.self,
+                        FairnessTrackingWorkflow.self,
+                    ],
+                    activities: [activity]
+                )
+                defer { workerTask.cancel() }
+                try await allDone.wait(for: "all \(total) activities", count: total, timeout: .seconds(20))
+            }
+
+            // All 21 child workflows are enqueued atomically by enqueueChildTasksBatch,
+            // so both fairness frontiers are visible to the worker's first poll.
+            // lightIndex ≤ 12 (out of 21 total activities) proves fairness prevents full
+            // starvation — without it, light would always appear at index 20.
+            let seq = log.value
+            let lightIndex = seq.firstIndex(of: "light") ?? seq.count
+            #expect(
+                lightIndex <= 12,
+                "light child must not be fully starved (index ≤ 12); got \(lightIndex); order: \(seq)"
+            )
+        }
+    }
+}

--- a/Tests/StrandTests/IntegrationTests.swift
+++ b/Tests/StrandTests/IntegrationTests.swift
@@ -365,7 +365,7 @@ struct TaskExecutionTests {
     @Test("startWorkflow with the same id returns the same task for both calls")
     func idempotencyKey() async throws {
         try await withTestEnvironment { client in
-            let key = "idem:\(UUID().uuidString)"
+            let key = "idem:\(UUID())"
 
             let h1 = try await client.startWorkflow(
                 EchoWorkflow.self,
@@ -424,7 +424,7 @@ struct EventTests {
     @Test("workflow suspends on waitForEvent, then resumes when event is emitted")
     func suspendAndResume() async throws {
         try await withTestEnvironment { client in
-            let eventName = "resume:\(UUID().uuidString)"
+            let eventName = "resume:\(UUID())"
 
             let workerTask = startWorker(
                 postgres: client.postgres,
@@ -459,7 +459,7 @@ struct EventTests {
     @Test("timed-out waitForEvent persists a sentinel so replay skips re-suspension")
     func timeoutPersistsSentinel() async throws {
         try await withTestEnvironment { client in
-            let eventName = "never:\(UUID().uuidString)"
+            let eventName = "never:\(UUID())"
 
             let workerTask = startWorker(
                 postgres: client.postgres,

--- a/Tests/StrandTests/TestHelpers.swift
+++ b/Tests/StrandTests/TestHelpers.swift
@@ -128,7 +128,7 @@ func withTestEnvironment<T: Sendable>(
 ) async throws -> T {
     let logger = Logger(label: "test.strand")
     let queueName =
-        "t\(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(12).lowercased())"
+        "t\(UUID().uuidString.replacing("-", with: "").prefix(12).lowercased())"
     let postgres = makePostgresClient(logger: logger)
     let client = StrandClient(
         postgres: postgres,

--- a/Tests/StrandTests/WorkerLifecycleTests.swift
+++ b/Tests/StrandTests/WorkerLifecycleTests.swift
@@ -403,7 +403,7 @@ struct WorkerLifecycleTests {
             // Build a second client scoped to a unique namespace B but the same queue.
             let nsBSuffix = UUID()
                 .uuidString
-                .replacingOccurrences(of: "-", with: "")
+                .replacing("-", with: "")
                 .prefix(12)
                 .lowercased()
             let nsB = "wlt-nsb-\(nsBSuffix)"


### PR DESCRIPTION
## Summary

Added fairness to Workflow and ChildWorkflow Options

## Changes

- Added Fairness to Workflow and ChildWorkflow options 
- Added Queries.enqueueChildTasksBatch and ChildEnqueueSpec to atomically enqueue many child tasks in a single transaction with O(1) round-trips, multi-row INSERTs, run insertion, event_waits unnest insertion, and per-queue notifications.
- Added client cancelTasks(_:) and Queries.cancelTasksBatch(...) to cancel multiple tasks (and their descendants) in one transaction and emit completion signals.
- Split createQueue into connection-level and pool-level overloads and added PostgresConnection/PostgresClient notifyWorkers(namespace:queue:logger:) helpers to centralize pg_notify usage (replacing inline NOTIFY calls).
- Made TaskPriority PostgresCodable and updated queries to decode/encode priority as TaskPriority instead of Int.
- Added structured history payload types (ActivityScheduledData, ChildWorkflowData, NamedEventData, TimerStartedData, SignalReceivedData, WorkflowFailedData) and switched history writes to use them.
- Refactored WorkflowRegistration to extract helpers: applyAndPersistSignals, appendChildWorkflowCompletedHistory, runLocalActivities and a local `record` helper for history writes; replaced repeated logic with these helpers and introduced teardownHandler usage for handler cleanup.


## Testing

<!-- How did you verify this works? Did you run `swift test`? -->

- [x] `swift test` passes locally

## AI Disclosure

<!--
  REQUIRED if any AI assistance was used — see CONTRIBUTING.md.
  Delete this section entirely if no AI was involved.
-->

- [ ] I used AI assistance while working on this PR

**Tool(s) used:** <!-- e.g. Claude, Copilot, ChatGPT -->

**Extent of use:**
<!-- Describe honestly. Examples:
  - Generated first draft of WorkflowDag.tsx, reviewed and edited manually.
  - Used for commit message suggestions only.
  - Pair-programmed the entire feature; all output was reviewed.
-->

**Was the PR description itself AI-generated?** No
