### PR TITLE
Scheduling improvements

### DIFF
--- a/Sources/Strand/Client.swift
+++ b/Sources/Strand/Client.swift
@@ -1090,6 +1090,9 @@ public struct StrandClient: Sendable {
     }
 
     /// Fetches a single schedule by ID.  Returns `nil` when not found.
+    ///
+    /// The returned `ScheduleSummary` is built from ``ScheduleFullRow``, which
+    /// is ever needed.
     public func getSchedule(
         id: UUID,
         queue: String? = nil,
@@ -1124,6 +1127,57 @@ public struct StrandClient: Sendable {
             kind: row.kind,
             createdAt: row.createdAt
         )
+    }
+
+    /// Enqueues a single execution for a specific schedule slot ("run for partition").
+    ///
+    /// Uses the same idempotency key format as `StrandScheduler.fire()` so a slot
+    /// already executed by the regular schedule is blocked via `ON CONFLICT` unless
+    /// `allowOverwrite` is `true`.
+    @discardableResult
+    public func runScheduleSlot(
+        scheduleID: UUID,
+        partitionTime: Date,
+        allowOverwrite: Bool = false,
+        namespaceID overrideNS: String? = nil
+    ) async throws -> (taskID: UUID, runID: UUID) {
+        let ns = overrideNS ?? namespaceID
+        guard
+            let schedule = try await ScheduleQueries.getSchedule(
+                on: postgres,
+                namespaceID: ns,
+                id: scheduleID,
+                logger: logger
+            )
+        else {
+            throw StrandError.database(underlying: QueryError("schedule '\(scheduleID)' not found"))
+        }
+        let idempotencyKey: String? =
+            allowOverwrite
+            ? nil
+            : "$schedule:\(scheduleID):\(partitionTime.timeIntervalSince1970)"
+        let meta = SchedulingMetadata(
+            executionTime: Date(),
+            partitionTime: partitionTime,
+            scheduleId: scheduleID.uuidString,
+            scheduledBy: schedule.name
+        )
+        let enqueued = try await Queries.enqueueTask(
+            on: postgres,
+            namespaceID: ns,
+            queue: schedule.queue,
+            taskName: schedule.taskName,
+            paramsBuffer: schedule.paramsBuffer,
+            headersBuffer: schedule.headersBuffer,
+            schedulingMetadata: meta,
+            retryStrategyBuffer: schedule.retryStrategyBuffer,
+            maxAttempts: schedule.maxAttempts,
+            cancellationBuffer: schedule.cancellationBuffer,
+            idempotencyKey: idempotencyKey,
+            kind: schedule.kind,
+            logger: logger
+        )
+        return (taskID: enqueued.taskID, runID: enqueued.runID)
     }
 
     /// Lists schedules for `queue` (or all queues when `queue` is `nil`).
@@ -1170,6 +1224,111 @@ public struct StrandClient: Sendable {
                 createdAt: row.createdAt
             )
         }
+    }
+
+    // MARK: - Backfill
+
+    /// Creates a backfill that retroactively executes `workflowType` for every
+    /// schedule slot between `range.lowerBound` (inclusive) and `range.upperBound`
+    /// (exclusive).
+    ///
+    /// The `StrandScheduler` drives execution: it enqueues up to
+    /// `options.concurrency` slots per poll cycle without occupying worker
+    /// task-queue slots for orchestration.
+    @discardableResult
+    public func createBackfill<W: Workflow>(
+        _ workflowType: W.Type,
+        input: W.Input,
+        schedule: SchedulePattern,
+        range: Range<Date>,
+        queue overrideQueue: String? = nil,
+        scheduleId: UUID? = nil,
+        options: BackfillOptions = .init()
+    ) async throws -> BackfillHandle where W.Input: Codable & Sendable {
+        let q = overrideQueue ?? queueName
+        let paramsBuffer = try JSON.encode(input)
+        let patternBuffer = try JSON.encode(schedule)
+        let id = UUID.v7()
+        // Subtract 1 s so the start is inclusive: nextRunTime finds the slot AT
+        // lowerBound when it coincides with a schedule boundary
+        // (-1 ms adjustment on BackfillRequest.StartTime).
+        let firstSlot =
+            try ScheduleCalculator.nextRunTime(
+                for: schedule,
+                after: range.lowerBound.addingTimeInterval(-1),
+                timezone: schedule.timezone
+            ) ?? range.lowerBound
+        let totalSlots = ScheduleCalculator.countSlots(for: schedule, in: range)
+        try await BackfillQueries.createBackfill(
+            on: postgres,
+            id: id,
+            namespaceID: namespaceID,
+            queue: q,
+            taskName: W.workflowName,
+            taskKind: .workflow,
+            paramsBuffer: paramsBuffer,
+            headersBuffer: nil,
+            retryStrategyBuffer: nil,
+            maxAttempts: nil,
+            schedulePatternBuffer: patternBuffer,
+            rangeStart: range.lowerBound,
+            rangeEnd: range.upperBound,
+            concurrency: options.concurrency,
+            allowOverwrite: options.allowOverwrite,
+            description: options.description,
+            scheduleId: scheduleId,
+            nextSlotTime: firstSlot,
+            totalSlots: totalSlots,
+            logger: logger
+        )
+        return BackfillHandle(id: id, postgres: postgres, namespaceID: namespaceID, logger: logger)
+    }
+
+    /// Creates a backfill for a standalone activity.
+    @discardableResult
+    public func createBackfill<A: ActivityDefinition>(
+        _ activityType: A.Type,
+        input: A.Input,
+        schedule: SchedulePattern,
+        range: Range<Date>,
+        queue overrideQueue: String? = nil,
+        scheduleId: UUID? = nil,
+        options: BackfillOptions = .init()
+    ) async throws -> BackfillHandle where A.Input: Codable & Sendable {
+        let q = overrideQueue ?? queueName
+        let paramsBuffer = try JSON.encode(input)
+        let patternBuffer = try JSON.encode(schedule)
+        let id = UUID.v7()
+        let firstSlot =
+            try ScheduleCalculator.nextRunTime(
+                for: schedule,
+                after: range.lowerBound.addingTimeInterval(-1),
+                timezone: schedule.timezone
+            ) ?? range.lowerBound
+        let totalSlots = ScheduleCalculator.countSlots(for: schedule, in: range)
+        try await BackfillQueries.createBackfill(
+            on: postgres,
+            id: id,
+            namespaceID: namespaceID,
+            queue: q,
+            taskName: A.name,
+            taskKind: .activity,
+            paramsBuffer: paramsBuffer,
+            headersBuffer: nil,
+            retryStrategyBuffer: nil,
+            maxAttempts: nil,
+            schedulePatternBuffer: patternBuffer,
+            rangeStart: range.lowerBound,
+            rangeEnd: range.upperBound,
+            concurrency: options.concurrency,
+            allowOverwrite: options.allowOverwrite,
+            description: options.description,
+            scheduleId: scheduleId,
+            nextSlotTime: firstSlot,
+            totalSlots: totalSlots,
+            logger: logger
+        )
+        return BackfillHandle(id: id, postgres: postgres, namespaceID: namespaceID, logger: logger)
     }
 
     // MARK: - Cleanup

--- a/Sources/Strand/DB/BackfillQueries.swift
+++ b/Sources/Strand/DB/BackfillQueries.swift
@@ -1,0 +1,337 @@
+package import Logging
+package import NIOCore
+package import PostgresNIO
+
+#if canImport(FoundationEssentials)
+package import FoundationEssentials
+#else
+package import Foundation
+#endif
+
+package enum BackfillQueries {
+
+    // MARK: - Types
+
+    package enum BackfillStatus: String, Sendable {
+        case running = "RUNNING"
+        case halted = "HALTED"
+        case completed = "COMPLETED"
+        case failed = "FAILED"
+    }
+
+    package struct BackfillRow: Sendable {
+        package let id: UUID
+        package let namespaceID: String
+        package let queue: String
+        package let taskName: String
+        package let taskKind: TaskKind
+        package let paramsBuffer: ByteBuffer
+        package let headersBuffer: ByteBuffer?
+        package let retryStrategyBuffer: ByteBuffer?
+        package let maxAttempts: Int?
+        package let schedulePatternBuffer: ByteBuffer
+        package let rangeStart: Date
+        package let rangeEnd: Date
+        package let concurrency: Int
+        package let allowOverwrite: Bool
+        package let description: String?
+        package let scheduleId: UUID?
+        package let status: BackfillStatus
+        package let nextSlotTime: Date
+        package let totalSlots: Int
+        package let completedSlots: Int
+        package let createdAt: Date
+        package let completedAt: Date?
+    }
+
+    // MARK: - Create
+
+    package static func createBackfill(
+        on client: PostgresClient,
+        id: UUID,
+        namespaceID: String,
+        queue: String,
+        taskName: String,
+        taskKind: TaskKind,
+        paramsBuffer: ByteBuffer,
+        headersBuffer: ByteBuffer?,
+        retryStrategyBuffer: ByteBuffer?,
+        maxAttempts: Int?,
+        schedulePatternBuffer: ByteBuffer,
+        rangeStart: Date,
+        rangeEnd: Date,
+        concurrency: Int,
+        allowOverwrite: Bool,
+        description: String?,
+        scheduleId: UUID? = nil,
+        nextSlotTime: Date,
+        totalSlots: Int,
+        logger: Logger
+    ) async throws {
+        try await client.query(
+            """
+            INSERT INTO strand.backfills
+                (id, namespace_id, queue, task_name, task_kind, params, headers,
+                 retry_strategy, max_attempts, schedule_pattern,
+                 range_start, range_end, concurrency, allow_overwrite, description,
+                 schedule_id, next_slot_time, total_slots)
+            VALUES
+                (\(id), \(namespaceID), \(queue), \(taskName), \(taskKind),
+                 \(paramsBuffer), \(headersBuffer), \(retryStrategyBuffer), \(maxAttempts),
+                 \(schedulePatternBuffer), \(rangeStart), \(rangeEnd), \(concurrency),
+                 \(allowOverwrite), \(description), \(scheduleId), \(nextSlotTime), \(totalSlots))
+            """,
+            logger: logger
+        )
+    }
+
+    // MARK: - List running (called by StrandScheduler each poll cycle)
+
+    package static func listRunning(
+        on client: PostgresClient,
+        namespaceID: String,
+        limit: Int = 50,
+        logger: Logger
+    ) async throws -> [BackfillRow] {
+        let stream = try await client.query(
+            """
+            SELECT id, namespace_id, queue, task_name, task_kind, params, headers,
+                   retry_strategy, max_attempts, schedule_pattern,
+                   range_start, range_end, concurrency, allow_overwrite, description,
+                   schedule_id, status, next_slot_time, total_slots, completed_slots, created_at, completed_at
+            FROM strand.backfills
+            WHERE namespace_id = \(namespaceID)
+              AND status = \(BackfillStatus.running)
+            ORDER BY created_at
+            LIMIT \(limit)
+            """,
+            logger: logger
+        )
+        var rows: [BackfillRow] = []
+        for try await row in stream { rows.append(try BackfillRow(row: row)) }
+        return rows
+    }
+
+    // MARK: - Count in-flight tasks (concurrency enforcement)
+
+    package static func countActiveTasks(
+        on client: PostgresClient,
+        backfillID: UUID,
+        namespaceID: String,
+        logger: Logger
+    ) async throws -> Int {
+        let stream = try await client.query(
+            """
+            SELECT COUNT(*)::int
+            FROM strand.tasks
+            WHERE backfill_id = \(backfillID)
+              AND namespace_id = \(namespaceID)
+              AND state IN (\(TaskState.pending), \(TaskState.running), \(TaskState.sleeping), \(TaskState.waiting))
+            """,
+            logger: logger
+        )
+        for try await row in stream {
+            var col = row.makeIterator()
+            return try col.next()!.decode(Int.self, context: .default)
+        }
+        return 0
+    }
+
+    // MARK: - Advance cursor
+
+    package static func advanceCursor(
+        on client: PostgresClient,
+        backfillID: UUID,
+        namespaceID: String,
+        nextSlotTime: Date,
+        firedCount: Int,
+        logger: Logger
+    ) async throws {
+        try await client.query(
+            """
+            UPDATE strand.backfills
+            SET next_slot_time  = \(nextSlotTime),
+                completed_slots = completed_slots + \(firedCount)
+            WHERE id = \(backfillID) AND namespace_id = \(namespaceID)
+            """,
+            logger: logger
+        )
+    }
+
+    // MARK: - Mark completed
+
+    package static func markCompleted(
+        on client: PostgresClient,
+        backfillID: UUID,
+        namespaceID: String,
+        logger: Logger
+    ) async throws {
+        try await client.query(
+            """
+            UPDATE strand.backfills
+            SET status       = \(BackfillStatus.completed),
+                completed_at = NOW()
+            WHERE id = \(backfillID) AND namespace_id = \(namespaceID)
+              AND status = \(BackfillStatus.running)
+            """,
+            logger: logger
+        )
+    }
+
+    // MARK: - Halt / resume / change concurrency
+
+    package static func halt(
+        on client: PostgresClient,
+        backfillID: UUID,
+        namespaceID: String,
+        logger: Logger
+    ) async throws {
+        try await client.query(
+            """
+            UPDATE strand.backfills
+            SET status = \(BackfillStatus.halted)
+            WHERE id = \(backfillID) AND namespace_id = \(namespaceID)
+              AND status = \(BackfillStatus.running)
+            """,
+            logger: logger
+        )
+    }
+
+    package static func resume(
+        on client: PostgresClient,
+        backfillID: UUID,
+        namespaceID: String,
+        logger: Logger
+    ) async throws {
+        try await client.query(
+            """
+            UPDATE strand.backfills
+            SET status = \(BackfillStatus.running)
+            WHERE id = \(backfillID) AND namespace_id = \(namespaceID)
+              AND status = \(BackfillStatus.halted)
+            """,
+            logger: logger
+        )
+    }
+
+    package static func setConcurrency(
+        on client: PostgresClient,
+        backfillID: UUID,
+        concurrency: Int,
+        namespaceID: String,
+        logger: Logger
+    ) async throws {
+        try await client.query(
+            "UPDATE strand.backfills SET concurrency = \(max(1, concurrency)) WHERE id = \(backfillID) AND namespace_id = \(namespaceID)",
+            logger: logger
+        )
+    }
+
+    // MARK: - Get single backfill
+
+    package static func get(
+        on client: PostgresClient,
+        backfillID: UUID,
+        namespaceID: String,
+        logger: Logger
+    ) async throws -> BackfillRow? {
+        let stream = try await client.query(
+            """
+            SELECT id, namespace_id, queue, task_name, task_kind, params, headers,
+                   retry_strategy, max_attempts, schedule_pattern,
+                   range_start, range_end, concurrency, allow_overwrite, description,
+                   schedule_id, status, next_slot_time, total_slots, completed_slots, created_at, completed_at
+            FROM strand.backfills
+            WHERE id = \(backfillID) AND namespace_id = \(namespaceID)
+            """,
+            logger: logger
+        )
+        for try await row in stream { return try BackfillRow(row: row) }
+        return nil
+    }
+
+    // MARK: - List backfills for a (namespace, queue, taskName) triple
+
+    package static func listForQueue(
+        on client: PostgresClient,
+        namespaceID: String,
+        queue: String,
+        taskName: String,
+        limit: Int = 20,
+        logger: Logger
+    ) async throws -> [BackfillRow] {
+        let stream = try await client.query(
+            """
+            SELECT id, namespace_id, queue, task_name, task_kind, params, headers,
+                   retry_strategy, max_attempts, schedule_pattern,
+                   range_start, range_end, concurrency, allow_overwrite, description,
+                   schedule_id, status, next_slot_time, total_slots, completed_slots, created_at, completed_at
+            FROM strand.backfills
+            WHERE namespace_id = \(namespaceID) AND queue = \(queue) AND task_name = \(taskName)
+            ORDER BY created_at DESC
+            LIMIT \(limit)
+            """,
+            logger: logger
+        )
+        var rows: [BackfillRow] = []
+        for try await row in stream { rows.append(try BackfillRow(row: row)) }
+        return rows
+    }
+}
+
+// MARK: - BackfillStatus: PostgresCodable
+
+extension BackfillQueries.BackfillStatus: PostgresCodable {
+    package static var psqlType: PostgresDataType { .text }
+    package static var psqlFormat: PostgresFormat { .binary }
+
+    package func encode<E: PostgresJSONEncoder>(
+        into byteBuffer: inout ByteBuffer,
+        context: PostgresEncodingContext<E>
+    ) throws {
+        rawValue.encode(into: &byteBuffer, context: context)
+    }
+
+    package init<D: PostgresJSONDecoder>(
+        from byteBuffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PostgresDecodingContext<D>
+    ) throws {
+        let raw = try String(from: &byteBuffer, type: type, format: format, context: context)
+        guard let v = BackfillQueries.BackfillStatus(rawValue: raw) else {
+            throw PostgresDecodingError.Code.typeMismatch
+        }
+        self = v
+    }
+}
+
+// MARK: - BackfillRow decoding
+
+extension BackfillQueries.BackfillRow {
+    package init(row: PostgresRow) throws {
+        var col = row.makeIterator()
+        id = try col.next()!.decode(UUID.self, context: .default)
+        namespaceID = try col.next()!.decode(String.self, context: .default)
+        queue = try col.next()!.decode(String.self, context: .default)
+        taskName = try col.next()!.decode(String.self, context: .default)
+        taskKind = try col.next()!.decode(TaskKind.self, context: .default)
+        paramsBuffer = try col.next()!.decode(ByteBuffer.self, context: .default)
+        headersBuffer = try col.next()!.decode(ByteBuffer?.self, context: .default)
+        retryStrategyBuffer = try col.next()!.decode(ByteBuffer?.self, context: .default)
+        maxAttempts = try col.next()!.decode(Int?.self, context: .default)
+        schedulePatternBuffer = try col.next()!.decode(ByteBuffer.self, context: .default)
+        rangeStart = try col.next()!.decode(Date.self, context: .default)
+        rangeEnd = try col.next()!.decode(Date.self, context: .default)
+        concurrency = try col.next()!.decode(Int.self, context: .default)
+        allowOverwrite = try col.next()!.decode(Bool.self, context: .default)
+        description = try col.next()!.decode(String?.self, context: .default)
+        scheduleId = try col.next()!.decode(UUID?.self, context: .default)
+        status = try col.next()!.decode(BackfillQueries.BackfillStatus.self, context: .default)
+        nextSlotTime = try col.next()!.decode(Date.self, context: .default)
+        totalSlots = try col.next()!.decode(Int.self, context: .default)
+        completedSlots = try col.next()!.decode(Int.self, context: .default)
+        createdAt = try col.next()!.decode(Date.self, context: .default)
+        completedAt = try col.next()!.decode(Date?.self, context: .default)
+    }
+}

--- a/Sources/Strand/DB/Queries.swift
+++ b/Sources/Strand/DB/Queries.swift
@@ -163,6 +163,7 @@ enum Queries {
         fairnessWeight: Float = 1.0,
         kind: TaskKind = .workflow,
         parentTaskID: UUID? = nil,
+        backfillID: UUID? = nil,
         logger: Logger
     ) async throws -> EnqueueRow {
         try await client.withTransaction(logger: logger) { conn in
@@ -176,14 +177,14 @@ enum Queries {
                     (namespace_id, id, queue, name, params, headers, scheduling_metadata,
                      retry_strategy, max_attempts, timeout_seconds, heartbeat_timeout_seconds,
                      cancellation, idempotency_key, priority, fairness_key, fairness_weight,
-                     state, kind, parent_task_id, deadline_at)
+                     state, kind, parent_task_id, deadline_at, backfill_id)
                 VALUES (\(namespaceID), \(taskID), \(queue), \(taskName), \(paramsBuffer),
                         \(headersBuffer), \(schedulingMetadata),
                         \(retryStrategyBuffer), \(maxAttempts),
                         \(timeoutSeconds), \(heartbeatTimeoutSeconds),
                         \(cancellationBuffer), \(idempotencyKey), \(priority),
                         \(fairnessKey), \(fairnessWeight), \(TaskState.pending),
-                        \(kind), \(parentTaskID), \(deadlineAt))
+                        \(kind), \(parentTaskID), \(deadlineAt), \(backfillID))
                 ON CONFLICT (namespace_id, queue, idempotency_key) DO NOTHING
                 """,
                 logger: logger
@@ -2060,7 +2061,7 @@ private func retryDelay(strategy buf: ByteBuffer?, attempt: Int) -> TimeInterval
     return Swift.min(initial * pow(s.multiplier, Double(Swift.max(attempt - 1, 0))), cap)
 }
 
-private struct QueryError: Error, CustomStringConvertible {
+struct QueryError: Error, CustomStringConvertible {
     let description: String
     init(_ msg: String) { self.description = msg }
 }

--- a/Sources/Strand/DB/ScheduleQueries.swift
+++ b/Sources/Strand/DB/ScheduleQueries.swift
@@ -31,21 +31,21 @@ package struct ScheduleRow: Sendable {
 
 /// A schedule summary row returned by ``ScheduleQueries/listSchedules``.
 package struct ScheduleSummaryRow: Sendable {
-    let id: UUID
-    let queue: String
-    let name: String
-    let taskName: String
-    let patternBuffer: ByteBuffer
-    let isActive: Bool
-    let startsAt: Date?
-    let endsAt: Date?
-    let nextRunAt: Date?
-    let lastRunAt: Date?
-    let lastTaskID: UUID?
-    let runCount: Int
-    let accuracy: ScheduleAccuracy
-    let kind: TaskKind  // 'WORKFLOW' or 'ACTIVITY'
-    let createdAt: Date
+    package let id: UUID
+    package let queue: String
+    package let name: String
+    package let taskName: String
+    package let patternBuffer: ByteBuffer
+    package let isActive: Bool
+    package let startsAt: Date?
+    package let endsAt: Date?
+    package let nextRunAt: Date?
+    package let lastRunAt: Date?
+    package let lastTaskID: UUID?
+    package let runCount: Int
+    package let accuracy: ScheduleAccuracy
+    package let kind: TaskKind  // 'WORKFLOW' or 'ACTIVITY'
+    package let createdAt: Date
 }
 
 /// A task row fired by a specific schedule, returned by ``ScheduleQueries/listScheduleRuns``.
@@ -55,6 +55,39 @@ package struct ScheduleRunRow: Sendable {
     package let attempt: Int
     package let createdAt: Date
     package let completedAt: Date?
+}
+
+/// Full schedule row returned by ``ScheduleQueries/getSchedule(on:namespaceID:id:logger:)``.
+///
+/// Carries every column: the display fields shared with ``ScheduleSummaryRow``
+/// **plus** the payload buffers (`params`, `headers`, `retry_strategy`,
+/// `cancellation`) needed for backfill and run-for-partition operations.
+///
+/// ``ScheduleSummaryRow`` still exists for **list queries** — loading payload
+/// buffers for up to 200 rows just to render names and timestamps would be
+/// wasteful. Single-ID lookups have no such concern, so they always fetch
+/// everything in one query rather than requiring a second round-trip.
+package struct ScheduleFullRow: Sendable {
+    package let id: UUID
+    package let queue: String
+    package let name: String
+    package let taskName: String
+    package let patternBuffer: ByteBuffer
+    package let isActive: Bool
+    package let startsAt: Date?
+    package let endsAt: Date?
+    package let nextRunAt: Date?
+    package let lastRunAt: Date?
+    package let lastTaskID: UUID?
+    package let runCount: Int
+    package let accuracy: ScheduleAccuracy
+    package let kind: TaskKind
+    package let createdAt: Date
+    package let paramsBuffer: ByteBuffer
+    package let headersBuffer: ByteBuffer?
+    package let retryStrategyBuffer: ByteBuffer?
+    package let maxAttempts: Int?
+    package let cancellationBuffer: ByteBuffer?
 }
 
 // MARK: - Queries
@@ -370,18 +403,24 @@ package enum ScheduleQueries {
         )
     }
 
-    /// Fetches a single schedule by primary key.  Returns `nil` when not found.
+    /// Fetches a single schedule by primary key.
+    ///
+    /// Returns `nil` when not found. Returns a ``ScheduleFullRow`` containing
+    /// both the display fields (same as list queries) and the payload buffers
+    /// needed for backfill and run-for-partition operations — one query covers
+    /// all callers instead of requiring a separate `getScheduleDetail` call.
     package static func getSchedule(
         on client: PostgresClient,
         namespaceID: String,
         id: UUID,
         logger: Logger
-    ) async throws -> ScheduleSummaryRow? {
+    ) async throws -> ScheduleFullRow? {
         let stream = try await client.query(
             """
             SELECT id, queue, name, task_name, pattern, is_active,
                    starts_at, ends_at, next_run_at, last_run_at, last_task_id,
-                   run_count, accuracy, kind, created_at
+                   run_count, accuracy, kind, created_at,
+                   params, headers, retry_strategy, max_attempts, cancellation
             FROM strand.schedules
             WHERE namespace_id = \(namespaceID)
               AND id           = \(id)
@@ -391,7 +430,7 @@ package enum ScheduleQueries {
         )
         guard let row = try await stream.first(where: { _ in true }) else { return nil }
         var col = row.makeIterator()
-        return ScheduleSummaryRow(
+        return ScheduleFullRow(
             id: try col.next()!.decode(UUID.self, context: .default),
             queue: try col.next()!.decode(String.self, context: .default),
             name: try col.next()!.decode(String.self, context: .default),
@@ -406,7 +445,12 @@ package enum ScheduleQueries {
             runCount: try col.next()!.decode(Int.self, context: .default),
             accuracy: try col.next()!.decode(ScheduleAccuracy.self, context: .default),
             kind: try col.next()!.decode(TaskKind.self, context: .default),
-            createdAt: try col.next()!.decode(Date.self, context: .default)
+            createdAt: try col.next()!.decode(Date.self, context: .default),
+            paramsBuffer: try col.next()!.decode(ByteBuffer.self, context: .default),
+            headersBuffer: try col.next()!.decode(ByteBuffer?.self, context: .default),
+            retryStrategyBuffer: try col.next()!.decode(ByteBuffer?.self, context: .default),
+            maxAttempts: try col.next()!.decode(Int?.self, context: .default),
+            cancellationBuffer: try col.next()!.decode(ByteBuffer?.self, context: .default)
         )
     }
 

--- a/Sources/Strand/Schedule/BackfillTypes.swift
+++ b/Sources/Strand/Schedule/BackfillTypes.swift
@@ -1,0 +1,148 @@
+import Logging
+import NIOCore
+import PostgresNIO
+
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
+public import Foundation
+#endif
+
+// MARK: - BackfillOptions
+
+/// Options controlling how a backfill is executed.
+public struct BackfillOptions: Sendable {
+    /// Maximum number of slots executing concurrently during the backfill.
+    /// Does not affect normally-scheduled executions.
+    public var concurrency: Int
+
+    /// Whether to re-run slots that already have a completed task with the
+    /// same idempotency key. When `false` (default) those slots are skipped.
+    public var allowOverwrite: Bool
+
+    /// Human-readable note explaining why this backfill was created.
+    public var description: String?
+
+    public init(
+        concurrency: Int = 1,
+        allowOverwrite: Bool = false,
+        description: String? = nil
+    ) {
+        self.concurrency = max(1, concurrency)
+        self.allowOverwrite = allowOverwrite
+        self.description = description
+    }
+}
+
+// MARK: - BackfillHandle
+
+/// A reference to a running backfill. Returned by `StrandClient.createBackfill`.
+public struct BackfillHandle: Sendable {
+    /// Stable identifier for this backfill.
+    public let id: UUID
+
+    private let postgres: PostgresClient
+    private let namespaceID: String
+    private let logger: Logger
+
+    init(id: UUID, postgres: PostgresClient, namespaceID: String, logger: Logger) {
+        self.id = id
+        self.postgres = postgres
+        self.namespaceID = namespaceID
+        self.logger = logger
+    }
+
+    /// Stop enqueueing new slots. In-flight tasks continue to completion.
+    public func halt() async throws {
+        try await BackfillQueries.halt(
+            on: postgres,
+            backfillID: id,
+            namespaceID: namespaceID,
+            logger: logger
+        )
+    }
+
+    /// Resume a halted backfill.
+    public func resume() async throws {
+        try await BackfillQueries.resume(
+            on: postgres,
+            backfillID: id,
+            namespaceID: namespaceID,
+            logger: logger
+        )
+    }
+
+    /// Change the maximum concurrency in-flight. Takes effect on the next
+    /// `StrandScheduler` poll cycle.
+    public func setConcurrency(_ n: Int) async throws {
+        try await BackfillQueries.setConcurrency(
+            on: postgres,
+            backfillID: id,
+            concurrency: n,
+            namespaceID: namespaceID,
+            logger: logger
+        )
+    }
+
+    /// Returns the current status snapshot.
+    public func status() async throws -> BackfillStatus {
+        guard
+            let row = try await BackfillQueries.get(
+                on: postgres,
+                backfillID: id,
+                namespaceID: namespaceID,
+                logger: logger
+            )
+        else {
+            throw StrandError.database(underlying: QueryError("backfill not found"))
+        }
+        return BackfillStatus(from: row)
+    }
+}
+
+// MARK: - BackfillStatus
+
+public struct BackfillStatus: Sendable {
+    public let id: UUID
+    public let state: BackfillState
+    public let totalSlots: Int
+    public let completedSlots: Int
+    public let concurrency: Int
+    public let nextSlotTime: Date
+    public let createdAt: Date
+    public let completedAt: Date?
+
+    public var progressFraction: Double {
+        guard totalSlots > 0 else { return 0 }
+        return Double(completedSlots) / Double(totalSlots)
+    }
+
+    init(from row: BackfillQueries.BackfillRow) {
+        id = row.id
+        state = BackfillState(raw: row.status)
+        totalSlots = row.totalSlots
+        completedSlots = row.completedSlots
+        concurrency = row.concurrency
+        nextSlotTime = row.nextSlotTime
+        createdAt = row.createdAt
+        completedAt = row.completedAt
+    }
+}
+
+// MARK: - BackfillState
+
+public enum BackfillState: Sendable {
+    case running
+    case halted
+    case completed
+    case failed
+
+    init(raw: BackfillQueries.BackfillStatus) {
+        switch raw {
+        case .running: self = .running
+        case .halted: self = .halted
+        case .completed: self = .completed
+        case .failed: self = .failed
+        }
+    }
+}

--- a/Sources/Strand/Schedule/ISO8601Duration.swift
+++ b/Sources/Strand/Schedule/ISO8601Duration.swift
@@ -201,7 +201,7 @@ public struct ISO8601Duration: Codable, Sendable, Equatable {
 
     /// UTC Gregorian calendar used as the default for date arithmetic.
     /// Avoids silently inheriting the server's system timezone/locale from
-    /// `Calendar.current` when no explicit calendar is provided by the caller.
+    /// `Calendar(identifier: .gregorian)` when no explicit calendar is provided by the caller.
     @usableFromInline static let utcGregorian: Calendar = {
         var c = Calendar(identifier: .gregorian)
         c.timeZone = TimeZone(identifier: "UTC")!

--- a/Sources/Strand/Schedule/ScheduleCalculator.swift
+++ b/Sources/Strand/Schedule/ScheduleCalculator.swift
@@ -365,6 +365,31 @@ public struct ScheduleCalculator {
         try nextRunTime(for: schedule, after: createdAt, timezone: timezone)
     }
 
+    /// Counts the number of schedule slots in `range` (start **inclusive**, end exclusive).
+    ///
+    /// The start is made inclusive by searching from `lowerBound - 1 s` so a slot
+    /// that falls exactly on the range boundary is counted. This matches Temporal’s
+    /// backfill semantics where `StartTime` is adjusted by -1 ms before evaluation.
+    ///
+    /// Capped at `cap` (default 100 000) to bound O(n) iteration for large ranges.
+    public static func countSlots(
+        for schedule: SchedulePattern,
+        in range: Range<Date>,
+        cap: Int = 100_000
+    ) -> Int {
+        var count = 0
+        var cursor = range.lowerBound.addingTimeInterval(-1)
+        while count < cap {
+            guard
+                let next = try? nextRunTime(for: schedule, after: cursor, timezone: schedule.timezone),
+                next < range.upperBound
+            else { break }
+            count += 1
+            cursor = next
+        }
+        return count
+    }
+
     // MARK: - Validation and Utilities
 
     /// Validate that a schedule configuration is valid

--- a/Sources/Strand/Schedule/SchedulePattern.swift
+++ b/Sources/Strand/Schedule/SchedulePattern.swift
@@ -68,14 +68,28 @@ public enum SchedulePattern: Sendable, Codable, Equatable, Hashable {
                 nextHour.second = 0
                 guard let boundaryTime = calendar.date(from: nextHour) else { return nil }
                 return scheduleOffset.apply(to: boundaryTime, calendar: calendar)
-            } else if seconds == 86400 {  // 1 day
-                let components = calendar.dateComponents([.year, .month, .day], from: date)
-                var nextDay = components
-                nextDay.day = (components.day ?? 0) + 1
-                nextDay.hour = 0
-                nextDay.minute = 0
-                nextDay.second = 0
-                guard let boundaryTime = calendar.date(from: nextDay) else { return nil }
+            } else if seconds > 0 && seconds % 86400 == 0 {
+                // N whole-day intervals (1 day, 7 days, 14 days, …).
+                //
+                // calendar.date(byAdding: .day, value: N, to: startOfDay) resolves the
+                // correct UTC instant for “same wall-clock time N calendar days later” in
+                // the schedule’s timezone, correctly handling DST transitions:
+                //   • Fall-back  (e.g. Nov 3 US): a 7-day gap spans 25 h in UTC, yet
+                //     the next fire time stays at 00:00 local.
+                //   • Spring-forward (e.g. Mar 9 US): a 7-day gap spans 23 h in UTC,
+                //     yet the next fire time stays at 00:00 local.
+                //
+                // No epsilon needed: startOfDay ≤ date, so startOfDay + N days > date
+                // for any N ≥ 1.
+                let nDays = Int(seconds / 86400)
+                let startOfCurrentDay = calendar.startOfDay(for: date)
+                guard
+                    let boundaryTime = calendar.date(
+                        byAdding: .day,
+                        value: nDays,
+                        to: startOfCurrentDay
+                    )
+                else { return nil }
                 return scheduleOffset.apply(to: boundaryTime, calendar: calendar)
             } else {
                 // All non-standard intervals snap to epoch-aligned boundaries.

--- a/Sources/Strand/Schedule/SchedulingMetadata.swift
+++ b/Sources/Strand/Schedule/SchedulingMetadata.swift
@@ -41,6 +41,10 @@ public struct SchedulingMetadata: Codable, Sendable {
     /// Human-readable name of the schedule.
     public let scheduledBy: String?
 
+    /// UUID of the backfill that triggered this task. `nil` for regularly-scheduled
+    /// or manually-enqueued tasks.
+    public let backfillId: UUID?
+
     /// Metadata format version.
     public let version: Int
 
@@ -50,6 +54,7 @@ public struct SchedulingMetadata: Codable, Sendable {
         scheduleOffset: String? = nil,
         scheduleId: String? = nil,
         scheduledBy: String? = nil,
+        backfillId: UUID? = nil,
         version: Int = 1
     ) {
         self.executionTime = executionTime
@@ -57,6 +62,7 @@ public struct SchedulingMetadata: Codable, Sendable {
         self.scheduleOffset = scheduleOffset
         self.scheduleId = scheduleId
         self.scheduledBy = scheduledBy
+        self.backfillId = backfillId
         self.version = version
     }
 }

--- a/Sources/Strand/Schedule/StrandScheduler.swift
+++ b/Sources/Strand/Schedule/StrandScheduler.swift
@@ -210,18 +210,31 @@ public struct StrandScheduler: Service {
             // 1. Fire anything that is already due.
             do { try await fireSchedules() } catch {
                 client.logger.info(
-                    "scheduler fire error: \(String(reflecting: error))"
+                    "scheduler fire error:",
+                    metadata: [
+                        "error": " \(String(reflecting: error))"
+                    ]
                 )
             }
 
-            // 2. Find the next scheduled fire time across all active schedules.
+            // 2. Process pending backfill slots.
+            do { try await processBackfills() } catch {
+                client.logger.error(
+                    "backfill processing error:",
+                    metadata: [
+                        "error": " \(String(reflecting: error))"
+                    ]
+                )
+            }
+
+            // 3. Find the next scheduled fire time across all active schedules.
             let nextFireAt = try? await ScheduleQueries.nextScheduledFireTime(
                 on: client.postgres,
                 namespaceID: client.namespaceID,
                 logger: client.logger
             )
 
-            // 3. Sleep until next fire (but never longer than sleepCap so newly-added
+            // 4. Sleep until next fire (but never longer than sleepCap so newly-added
             //    schedules are detected promptly).
             let sleepFor: Duration
             let now = Date.now
@@ -249,6 +262,148 @@ public struct StrandScheduler: Service {
         }
     }
 
+    // MARK: - Backfill processing
+
+    /// Drives all RUNNING backfills: for each backfill, counts in-flight tasks,
+    /// computes how many new slots can be fired (concurrency - active), and
+    /// enqueues them. Advances the cursor and marks backfills complete when the
+    /// range is exhausted.
+    ///
+    /// This runs in the scheduler's poll loop — zero worker task-queue slots
+    /// are consumed for orchestration. The actual workflow/activity executions
+    /// use worker slots as normal.
+    private func processBackfills(now: Date = .now) async throws {
+        let backfills = try await BackfillQueries.listRunning(
+            on: client.postgres,
+            namespaceID: client.namespaceID,
+            logger: client.logger
+        )
+        guard !backfills.isEmpty else { return }
+
+        for backfill in backfills {
+            do {
+                try await processBackfill(backfill, now: now)
+            } catch {
+                client.logger.error(
+                    "backfill error",
+                    metadata: [
+                        "backfill_id": .stringConvertible(backfill.id),
+                        "error": " \(String(reflecting: error))",
+                    ]
+                )
+            }
+        }
+    }
+
+    private func processBackfill(_ backfill: BackfillQueries.BackfillRow, now: Date) async throws {
+        let logger = client.logger
+        let postgres = client.postgres
+
+        // How many slots from this backfill are currently in-flight?
+        let active = try await BackfillQueries.countActiveTasks(
+            on: postgres,
+            backfillID: backfill.id,
+            namespaceID: backfill.namespaceID,
+            logger: logger
+        )
+        let slots = backfill.concurrency - active
+        guard slots > 0 else { return }
+
+        // Decode the stored SchedulePattern to compute next slot times.
+        let pattern = try JSON.decode(SchedulePattern.self, from: backfill.schedulePatternBuffer)
+
+        var cursor = backfill.nextSlotTime
+        var fired = 0
+
+        while fired < slots {
+            // Compute the next slot strictly after the cursor.
+            guard
+                let slotAt = try ScheduleCalculator.nextRunTime(
+                    for: pattern,
+                    after: cursor,
+                    timezone: pattern.timezone
+                ),
+                slotAt < backfill.rangeEnd
+            else {
+                // Range exhausted — mark the backfill complete.
+                try await BackfillQueries.markCompleted(
+                    on: postgres,
+                    backfillID: backfill.id,
+                    namespaceID: backfill.namespaceID,
+                    logger: logger
+                )
+                logger.debug(
+                    "backfill '\(backfill.id)' completed — \(backfill.completedSlots + fired) slots fired"
+                )
+                return
+            }
+
+            // Compute scheduling metadata (same structure as StrandScheduler.fire).
+            var partitionTime: Date? = nil
+            if let times = try? ScheduleCalculator.calculateExecutionTimes(
+                for: pattern,
+                executingAt: slotAt,
+                timezone: pattern.timezone
+            ) {
+                partitionTime = times.scheduledTime
+            }
+            let schedulingMeta = SchedulingMetadata(
+                executionTime: now,
+                partitionTime: partitionTime ?? slotAt,
+                scheduleOffset: pattern.partitionOffset,
+                backfillId: backfill.id
+            )
+
+            // When allowOverwrite=false, use a key that matches what StrandScheduler.fire()
+            // would produce for the same slot so slots already run by the schedule (or a
+            // previous backfill for the same schedule) are deduplicated via ON CONFLICT.
+            // Standalone backfills (no scheduleId) use a backfill-scoped key to prevent
+            // double-firing within the same backfill on retries.
+            let idKey: String?
+            if backfill.allowOverwrite {
+                idKey = nil  // no dedup — always create a fresh task
+            } else if let scheduleId = backfill.scheduleId {
+                idKey = "$schedule:\(scheduleId):\(slotAt.timeIntervalSince1970)"
+            } else {
+                idKey = "$backfill:\(backfill.id):\(slotAt.timeIntervalSince1970)"
+            }
+
+            _ = try await Queries.enqueueTask(
+                on: postgres,
+                namespaceID: backfill.namespaceID,
+                queue: backfill.queue,
+                taskName: backfill.taskName,
+                paramsBuffer: backfill.paramsBuffer,
+                headersBuffer: backfill.headersBuffer,
+                schedulingMetadata: schedulingMeta,
+                retryStrategyBuffer: backfill.retryStrategyBuffer,
+                maxAttempts: backfill.maxAttempts,
+                cancellationBuffer: nil,
+                idempotencyKey: idKey,
+                kind: backfill.taskKind,
+                backfillID: backfill.id,
+                logger: logger
+            )
+
+            cursor = slotAt
+            fired += 1
+        }
+
+        if fired > 0 {
+            try await BackfillQueries.advanceCursor(
+                on: postgres,
+                backfillID: backfill.id,
+                namespaceID: backfill.namespaceID,
+                nextSlotTime: cursor,
+                firedCount: fired,
+                logger: logger
+            )
+            logger.debug(
+                "backfill '\(backfill.id)': fired \(fired) slots, cursor=\(cursor.ISO8601Format())"
+            )
+        }
+    }
+
     private func fireSchedules(now: Date = .now) async throws {
         let rows = try await ScheduleQueries.pollDueSchedules(
             on: client.postgres,
@@ -269,7 +424,11 @@ public struct StrandScheduler: Service {
                         try await self.fire(row, now: now)
                     } catch {
                         self.client.logger.error(
-                            "failed to fire schedule '\(row.name)': \(String(reflecting: error))"
+                            "failed to fire schedule",
+                            metadata: [
+                                "schedule_name": .stringConvertible(row.name),
+                                "error": " \(String(reflecting: error))",
+                            ]
                         )
                     }
                 }

--- a/Sources/StrandServer/Models.swift
+++ b/Sources/StrandServer/Models.swift
@@ -289,6 +289,12 @@ extension DailyRunCountResponse: ResponseCodable {}
 
 extension SimpleResponse: ResponseCodable {}
 
+struct RunScheduleResponse: Codable, Sendable {
+    let taskId: UUID
+    let runId: UUID
+}
+extension RunScheduleResponse: ResponseCodable {}
+
 struct EnqueueResultResponse: Codable, Sendable {
     let taskID: UUID
     let runID: UUID

--- a/Sources/StrandServer/Routes/BackfillRoutes.swift
+++ b/Sources/StrandServer/Routes/BackfillRoutes.swift
@@ -1,0 +1,213 @@
+import Hummingbird
+import NIOCore
+import PostgresNIO
+import Strand
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+// MARK: - Response types
+
+struct BackfillResponse: Codable, Sendable {
+    let id: String
+    let scheduleId: UUID?
+    let queue: String
+    let taskName: String
+    let taskKind: String
+    let rangeStart: Date
+    let rangeEnd: Date
+    let concurrency: Int
+    let allowOverwrite: Bool
+    let description: String?
+    let status: String
+    let nextSlotTime: Date
+    let totalSlots: Int
+    let completedSlots: Int
+    let createdAt: Date
+    let completedAt: Date?
+}
+extension BackfillResponse: ResponseCodable {}
+
+// MARK: - Routes
+
+struct BackfillRoutes {
+    let client: StrandClient
+    let postgres: PostgresClient
+
+    private struct CreateBackfillBody: Decodable {
+        let rangeStart: Date
+        let rangeEnd: Date
+        let concurrency: Int?
+        let allowOverwrite: Bool?
+        let description: String?
+    }
+
+    private struct UpdateConcurrencyBody: Decodable {
+        let concurrency: Int
+    }
+
+    func register(on router: some RouterMethods<StrandRequestContext>) {
+
+        // ── POST /api/:namespace/schedules/:id/backfills ────────────────────────────────────
+        // Create a backfill for an existing schedule. Inherits task_name, params,
+        // kind, and schedule_pattern from the schedule row.
+        router.post("schedules/:id/backfills") { req, ctx -> BackfillResponse in
+            let scheduleID = try ctx.parameters.require("id", as: UUID.self)
+            let body = try await req.decode(as: CreateBackfillBody.self, context: ctx)
+
+            // Load full schedule data (params, pattern, task config)
+            guard
+                let schedule = try await ScheduleQueries.getSchedule(
+                    on: self.postgres,
+                    namespaceID: ctx.namespaceID,
+                    id: scheduleID,
+                    logger: self.client.logger
+                )
+            else {
+                throw HTTPError(.notFound, message: "Schedule not found")
+            }
+
+            let id = UUID.v7()
+            let pattern = try JSON.decode(SchedulePattern.self, from: schedule.patternBuffer)
+            let firstSlot =
+                try ScheduleCalculator.nextRunTime(
+                    for: pattern,
+                    after: body.rangeStart,
+                    timezone: pattern.timezone
+                ) ?? body.rangeStart
+            let concurrency = max(1, body.concurrency ?? 1)
+            let totalSlots = ScheduleCalculator.countSlots(for: pattern, in: body.rangeStart..<body.rangeEnd)
+
+            try await BackfillQueries.createBackfill(
+                on: self.postgres,
+                id: id,
+                namespaceID: ctx.namespaceID,
+                queue: schedule.queue,
+                taskName: schedule.taskName,
+                taskKind: schedule.kind,
+                paramsBuffer: schedule.paramsBuffer,
+                headersBuffer: schedule.headersBuffer,
+                retryStrategyBuffer: schedule.retryStrategyBuffer,
+                maxAttempts: schedule.maxAttempts,
+                schedulePatternBuffer: schedule.patternBuffer,
+                rangeStart: body.rangeStart,
+                rangeEnd: body.rangeEnd,
+                concurrency: concurrency,
+                allowOverwrite: body.allowOverwrite ?? false,
+                description: body.description,
+                scheduleId: scheduleID,
+                nextSlotTime: firstSlot,
+                totalSlots: totalSlots,
+                logger: self.client.logger
+            )
+            guard
+                let row = try await BackfillQueries.get(
+                    on: self.postgres,
+                    backfillID: id,
+                    namespaceID: ctx.namespaceID,
+                    logger: self.client.logger
+                )
+            else { throw HTTPError(.internalServerError) }
+            return BackfillResponse(from: row, scheduleId: row.scheduleId)
+        }
+
+        // ── GET /api/:namespace/schedules/:id/backfills ──────────────────────────────
+        router.get("schedules/:id/backfills") { _, ctx -> [BackfillResponse] in
+            let scheduleID = try ctx.parameters.require("id", as: UUID.self)
+            guard
+                let schedule = try await ScheduleQueries.getSchedule(
+                    on: self.postgres,
+                    namespaceID: ctx.namespaceID,
+                    id: scheduleID,
+                    logger: self.client.logger
+                )
+            else { throw HTTPError(.notFound) }
+            let rows = try await BackfillQueries.listForQueue(
+                on: self.postgres,
+                namespaceID: ctx.namespaceID,
+                queue: schedule.queue,
+                taskName: schedule.taskName,
+                logger: self.client.logger
+            )
+            return rows.map { BackfillResponse(from: $0, scheduleId: $0.scheduleId) }
+        }
+
+        // ── GET /api/:namespace/backfills/:id ───────────────────────────────────────────
+        router.get("backfills/:id") { _, ctx -> BackfillResponse? in
+            let id = try ctx.parameters.require("id", as: UUID.self)
+            guard
+                let row = try await BackfillQueries.get(
+                    on: self.postgres,
+                    backfillID: id,
+                    namespaceID: ctx.namespaceID,
+                    logger: self.client.logger
+                )
+            else { return nil }  // Hummingbird returns 204 No Content
+            return BackfillResponse(from: row, scheduleId: row.scheduleId)
+        }
+
+        // ── POST /api/:namespace/backfills/:id/halt ──────────────────────────────
+        router.post("backfills/:id/halt") { _, ctx -> SimpleResponse in
+            let id = try ctx.parameters.require("id", as: UUID.self)
+            try await BackfillQueries.halt(
+                on: self.postgres,
+                backfillID: id,
+                namespaceID: ctx.namespaceID,
+                logger: self.client.logger
+            )
+            return SimpleResponse(message: "halted", id: id.uuidString)
+        }
+
+        // ── POST /api/:namespace/backfills/:id/resume ────────────────────────────
+        router.post("backfills/:id/resume") { _, ctx -> SimpleResponse in
+            let id = try ctx.parameters.require("id", as: UUID.self)
+            try await BackfillQueries.resume(
+                on: self.postgres,
+                backfillID: id,
+                namespaceID: ctx.namespaceID,
+                logger: self.client.logger
+            )
+            return SimpleResponse(message: "resumed", id: id.uuidString)
+        }
+
+        // ── PATCH /api/:namespace/backfills/:id/concurrency ──────────────────────
+        router.patch("backfills/:id/concurrency") { req, ctx -> SimpleResponse in
+            let id = try ctx.parameters.require("id", as: UUID.self)
+            let body = try await req.decode(as: UpdateConcurrencyBody.self, context: ctx)
+            try await BackfillQueries.setConcurrency(
+                on: self.postgres,
+                backfillID: id,
+                concurrency: body.concurrency,
+                namespaceID: ctx.namespaceID,
+                logger: self.client.logger
+            )
+            return SimpleResponse(message: "updated", id: id.uuidString)
+        }
+    }
+}
+
+// MARK: - BackfillResponse init
+
+extension BackfillResponse {
+    init(from row: BackfillQueries.BackfillRow, scheduleId: UUID?) {
+        id = row.id.uuidString
+        self.scheduleId = scheduleId
+        queue = row.queue
+        taskName = row.taskName
+        taskKind = row.taskKind.rawValue
+        rangeStart = row.rangeStart
+        rangeEnd = row.rangeEnd
+        concurrency = row.concurrency
+        allowOverwrite = row.allowOverwrite
+        description = row.description
+        status = row.status.rawValue
+        nextSlotTime = row.nextSlotTime
+        totalSlots = row.totalSlots
+        completedSlots = row.completedSlots
+        createdAt = row.createdAt
+        completedAt = row.completedAt
+    }
+}

--- a/Sources/StrandServer/Routes/ScheduleRoutes.swift
+++ b/Sources/StrandServer/Routes/ScheduleRoutes.swift
@@ -116,6 +116,11 @@ extension UpcomingSlotResponse: ResponseCodable {}
 
 // MARK: - Routes
 
+private struct RunScheduleBody: Decodable {
+    let partitionTime: Date
+    let allowOverwrite: Bool?
+}
+
 struct ScheduleRoutes {
     let client: StrandClient
 
@@ -236,6 +241,25 @@ struct ScheduleRoutes {
                 cursor = next
             }
             return slots
+        }
+
+        // POST /api/:namespace/schedules/:id/run
+        // Fire a single execution for a specific partition time.
+        // Uses the scheduler's idempotency key format so re-running an already-completed
+        // slot is blocked via ON CONFLICT — unless allowOverwrite is true.
+        router.post("schedules/:id/run") { req, ctx -> RunScheduleResponse in
+            let scheduleID = try ctx.parameters.require("id", as: UUID.self)
+            let body = try await req.decode(as: RunScheduleBody.self, context: ctx)
+            let result = try await self.client.runScheduleSlot(
+                scheduleID: scheduleID,
+                partitionTime: body.partitionTime,
+                allowOverwrite: body.allowOverwrite ?? false,
+                namespaceID: ctx.namespaceID
+            )
+            return RunScheduleResponse(
+                taskId: result.taskID,
+                runId:  result.runID
+            )
         }
 
         // DELETE /api/:namespace/schedules/:id

--- a/Sources/StrandServer/StrandServer.swift
+++ b/Sources/StrandServer/StrandServer.swift
@@ -115,6 +115,7 @@ public struct StrandServer: Service {
         EventRoutes(client: client, postgres: postgres).register(on: nsGroup)
         WorkflowRoutes(client: client).register(on: nsGroup)
         ScheduleRoutes(client: client).register(on: nsGroup)
+        BackfillRoutes(client: client, postgres: postgres).register(on: nsGroup)
         WorkerRoutes(postgres: postgres, logger: client.logger).register(on: nsGroup)
         MetricsRoutes(
             postgres: postgres,

--- a/Tests/StrandTests/BackfillTests.swift
+++ b/Tests/StrandTests/BackfillTests.swift
@@ -1,0 +1,172 @@
+import Logging
+import NIOCore
+import PostgresNIO
+import Testing
+
+@testable import Strand
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+// Simple pass-through workflow for backfill testing
+private struct BackfillTestWorkflow: Workflow {
+    typealias Input = String
+    typealias Output = String
+    mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
+        input
+    }
+}
+
+@Suite("Integration — Backfill")
+struct BackfillTests {
+
+    // Test 1: createBackfill inserts a row and StrandScheduler enqueues slots
+    @Test("createBackfill enqueues tasks with correct backfill_id")
+    func backfillEnqueuesTasks() async throws {
+        try await withTestEnvironment { client in
+            let postgres = client.postgres
+            let logger = client.logger
+            let queue = client.queueName
+
+            // Start a worker to claim tasks that the scheduler enqueues
+            let workerTask = startWorker(
+                postgres: postgres,
+                queueName: queue,
+                logger: logger,
+                workflows: [BackfillTestWorkflow.self]
+            )
+            defer { workerTask.cancel() }
+
+            // Start a scheduler with a very short sleep cap so it processes
+            // the backfill quickly without waiting for the full sleepCap
+            let schedulerClient = StrandClient(
+                postgres: postgres,
+                queue: queue,
+                logger: logger
+            )
+            let scheduler = StrandScheduler(
+                client: schedulerClient,
+                options: SchedulerOptions(sleepCap: .milliseconds(200))
+            )
+            let schedulerTask = Task {
+                try? await scheduler.run()
+            }
+            defer { schedulerTask.cancel() }
+
+            // Give the scheduler time to start and register the namespace
+            try await Task.sleep(for: .milliseconds(400))
+
+            // Range: last 3 hours, 1-hour interval → 3 slots
+            let now = Date()
+            let rangeEnd = now
+            let rangeStart = Calendar(identifier: .gregorian).date(byAdding: .hour, value: -3, to: now)!
+            let range = rangeStart..<rangeEnd
+
+            let handle = try await client.createBackfill(
+                BackfillTestWorkflow.self,
+                input: "test",
+                schedule: .interval(.hours(1)),
+                range: range,
+                options: BackfillOptions(concurrency: 3)
+            )
+
+            // Wait long enough for the scheduler's poll loop to process the backfill
+            try await Task.sleep(for: .seconds(2))
+
+            // Verify tasks were created with the correct backfill_id
+            let taskStream = try await postgres.query(
+                "SELECT COUNT(*)::int FROM strand.tasks WHERE backfill_id = \(handle.id) AND namespace_id = 'default'",
+                logger: logger
+            )
+            var taskCount = 0
+            for try await row in taskStream {
+                var col = row.makeIterator()
+                taskCount = try col.next()!.decode(Int.self, context: .default)
+            }
+            #expect(taskCount > 0, "Expected at least one task to be enqueued for the backfill")
+
+            // Verify the backfill row exists and is in a valid terminal or running state
+            let status = try await handle.status()
+            #expect(status.state == .running || status.state == .completed)
+            #expect(status.completedSlots >= 0)
+        }
+    }
+
+    // Test 2: halt stops new slots from being enqueued
+    @Test("halt stops backfill from enqueuing new slots")
+    func haltStopsEnqueuing() async throws {
+        try await withTestEnvironment { client in
+            let now = Date()
+            let rangeEnd = now
+            let rangeStart = Calendar(identifier: .gregorian).date(byAdding: .hour, value: -10, to: now)!
+
+            let handle = try await client.createBackfill(
+                BackfillTestWorkflow.self,
+                input: "halt-test",
+                schedule: .interval(.hours(1)),
+                range: rangeStart..<rangeEnd,
+                options: BackfillOptions(concurrency: 1)
+            )
+
+            // Immediately halt before the scheduler runs
+            try await handle.halt()
+
+            let statusAfterHalt = try await handle.status()
+            #expect(statusAfterHalt.state == .halted)
+        }
+    }
+
+    // Test 3: BackfillStatus PostgresCodable round-trip
+    @Test("BackfillStatus encodes and decodes via PostgresCodable")
+    func backfillStatusPostgresCodable() async throws {
+        try await withTestEnvironment { client in
+            let postgres = client.postgres
+            let logger = client.logger
+
+            // Create a minimal backfill row so we can read it back
+            let now = Date()
+            let range = Calendar(identifier: .gregorian).date(byAdding: .hour, value: -2, to: now)!..<now
+            let handle = try await client.createBackfill(
+                BackfillTestWorkflow.self,
+                input: "codable-test",
+                schedule: .interval(.hours(1)),
+                range: range,
+                options: BackfillOptions()
+            )
+
+            // Read the status column directly as BackfillStatus via PostgresCodable
+            let stream = try await postgres.query(
+                "SELECT status FROM strand.backfills WHERE id = \(handle.id)",
+                logger: logger
+            )
+            var decoded: BackfillQueries.BackfillStatus? = nil
+            for try await row in stream {
+                var col = row.makeIterator()
+                decoded = try col.next()!.decode(
+                    BackfillQueries.BackfillStatus.self,
+                    context: .default
+                )
+            }
+            #expect(decoded == .running)
+
+            // Halt and verify the column value changes
+            try await handle.halt()
+            let stream2 = try await postgres.query(
+                "SELECT status FROM strand.backfills WHERE id = \(handle.id)",
+                logger: logger
+            )
+            var decodedAfterHalt: BackfillQueries.BackfillStatus? = nil
+            for try await row in stream2 {
+                var col = row.makeIterator()
+                decodedAfterHalt = try col.next()!.decode(
+                    BackfillQueries.BackfillStatus.self,
+                    context: .default
+                )
+            }
+            #expect(decodedAfterHalt == .halted)
+        }
+    }
+}

--- a/Tests/StrandTests/Schedule/PartitionOffsetTests.swift
+++ b/Tests/StrandTests/Schedule/PartitionOffsetTests.swift
@@ -62,7 +62,7 @@ struct PartitionOffsetCoreTests {
     @Test("Apply duration to date with calendar arithmetic")
     func testDurationApplicationWithCalendar() async throws {
         let baseDate = try #require(
-            Calendar.current.date(
+            Calendar(identifier: .gregorian).date(
                 from: DateComponents(
                     timeZone: TimeZone(identifier: "UTC"),
                     year: 2024,
@@ -77,7 +77,7 @@ struct PartitionOffsetCoreTests {
         // Test adding duration
         let duration = ISO8601Duration(days: 15, hours: 6, minutes: 30)
 
-        var calendar = Calendar.current
+        var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(identifier: "UTC")!
 
         let resultDate = duration.apply(to: baseDate, calendar: calendar)
@@ -101,7 +101,7 @@ struct PartitionOffsetCoreTests {
     @Test("Subtract duration from date with calendar arithmetic")
     func testDurationSubtractionWithCalendar() async throws {
         let baseDate = try #require(
-            Calendar.current.date(
+            Calendar(identifier: .gregorian).date(
                 from: DateComponents(
                     timeZone: TimeZone(identifier: "UTC"),
                     year: 2024,
@@ -116,7 +116,7 @@ struct PartitionOffsetCoreTests {
         // Test subtracting duration
         let duration = ISO8601Duration(days: 1, hours: 2)
 
-        var calendar = Calendar.current
+        var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(identifier: "UTC")!
 
         let resultDate = duration.subtract(from: baseDate, calendar: calendar)
@@ -295,7 +295,7 @@ struct PartitionOffsetCoreTests {
 
         // Execution time: 2025-07-29T02:00 (when the workflow actually runs)
         let executionTime = try #require(
-            Calendar.current.date(
+            Calendar(identifier: .gregorian).date(
                 from: DateComponents(
                     timeZone: TimeZone(identifier: "UTC"),
                     year: 2025,
@@ -309,7 +309,7 @@ struct PartitionOffsetCoreTests {
 
         // Data partition time should be: 2025-07-29T01:00 (the data period being processed)
         let expectedPartitionTime = try #require(
-            Calendar.current.date(
+            Calendar(identifier: .gregorian).date(
                 from: DateComponents(
                     timeZone: TimeZone(identifier: "UTC"),
                     year: 2025,
@@ -322,7 +322,7 @@ struct PartitionOffsetCoreTests {
         )
 
         // Apply the offset: execution time - PT1H = partition time
-        let partitionTime = config.offset.subtract(from: executionTime, calendar: Calendar.current)
+        let partitionTime = config.offset.subtract(from: executionTime, calendar: Calendar(identifier: .gregorian))
 
         #expect(partitionTime == expectedPartitionTime)
     }

--- a/Tests/StrandTests/Schedule/ScheduleCalculatorTests.swift
+++ b/Tests/StrandTests/Schedule/ScheduleCalculatorTests.swift
@@ -321,6 +321,60 @@ struct ScheduleCalculatorTests {
         #expect(offsetPartitionTime < partitionTime)  // Should be one day earlier
     }
 
+    // MARK: - countSlots
+
+    @Test("countSlots returns 0 for an empty range")
+    func countSlotsEmptyRange() {
+        let now = Date()
+        let count = ScheduleCalculator.countSlots(
+            for: .interval(.hours(1)),
+            in: now..<now
+        )
+        #expect(count == 0)
+    }
+
+    @Test("countSlots counts hourly slots across a 24-hour window")
+    func countSlotsHourly24h() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let start = cal.date(from: DateComponents(year: 2024, month: 6, day: 1, hour: 0))!
+        let end = cal.date(from: DateComponents(year: 2024, month: 6, day: 2, hour: 0))!
+        let count = ScheduleCalculator.countSlots(
+            for: .interval(.hours(1)),
+            in: start..<end
+        )
+        // 24 whole hours, start inclusive: 00:00, 01:00 … 23:00 = 24 slots
+        #expect(count == 24)
+    }
+
+    @Test("countSlots counts daily cron slots across a week")
+    func countSlotsDailyOneWeek() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let start = cal.date(from: DateComponents(year: 2024, month: 6, day: 1))!
+        let end = cal.date(from: DateComponents(year: 2024, month: 6, day: 8))!  // 7 days
+        let count = ScheduleCalculator.countSlots(
+            for: .cron("0 9 * * *", timezone: TimeZone(identifier: "UTC")!),
+            in: start..<end
+        )
+        #expect(count == 7)  // 7 × 09:00 UTC
+    }
+
+    @Test("countSlots respects cap parameter")
+    func countSlotsRespectsCap() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        // One year of hourly = 8760 slots; cap at 100
+        let start = cal.date(from: DateComponents(year: 2024, month: 1, day: 1))!
+        let end = cal.date(from: DateComponents(year: 2025, month: 1, day: 1))!
+        let count = ScheduleCalculator.countSlots(
+            for: .interval(.hours(1)),
+            in: start..<end,
+            cap: 100
+        )
+        #expect(count == 100)
+    }
+
     // MARK: - DST transition tests for N-day intervals
     //
     // N-day intervals must fire at the same wall-clock time regardless of DST transitions.

--- a/Tests/StrandTests/Schedule/ScheduleCalculatorTests.swift
+++ b/Tests/StrandTests/Schedule/ScheduleCalculatorTests.swift
@@ -320,4 +320,126 @@ struct ScheduleCalculatorTests {
         #expect(offsetPartitionTime != partitionTime)
         #expect(offsetPartitionTime < partitionTime)  // Should be one day earlier
     }
+
+    // MARK: - DST transition tests for N-day intervals
+    //
+    // N-day intervals must fire at the same wall-clock time regardless of DST transitions.
+    // Raw UTC-second arithmetic (seconds + N×86400) drifts by one hour:
+    //
+    //   Fall-back  (Nov 3, 2024 US): 7-day UTC gap = 25 h → naive next = 23:00 EST  (wrong)
+    //   Spring-forward (Mar 9, 2025 US): 7-day UTC gap = 23 h → naive next = 01:00 EDT (wrong)
+    //
+    // calendar.date(byAdding: .day, …) advances by calendar days in the timezone so
+    // the wall-clock time stays stable across both transitions.
+
+    /// Convenience: build a `Date` at midnight on `year-month-day` in `timeZone`.
+    private func midnight(
+        year: Int,
+        month: Int,
+        day: Int,
+        timeZone: TimeZone
+    ) -> Date {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = timeZone
+        return cal.date(
+            from: DateComponents(
+                year: year,
+                month: month,
+                day: day,
+                hour: 0,
+                minute: 0,
+                second: 0
+            )
+        )!
+    }
+
+    @Test("7-day interval: fall-back (2024-11-03 America/New_York) fires at local midnight, not 23:00")
+    func intervalSevenDayFallBack() throws {
+        let tz = TimeZone(identifier: "America/New_York")!
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = tz
+
+        // Fire from Sunday Oct 27 00:00 EDT (UTC-4) = Oct 27 04:00 UTC.
+        let oct27 = midnight(year: 2024, month: 10, day: 27, timeZone: tz)
+
+        let pattern = SchedulePattern.interval(.seconds(86400 * 7), timezone: tz)
+        let next = try #require(try pattern.nextRunTime(after: oct27))
+
+        // Expected: Nov 3 00:00 EST (UTC-5) = Nov 3 05:00 UTC.
+        // Raw arithmetic would give Nov 3 04:00 UTC = Nov 2 23:00 EST (one hour early).
+        let nov3 = midnight(year: 2024, month: 11, day: 3, timeZone: tz)
+        #expect(next == nov3)
+
+        // Verify in components so the failure message is human-readable.
+        let c = cal.dateComponents([.year, .month, .day, .hour, .minute], from: next)
+        #expect(c.year == 2024)
+        #expect(c.month == 11)
+        #expect(c.day == 3)
+        #expect(c.hour == 0)
+        #expect(c.minute == 0)
+    }
+
+    @Test("7-day interval: spring-forward (2025-03-09 America/New_York) fires at local midnight, not 01:00")
+    func intervalSevenDaySpringForward() throws {
+        let tz = TimeZone(identifier: "America/New_York")!
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = tz
+
+        // Fire from Sunday Mar 2 00:00 EST (UTC-5) = Mar 2 05:00 UTC.
+        let mar2 = midnight(year: 2025, month: 3, day: 2, timeZone: tz)
+
+        let pattern = SchedulePattern.interval(.seconds(86400 * 7), timezone: tz)
+        let next = try #require(try pattern.nextRunTime(after: mar2))
+
+        // Expected: Mar 9 00:00 EDT (UTC-4) = Mar 9 04:00 UTC.
+        // Raw arithmetic would give Mar 9 05:00 UTC = Mar 9 01:00 EDT (one hour late).
+        let mar9 = midnight(year: 2025, month: 3, day: 9, timeZone: tz)
+        #expect(next == mar9)
+
+        let c = cal.dateComponents([.year, .month, .day, .hour, .minute], from: next)
+        #expect(c.year == 2025)
+        #expect(c.month == 3)
+        #expect(c.day == 9)
+        #expect(c.hour == 0)
+        #expect(c.minute == 0)
+    }
+
+    @Test("1-day interval: fall-back regression — stays at local midnight after fix")
+    func intervalOneDayFallBack() throws {
+        let tz = TimeZone(identifier: "America/New_York")!
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = tz
+
+        let nov2 = midnight(year: 2024, month: 11, day: 2, timeZone: tz)
+        let pattern = SchedulePattern.interval(.seconds(86400), timezone: tz)
+        let next = try #require(try pattern.nextRunTime(after: nov2))
+
+        let nov3 = midnight(year: 2024, month: 11, day: 3, timeZone: tz)
+        #expect(next == nov3)
+
+        // Nov 3 midnight EST = 05:00 UTC, not 04:00 UTC (which would be Nov 2 23:00 EST).
+        let c = cal.dateComponents([.day, .hour], from: next)
+        #expect(c.day == 3)
+        #expect(c.hour == 0)
+    }
+
+    @Test("14-day interval: two-week cadence stays at local midnight across DST")
+    func intervalFourteenDayAcrossDST() throws {
+        let tz = TimeZone(identifier: "America/New_York")!
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = tz
+
+        // Oct 26, 2024 (two weeks before Nov 9 — safely past the Nov 3 fall-back)
+        let oct26 = midnight(year: 2024, month: 10, day: 26, timeZone: tz)
+        let pattern = SchedulePattern.interval(.seconds(86400 * 14), timezone: tz)
+        let next = try #require(try pattern.nextRunTime(after: oct26))
+
+        // Nov 9 00:00 EST (UTC-5) = Nov 9 05:00 UTC.
+        let nov9 = midnight(year: 2024, month: 11, day: 9, timeZone: tz)
+        #expect(next == nov9)
+
+        let c = cal.dateComponents([.day, .hour], from: next)
+        #expect(c.day == 9)
+        #expect(c.hour == 0)
+    }
 }

--- a/loom/src/api/backfills.ts
+++ b/loom/src/api/backfills.ts
@@ -1,0 +1,53 @@
+import { api } from "./client";
+
+export interface BackfillResponse {
+    id: string;
+    scheduleId: string | null;
+    queue: string;
+    taskName: string;
+    taskKind: string;
+    rangeStart: string;    // ISO 8601
+    rangeEnd: string;
+    concurrency: number;
+    allowOverwrite: boolean;
+    description: string | null;
+    status: "RUNNING" | "HALTED" | "COMPLETED" | "FAILED";
+    nextSlotTime: string;
+    totalSlots: number;
+    completedSlots: number;
+    createdAt: string;
+    completedAt: string | null;
+}
+
+export const createBackfill = (
+    namespace: string,
+    scheduleId: string,
+    body: {
+        rangeStart: string;
+        rangeEnd: string;
+        concurrency?: number;
+        allowOverwrite?: boolean;
+        description?: string;
+    }
+): Promise<BackfillResponse> =>
+    api.post<BackfillResponse>(
+        `/api/${namespace}/schedules/${scheduleId}/backfills`,
+        body
+    ).then(r => r.data);
+
+export const getBackfills = (
+    namespace: string,
+    scheduleId: string
+): Promise<BackfillResponse[]> =>
+    api.get<BackfillResponse[]>(
+        `/api/${namespace}/schedules/${scheduleId}/backfills`
+    ).then(r => r.data);
+
+export const haltBackfill = (namespace: string, id: string) =>
+    api.post(`/api/${namespace}/backfills/${id}/halt`).then(r => r.data);
+
+export const resumeBackfill = (namespace: string, id: string) =>
+    api.post(`/api/${namespace}/backfills/${id}/resume`).then(r => r.data);
+
+export const setBackfillConcurrency = (namespace: string, id: string, concurrency: number) =>
+    api.patch(`/api/${namespace}/backfills/${id}/concurrency`, { concurrency }).then(r => r.data);

--- a/loom/src/api/schedules.ts
+++ b/loom/src/api/schedules.ts
@@ -68,6 +68,18 @@ export interface UpcomingSlot {
     slot: string; // ISO 8601 UTC datetime
 }
 
+export const runSchedulePartition = (
+    namespace: string,
+    scheduleId: string,
+    body: { partitionTime: string; allowOverwrite?: boolean },
+): Promise<{ taskId: string; runId: string }> =>
+    api
+        .post<{
+            taskId: string;
+            runId: string;
+        }>(`/api/${namespace}/schedules/${encodeURIComponent(scheduleId)}/run`, body)
+        .then((r) => r.data);
+
 export const getScheduleUpcoming = (
     namespace: string,
     id: string,

--- a/loom/src/routes/schedules_/$scheduleId.tsx
+++ b/loom/src/routes/schedules_/$scheduleId.tsx
@@ -1,7 +1,8 @@
+import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { usePageTitle } from "@/lib/usePageTitle";
 import { Link, useParams, useNavigate } from "@tanstack/react-router";
-import { ArrowLeft, Trash2 } from "lucide-react";
+import { ArrowLeft, Trash2, RotateCcw } from "lucide-react";
 import {
     getSchedule,
     getScheduleRuns,
@@ -17,6 +18,55 @@ import { qk } from "@/lib/queryKeys";
 import { Button } from "@/components/ui/button";
 import { StatusBadge } from "@/components/ui/badge";
 import { RelativeTime } from "@/components/RelativeTime";
+import {
+    createBackfill,
+    getBackfills,
+    haltBackfill,
+    resumeBackfill,
+    type BackfillResponse,
+} from "@/api/backfills";
+import { runSchedulePartition } from "@/api/schedules";
+import { Play } from "lucide-react";
+
+// ── ISO 8601 helpers ──────────────────────────────────────────────────────────
+
+/** Placeholder / format hint for a given schedule pattern type.
+ *  Schedule Pattern: hourly → YYYY-MM-DDTHH, daily → YYYY-MM-DD, etc. */
+function isoPlaceholderFor(patternType: string): string {
+    switch (patternType.toLocaleLowerCase()) {
+        case "daily":
+        case "weekly":
+            return "2026-04-29";
+        case "monthly":
+            return "2026-05";
+        case "yearly":
+            return "2025";
+        default:
+            return "2026-05-12T15"; // interval / cron
+    }
+}
+
+/** Expands a partial ISO 8601 string to a full UTC ISO string that Date can parse.
+ *  "2025"          → "2025-01-01T00:00:00Z"
+ *  "2026-05"       → "2026-05-01T00:00:00Z"
+ *  "2026-04-29"    → "2026-04-29T00:00:00Z"
+ *  "2026-05-12T15" → "2026-05-12T15:00:00Z"
+ */
+function expandPartialISO(v: string): string {
+    const s = v.trim();
+    if (/^\d{4}$/.test(s)) return `${s}-01-01T00:00:00Z`;
+    if (/^\d{4}-\d{2}$/.test(s)) return `${s}-01T00:00:00Z`;
+    if (/^\d{4}-\d{2}-\d{2}$/.test(s)) return `${s}T00:00:00Z`;
+    if (/^\d{4}-\d{2}-\d{2}T\d{2}$/.test(s)) return `${s}:00:00Z`;
+    if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(s)) return `${s}:00Z`;
+    return s.includes("Z") || s.includes("+") ? s : `${s}Z`;
+}
+
+function parsePartialISO(v: string): Date | null {
+    if (!v.trim()) return null;
+    const d = new Date(expandPartialISO(v));
+    return isNaN(d.getTime()) ? null : d;
+}
 
 const TYPE_LABEL: Record<string, string> = {
     cron: "Cron",
@@ -63,6 +113,442 @@ function OptionalTime({ iso }: { iso: string | null }) {
             </span>
             <RelativeTime iso={iso} />
         </span>
+    );
+}
+
+// ── BackfillDialog ────────────────────────────────────────────────────────────
+
+function BackfillDialog({
+    open,
+    onClose,
+    namespace,
+    scheduleId,
+    patternType,
+    onCreated,
+}: {
+    open: boolean;
+    onClose: () => void;
+    namespace: string;
+    scheduleId: string;
+    patternType: string;
+    onCreated: () => void;
+}) {
+    const [rangeStart, setRangeStart] = useState("");
+    const [rangeEnd, setRangeEnd] = useState("");
+    const [concurrency, setConcurrency] = useState(1);
+    const [allowOverwrite, setAllowOverwrite] = useState(false);
+    const [description, setDescription] = useState("");
+    const [error, setError] = useState<string | null>(null);
+    const ph = isoPlaceholderFor(patternType);
+
+    const mutation = useMutation({
+        mutationFn: () => {
+            const start = parsePartialISO(rangeStart);
+            const end = parsePartialISO(rangeEnd);
+            if (!start) {
+                setError("Invalid start — use ISO 8601 e.g. " + ph);
+                return Promise.reject();
+            }
+            if (!end) {
+                setError("Invalid end — use ISO 8601 e.g. " + ph);
+                return Promise.reject();
+            }
+            if (end <= start) {
+                setError("End must be after start");
+                return Promise.reject();
+            }
+            setError(null);
+            return createBackfill(namespace, scheduleId, {
+                rangeStart: start.toISOString(),
+                rangeEnd: end.toISOString(),
+                concurrency,
+                allowOverwrite,
+                description: description || undefined,
+            });
+        },
+        onSuccess: () => {
+            onClose();
+            onCreated();
+        },
+        onError: (e: unknown) => {
+            if (error) return; // already set inline
+            setError(
+                e instanceof Error ? e.message : "Failed to create backfill",
+            );
+        },
+    });
+
+    if (!open) return null;
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+            <div className="bg-card border border-border rounded-lg p-6 w-full max-w-md shadow-xl space-y-4">
+                <div>
+                    <h2 className="text-base font-semibold">Create Backfill</h2>
+                    <p className="text-xs text-muted-foreground mt-1">
+                        Retroactively execute this schedule for a historical
+                        range. The scheduler drives slots — no worker
+                        concurrency consumed for orchestration.
+                    </p>
+                </div>
+
+                {/* Start */}
+                <div className="space-y-1">
+                    <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                        Start (inclusive)
+                    </label>
+                    <input
+                        autoFocus
+                        type="text"
+                        placeholder={ph}
+                        value={rangeStart}
+                        onChange={(e) => setRangeStart(e.target.value)}
+                        className="w-full rounded border border-border bg-secondary/20 px-3 py-1.5 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/40"
+                    />
+                    <p className="text-[10px] text-muted-foreground">
+                        ISO 8601 — e.g. {ph}
+                    </p>
+                </div>
+
+                {/* End */}
+                <div className="space-y-1">
+                    <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                        End (exclusive)
+                    </label>
+                    <input
+                        type="text"
+                        placeholder={ph}
+                        value={rangeEnd}
+                        onChange={(e) => setRangeEnd(e.target.value)}
+                        className="w-full rounded border border-border bg-secondary/20 px-3 py-1.5 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/40"
+                    />
+                    <p className="text-[10px] text-muted-foreground">
+                        ISO 8601 — e.g. {ph}
+                    </p>
+                </div>
+
+                {/* Concurrency */}
+                <div className="space-y-1">
+                    <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                        Concurrency
+                    </label>
+                    <input
+                        type="number"
+                        min={1}
+                        max={100}
+                        value={concurrency}
+                        onChange={(e) =>
+                            setConcurrency(
+                                Math.max(1, parseInt(e.target.value) || 1),
+                            )
+                        }
+                        className="w-full rounded border border-border bg-secondary/20 px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                    />
+                    <p className="text-[10px] text-muted-foreground">
+                        Max simultaneous slots. Does not affect normal scheduled
+                        executions.
+                    </p>
+                </div>
+
+                {/* Description */}
+                <div className="space-y-1">
+                    <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                        Description
+                    </label>
+                    <input
+                        type="text"
+                        placeholder="Why is this backfill being created?"
+                        value={description}
+                        onChange={(e) => setDescription(e.target.value)}
+                        className="w-full rounded border border-border bg-secondary/20 px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                    />
+                </div>
+
+                <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                        type="checkbox"
+                        checked={allowOverwrite}
+                        onChange={(e) => setAllowOverwrite(e.target.checked)}
+                        className="rounded"
+                    />
+                    <span className="text-xs text-muted-foreground">
+                        Allow overwrite — re-run slots that already completed
+                    </span>
+                </label>
+
+                {error && (
+                    <p className="text-xs text-red-400 bg-red-500/10 rounded px-3 py-2">
+                        {error}
+                    </p>
+                )}
+
+                <div className="flex justify-end gap-2 pt-1">
+                    <Button variant="outline" size="sm" onClick={onClose}>
+                        Cancel
+                    </Button>
+                    <Button
+                        size="sm"
+                        onClick={() => mutation.mutate()}
+                        disabled={
+                            !rangeStart.trim() ||
+                            !rangeEnd.trim() ||
+                            mutation.isPending
+                        }
+                    >
+                        {mutation.isPending ? "Creating…" : "Create backfill"}
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+// ── RunDialog — fire a single partition slot ──────────────────────────────────
+
+function RunDialog({
+    open,
+    onClose,
+    namespace,
+    scheduleId,
+    patternType,
+    onSuccess,
+}: {
+    open: boolean;
+    onClose: () => void;
+    namespace: string;
+    scheduleId: string;
+    patternType: string;
+    onSuccess: (taskId: string) => void;
+}) {
+    const [partitionTime, setPartitionTime] = useState("");
+    const [allowOverwrite, setAllowOverwrite] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const ph = isoPlaceholderFor(patternType);
+
+    const mutation = useMutation({
+        mutationFn: () => {
+            const pt = parsePartialISO(partitionTime);
+            if (!pt) {
+                setError("Invalid partition time — use ISO 8601 e.g. " + ph);
+                return Promise.reject();
+            }
+            setError(null);
+            return runSchedulePartition(namespace, scheduleId, {
+                partitionTime: pt.toISOString(),
+                allowOverwrite,
+            });
+        },
+        onSuccess: (data) => {
+            onClose();
+            onSuccess(data.taskId);
+        },
+        onError: (e: unknown) => {
+            if (error) return;
+            setError(e instanceof Error ? e.message : "Failed to trigger run");
+        },
+    });
+
+    if (!open) return null;
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+            <div className="bg-card border border-border rounded-lg p-6 w-full max-w-md shadow-xl space-y-4">
+                <div>
+                    <h2 className="text-base font-semibold">
+                        Run for partition
+                    </h2>
+                    <p className="text-xs text-muted-foreground mt-1">
+                        Fire a single execution for a specific historical
+                        partition. Uses the scheduler’s idempotency key —
+                        re-running an already-completed slot is blocked unless
+                        overwrite is enabled.
+                    </p>
+                </div>
+
+                <div className="space-y-1">
+                    <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                        Partition time
+                    </label>
+                    <input
+                        autoFocus
+                        type="text"
+                        placeholder={ph}
+                        value={partitionTime}
+                        onChange={(e) => setPartitionTime(e.target.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === "Enter") mutation.mutate();
+                        }}
+                        className="w-full rounded border border-border bg-secondary/20 px-3 py-1.5 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/40"
+                    />
+                    <p className="text-[10px] text-muted-foreground">
+                        ISO 8601 — e.g. {ph}
+                    </p>
+                </div>
+
+                <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                        type="checkbox"
+                        checked={allowOverwrite}
+                        onChange={(e) => setAllowOverwrite(e.target.checked)}
+                        className="rounded"
+                    />
+                    <span className="text-xs text-muted-foreground">
+                        Allow overwrite — re-run even if this partition already
+                        completed
+                    </span>
+                </label>
+
+                {error && (
+                    <p className="text-xs text-red-400 bg-red-500/10 rounded px-3 py-2">
+                        {error}
+                    </p>
+                )}
+
+                <div className="flex justify-end gap-2 pt-1">
+                    <Button variant="outline" size="sm" onClick={onClose}>
+                        Cancel
+                    </Button>
+                    <Button
+                        size="sm"
+                        onClick={() => mutation.mutate()}
+                        disabled={!partitionTime.trim() || mutation.isPending}
+                    >
+                        {mutation.isPending ? "Running…" : "Run"}
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function BackfillList({
+    namespace,
+    scheduleId,
+}: {
+    namespace: string;
+    scheduleId: string;
+}) {
+    const qc = useQueryClient();
+    const { data: backfills = [] } = useQuery({
+        queryKey: ["backfills", namespace, scheduleId],
+        queryFn: () => getBackfills(namespace, scheduleId),
+        refetchInterval: 5_000,
+    });
+
+    const haltMut = useMutation({
+        mutationFn: (id: string) => haltBackfill(namespace, id),
+        onSuccess: () =>
+            void qc.invalidateQueries({
+                queryKey: ["backfills", namespace, scheduleId],
+            }),
+    });
+    const resumeMut = useMutation({
+        mutationFn: (id: string) => resumeBackfill(namespace, id),
+        onSuccess: () =>
+            void qc.invalidateQueries({
+                queryKey: ["backfills", namespace, scheduleId],
+            }),
+    });
+
+    if (backfills.length === 0)
+        return (
+            <p className="text-xs text-muted-foreground italic">
+                No backfills yet.
+            </p>
+        );
+
+    return (
+        <div className="space-y-2">
+            {backfills.map((b: BackfillResponse) => {
+                const pct =
+                    b.totalSlots > 0
+                        ? Math.round((b.completedSlots / b.totalSlots) * 100)
+                        : 0;
+                const statusColor =
+                    b.status === "COMPLETED"
+                        ? "text-green-400"
+                        : b.status === "FAILED"
+                          ? "text-red-400"
+                          : b.status === "HALTED"
+                            ? "text-amber-400"
+                            : "text-blue-400";
+                return (
+                    <div
+                        key={b.id}
+                        className="rounded-lg border border-border/40 bg-secondary/10 px-4 py-3 space-y-2"
+                    >
+                        <div className="flex items-start justify-between gap-2">
+                            <div className="space-y-0.5 min-w-0">
+                                <p className="text-xs font-mono text-muted-foreground truncate">
+                                    {b.id}
+                                </p>
+                                {b.description && (
+                                    <p className="text-xs text-foreground/70">
+                                        {b.description}
+                                    </p>
+                                )}
+                                <p className="text-[10px] text-muted-foreground">
+                                    {new Date(b.rangeStart)
+                                        .toISOString()
+                                        .slice(0, 16)}{" "}
+                                    →{" "}
+                                    {new Date(b.rangeEnd)
+                                        .toISOString()
+                                        .slice(0, 16)}
+                                    {" · "}concurrency {b.concurrency}
+                                    {b.allowOverwrite && " · overwrite"}
+                                </p>
+                            </div>
+                            <span
+                                className={`text-xs font-medium shrink-0 ${statusColor}`}
+                            >
+                                {b.status}
+                            </span>
+                        </div>
+
+                        {/* Progress bar */}
+                        {b.totalSlots > 0 && (
+                            <div className="space-y-1">
+                                <div className="h-1.5 rounded-full bg-secondary/40 overflow-hidden">
+                                    <div
+                                        className="h-full rounded-full bg-blue-500 transition-all"
+                                        style={{ width: `${pct}%` }}
+                                    />
+                                </div>
+                                <p className="text-[10px] text-muted-foreground">
+                                    {b.completedSlots} / {b.totalSlots} slots (
+                                    {pct}%)
+                                </p>
+                            </div>
+                        )}
+
+                        {/* Actions */}
+                        <div className="flex gap-1.5">
+                            {b.status === "RUNNING" && (
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => haltMut.mutate(b.id)}
+                                    disabled={haltMut.isPending}
+                                    className="h-6 text-[10px] px-2"
+                                >
+                                    Halt
+                                </Button>
+                            )}
+                            {b.status === "HALTED" && (
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => resumeMut.mutate(b.id)}
+                                    disabled={resumeMut.isPending}
+                                    className="h-6 text-[10px] px-2"
+                                >
+                                    Resume
+                                </Button>
+                            )}
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
     );
 }
 
@@ -135,6 +621,9 @@ export function ScheduleDetailPage() {
         },
     });
 
+    const [backfillOpen, setBackfillOpen] = useState(false);
+    const [runOpen, setRunOpen] = useState(false);
+
     return (
         <div className="px-6 py-5">
             {/* Back link */}
@@ -200,6 +689,20 @@ export function ScheduleDetailPage() {
                                     Resume
                                 </Button>
                             )}
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => setRunOpen(true)}
+                            >
+                                <Play size={13} /> Run
+                            </Button>
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => setBackfillOpen(true)}
+                            >
+                                <RotateCcw size={13} /> Backfill
+                            </Button>
                             <Button
                                 variant="destructive"
                                 size="sm"
@@ -300,6 +803,17 @@ export function ScheduleDetailPage() {
                         </section>
                     )}
 
+                    {/* Backfills */}
+                    <section className="rounded-lg border border-border bg-card/40 p-4">
+                        <h2 className="text-[10px] uppercase tracking-wide font-medium text-muted-foreground mb-2">
+                            Backfills
+                        </h2>
+                        <BackfillList
+                            namespace={namespace}
+                            scheduleId={scheduleId}
+                        />
+                    </section>
+
                     {/* Recent Runs */}
                     <section className="rounded-lg border border-border bg-card/40 overflow-hidden">
                         <div className="px-4 py-3 border-b border-border/50">
@@ -385,6 +899,32 @@ export function ScheduleDetailPage() {
                     </section>
                 </div>
             )}
+
+            <RunDialog
+                open={runOpen}
+                onClose={() => setRunOpen(false)}
+                namespace={namespace}
+                scheduleId={scheduleId}
+                patternType={schedule?.patternType ?? "cron"}
+                onSuccess={(taskId) =>
+                    void navigate({
+                        to: "/$namespace/tasks/$taskId",
+                        params: { namespace, taskId },
+                    })
+                }
+            />
+            <BackfillDialog
+                open={backfillOpen}
+                onClose={() => setBackfillOpen(false)}
+                namespace={namespace}
+                scheduleId={scheduleId}
+                patternType={schedule?.patternType ?? "cron"}
+                onCreated={() =>
+                    void qc.invalidateQueries({
+                        queryKey: ["backfills", namespace, scheduleId],
+                    })
+                }
+            />
         </div>
     );
 }

--- a/strand.sql
+++ b/strand.sql
@@ -96,6 +96,7 @@ CREATE TABLE IF NOT EXISTS strand.tasks (
     -- claimTasks skips tasks past this deadline so workers never start doomed work.
     deadline_at  TIMESTAMPTZ,
     result       BYTEA,                  -- JSON-encoded success payload
+    backfill_id  UUID,                  -- set when fired by StrandScheduler.processBackfills; FK added below
 
     CONSTRAINT strand_tasks_pkey            PRIMARY KEY (id),
     -- FK to strand.queues: tasks are always in a registered queue.
@@ -345,6 +346,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS strand_event_triggers_emission_task_idx
 
 -- ALTER TABLE strand.runs ADD COLUMN IF NOT EXISTS heartbeat_details BYTEA;
 -- ALTER TABLE strand.tasks ADD COLUMN IF NOT EXISTS heartbeat_timeout_seconds INTEGER;
+-- ALTER TABLE strand.tasks ADD COLUMN IF NOT EXISTS backfill_id UUID REFERENCES strand.backfills(id) ON DELETE SET NULL;
+-- ALTER TABLE strand.backfills ADD COLUMN IF NOT EXISTS schedule_id UUID REFERENCES strand.schedules(id) ON DELETE SET NULL;
 
 -- Migration for existing databases:
 -- ALTER TABLE strand.events DROP CONSTRAINT strand_events_pkey;
@@ -517,6 +520,58 @@ CREATE TABLE IF NOT EXISTS strand.schedules (
 CREATE INDEX IF NOT EXISTS strand_schedules_due_idx
     ON strand.schedules (namespace_id, next_run_at)
     WHERE is_active = TRUE AND next_run_at IS NOT NULL;
+
+-- ───────────────────────────────────────────────────────────────────────────────
+-- Backfills — retroactive scheduled execution over a historical time range.
+--
+-- One row per backfill request. `StrandScheduler.processBackfills()` polls
+-- RUNNING rows each cycle and enqueues up to `concurrency` slots at a time.
+-- Each enqueued task carries `backfill_id` so the dashboard can list all
+-- tasks that belong to a given backfill.
+-- ───────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS strand.backfills (
+    id               UUID        NOT NULL,
+    namespace_id     TEXT        NOT NULL REFERENCES strand.namespaces(id),
+    queue            TEXT        NOT NULL,
+    task_name        TEXT        NOT NULL,
+    task_kind        TEXT        NOT NULL DEFAULT 'WORKFLOW',
+    params           BYTEA       NOT NULL,
+    headers          BYTEA,
+    retry_strategy   BYTEA,
+    max_attempts     INTEGER,
+    schedule_pattern BYTEA       NOT NULL,   -- JSON-encoded SchedulePattern
+    range_start      TIMESTAMPTZ NOT NULL,   -- inclusive
+    range_end        TIMESTAMPTZ NOT NULL,   -- exclusive
+    concurrency      INTEGER     NOT NULL DEFAULT 1,
+    allow_overwrite  BOOLEAN     NOT NULL DEFAULT false,
+    description      TEXT,
+    schedule_id      UUID        REFERENCES strand.schedules(id) ON DELETE SET NULL,
+    status           TEXT        NOT NULL DEFAULT 'RUNNING',
+    next_slot_time   TIMESTAMPTZ NOT NULL,   -- cursor: next slot to fire
+    total_slots      INTEGER     NOT NULL DEFAULT 0,
+    completed_slots  INTEGER     NOT NULL DEFAULT 0,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at     TIMESTAMPTZ,
+    CONSTRAINT strand_backfills_pkey   PRIMARY KEY (id),
+    CONSTRAINT strand_backfills_kind   CHECK (task_kind IN ('WORKFLOW', 'ACTIVITY')),
+    CONSTRAINT strand_backfills_status CHECK (status IN ('RUNNING', 'HALTED', 'COMPLETED', 'FAILED')),
+    CONSTRAINT strand_backfills_conc   CHECK (concurrency >= 1)
+);
+
+-- StrandScheduler polls this index each cycle.
+CREATE INDEX IF NOT EXISTS strand_backfills_running_idx
+    ON strand.backfills (namespace_id, status)
+    WHERE status = 'RUNNING';
+
+-- Now that strand.backfills exists, add the FK from strand.tasks.
+ALTER TABLE strand.tasks
+    ADD CONSTRAINT strand_tasks_backfill_fk
+    FOREIGN KEY (backfill_id) REFERENCES strand.backfills(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS strand_tasks_backfill_idx
+    ON strand.tasks (backfill_id)
+    WHERE backfill_id IS NOT NULL;
 
 -- ───────────────────────────────────────────────────────────────────────────────
 -- Workers — ephemeral runtime heartbeat table.


### PR DESCRIPTION
## Summary

Schedule backfill, re-run a schedule for a given date and fixed an issue that could cause schedules to drift during DST

## Changes

- Backfill support
- Re-run a schedule slot
- Fixed schedule drift during DST
- Added UI for re-run schedule 
- Added UI for backfill

## Testing

<!-- How did you verify this works? Did you run `swift test`? -->

- [x] `swift test` passes locally

## AI Disclosure

<!--
  REQUIRED if any AI assistance was used — see CONTRIBUTING.md.
  Delete this section entirely if no AI was involved.
-->

- [ ] I used AI assistance while working on this PR

**Tool(s) used:** <!-- e.g. Claude, Copilot, ChatGPT -->

**Extent of use:**
<!-- Describe honestly. Examples:
  - Generated first draft of WorkflowDag.tsx, reviewed and edited manually.
  - Used for commit message suggestions only.
  - Pair-programmed the entire feature; all output was reviewed.
-->

**Was the PR description itself AI-generated?** No
