### PR TITLE
Use Double for fairnessWeight; reset child tasks

### DIFF
--- a/Sources/Strand/Activity.swift
+++ b/Sources/Strand/Activity.swift
@@ -81,7 +81,7 @@ public struct ActivityOptions: Sendable {
 
     /// Relative throughput weight for this fairness key. Default `1.0`.
     /// A key with weight `5.0` is dispatched ~5× more often than `1.0`.
-    public var fairnessWeight: Float
+    public var fairnessWeight: Double
 
     /// Key-value metadata forwarded with the activity task (e.g. trace IDs).
     public var headers: [String: String]
@@ -104,7 +104,7 @@ public struct ActivityOptions: Sendable {
         priority: TaskPriority = .normal,
         delayUntil: Date? = nil,
         fairnessKey: String? = nil,
-        fairnessWeight: Float = 1.0,
+        fairnessWeight: Double = 1.0,
         headers: [String: String] = [:],
         idempotencyKey: String? = nil,
         cancellation: CancellationPolicy? = nil

--- a/Sources/Strand/Client.swift
+++ b/Sources/Strand/Client.swift
@@ -381,7 +381,7 @@ public struct StrandClient: Sendable {
         maxDuration: Duration? = nil,
         heartbeatTimeoutSeconds: Int? = nil,
         fairnessKey: String? = nil,
-        fairnessWeight: Float = 1.0,
+        fairnessWeight: Double = 1.0,
         kind: TaskKind = .workflow,
         parentTaskID: UUID? = nil
     ) async throws -> EnqueueResult {
@@ -574,7 +574,25 @@ public struct StrandClient: Sendable {
                 createdAt: Date.now
             )
         default:
-            // FAILED, CANCELLED, or any other terminal state — same task, next attempt.
+            // FAILED, CANCELLED, or any other terminal state.
+            //
+            // Step 1: reset descendant tasks based on the retry mode.
+            //   - failedOnly           -> descendants in FAILED/CANCELLED state
+            //   - failedAndDependents  -> above + temporally later descendants
+            //   - all                  -> every descendant regardless of state
+            // Deletes their task_completions rows and creates fresh PENDING runs so
+            // the parent's next activation re-runs them instead of replaying cached
+            // failures. Safe no-op when the selected task has no descendants
+            // (e.g. a plain activity).
+            try await Queries.resetChildTasks(
+                on: postgres,
+                rootTaskID: taskID,
+                namespaceID: ns,
+                mode: options.mode,
+                resetHistory: options.resetHistory,
+                logger: logger
+            )
+            // Step 2: retry the root task itself.
             let (runID, attempt) = try await Queries.retryTask(
                 on: postgres,
                 namespaceID: ns,

--- a/Sources/Strand/DB/ManagementQueries.swift
+++ b/Sources/Strand/DB/ManagementQueries.swift
@@ -258,6 +258,7 @@ package enum ManagementQueries {
     package static func listQueueStats(
         on client: PostgresClient,
         namespaceID: String,
+        rootOnly: Bool = false,
         logger: Logger
     ) async throws -> [QueueStatsRow] {
         let stream = try await client.query(
@@ -274,7 +275,11 @@ package enum ManagementQueries {
               COUNT(t.id) FILTER (WHERE t.state = 'CANCELLED')  AS cancelled,
               q.is_paused
             FROM strand.queues q
-            LEFT JOIN strand.tasks t ON t.queue = q.name AND t.namespace_id = q.namespace_id
+            -- When rootOnly=true, only join root tasks (parent_task_id IS NULL)
+            -- so the stats bar counts the same population as the task list.
+            LEFT JOIN strand.tasks t ON t.queue = q.name
+                                    AND t.namespace_id = q.namespace_id
+                                    AND (NOT \(rootOnly) OR t.parent_task_id IS NULL)
             WHERE q.namespace_id = \(namespaceID)
             GROUP BY q.name, q.created_at, q.is_paused
             ORDER BY q.name
@@ -291,6 +296,7 @@ package enum ManagementQueries {
         on client: PostgresClient,
         namespaceID: String,
         queue: String,
+        rootOnly: Bool = false,
         logger: Logger
     ) async throws -> QueueStatsRow? {
         let stream = try await client.query(
@@ -307,7 +313,11 @@ package enum ManagementQueries {
               COUNT(t.id) FILTER (WHERE t.state = 'CANCELLED')  AS cancelled,
               q.is_paused
             FROM strand.queues q
-            LEFT JOIN strand.tasks t ON t.queue = q.name AND t.namespace_id = q.namespace_id
+            -- When rootOnly=true, only join root tasks (parent_task_id IS NULL)
+            -- so the stats bar counts the same population as the task list.
+            LEFT JOIN strand.tasks t ON t.queue = q.name
+                                    AND t.namespace_id = q.namespace_id
+                                    AND (NOT \(rootOnly) OR t.parent_task_id IS NULL)
             WHERE q.name = \(queue) AND q.namespace_id = \(namespaceID)
             GROUP BY q.name, q.created_at, q.is_paused
             """,

--- a/Sources/Strand/DB/Queries.swift
+++ b/Sources/Strand/DB/Queries.swift
@@ -160,7 +160,7 @@ enum Queries {
         heartbeatTimeoutSeconds: Int? = nil,
         deadlineAt: Date? = nil,
         fairnessKey: String? = nil,
-        fairnessWeight: Float = 1.0,
+        fairnessWeight: Double = 1.0,
         kind: TaskKind = .workflow,
         parentTaskID: UUID? = nil,
         backfillID: UUID? = nil,
@@ -265,7 +265,7 @@ enum Queries {
         let heartbeatTimeoutSeconds: Int?
         let deadlineAt: Date?
         let fairnessKey: String?
-        let fairnessWeight: Float
+        let fairnessWeight: Double
         let kind: TaskKind  // .activity or .workflow
     }
 
@@ -1714,6 +1714,75 @@ enum Queries {
 
     // MARK: - continueAsNew for child workflows
 
+    /// Deletes transient workflow artefacts for `taskID` so a fresh activation
+    /// starts from a clean state.
+    ///
+    /// Called inside an existing transaction by
+    /// ``retryTask(on:namespaceID:taskID:resetHistory:logger:)`` when
+    /// `resetHistory` is `true`. All retry modes operate on FAILED or CANCELLED
+    /// tasks, which have no outstanding `event_waits` by construction, so this
+    /// function never needs to touch that table.
+    ///
+    /// ``continueChildWorkflowAsNew(on:namespaceID:taskID:currentRunID:currentVersion:newInput:newRunID:logger:)``
+    /// performs the same deletions inline as named CTE arms (plus `event_waits`,
+    /// which is required for a still-RUNNING task) to keep that operation a
+    /// **single round-trip**. If you add a table here, mirror it there.
+    ///
+    /// - Parameter clearHistory: Pass `true` when the caller wants a full
+    ///   clean-slate reset. Deletes `workflow_history` so `nextHistorySeq`
+    ///   resets to 1 and `WORKFLOW_STARTED` is re-emitted on the new activation.
+    ///   Pass `false` for `continueAsNew`-style resets that intentionally
+    ///   preserve the accumulated history across continuation cycles.
+    static func clearWorkflowArtefacts(
+        on conn: PostgresConnection,
+        taskID: UUID,
+        namespaceID: String,
+        clearHistory: Bool,
+        logger: Logger
+    ) async throws {
+        // Checkpoints — isolated from the new run by run_id in SELECT, but the
+        // old rows still appear in the Loom dashboard for the old failed run.
+        try await conn.query(
+            "DELETE FROM strand.checkpoints WHERE task_id = \(taskID) AND namespace_id = \(namespaceID)",
+            logger: logger
+        )
+        // Workflow state — keyed by task_id only; without this delete the fresh
+        // _activate path restores stale signal-mutated fields (isPaused=true etc.)
+        // instead of starting from W().
+        try await conn.query(
+            "DELETE FROM strand.workflow_state WHERE task_id = \(taskID) AND namespace_id = \(namespaceID)",
+            logger: logger
+        )
+        // Pending signals — stale signals queued before the failure must not
+        // replay against the fresh W() state of the reset run.
+        try await conn.query(
+            "DELETE FROM strand.workflow_signals WHERE task_id = \(taskID) AND namespace_id = \(namespaceID)",
+            logger: logger
+        )
+        if clearHistory {
+            // nextHistorySeq() uses MAX(seq); without this delete the new activation
+            // inherits the old sequence number and isFirstActivation stays false
+            // (WORKFLOW_STARTED is never re-emitted on the reset run).
+            try await conn.query(
+                "DELETE FROM strand.workflow_history WHERE task_id = \(taskID) AND namespace_id = \(namespaceID)",
+                logger: logger
+            )
+            // Delete all terminal run records so the Runs panel shows a clean
+            // slate. The newly-inserted PENDING run (created by retryTask before
+            // this call) has state = 'PENDING' and is NOT matched by this DELETE.
+            // PostgreSQL CTE isolation guarantees the same for resetChildTasks.
+            try await conn.query(
+                """
+                DELETE FROM strand.runs
+                WHERE  task_id      = \(taskID)
+                  AND  namespace_id = \(namespaceID)
+                  AND  state NOT IN ('PENDING', 'RUNNING', 'SLEEPING', 'WAITING')
+                """,
+                logger: logger
+            )
+        }
+    }
+
     /// Resets a **child** workflow for continuation-as-new without signalling its parent.
     ///
     /// When `context.continueAsNew(input:)` is called inside a child workflow
@@ -1735,6 +1804,7 @@ enum Queries {
     /// The entire operation is one atomic CTE. If the CAS check
     /// (`state = RUNNING AND version = currentVersion`) fails (race / duplicate),
     /// all CTEs are no-ops — safe under concurrent execution.
+    ///
     static func continueChildWorkflowAsNew(
         on client: PostgresClient,
         namespaceID: String,
@@ -1764,6 +1834,10 @@ enum Queries {
                   AND namespace_id = \(namespaceID)
                 RETURNING id, queue, priority, fairness_key, fairness_weight, kind
             ),
+            -- These DELETE arms mirror clearWorkflowArtefacts(clearHistory: false)
+            -- plus del_event_waits (required here; FAILED tasks never have waits).
+            -- Both are inlined to keep this a single round-trip.
+            -- If you add a table to clearWorkflowArtefacts, add a matching arm here.
             del_checkpoints AS (
                 DELETE FROM strand.checkpoints
                 WHERE task_id      = (SELECT task_id FROM complete_run)
@@ -1800,6 +1874,171 @@ enum Queries {
             """,
             logger: logger
         )
+    }
+
+    // MARK: - resetChildTasks
+
+    /// Resets descendant tasks of `rootTaskID` to PENDING based on the retry mode,
+    /// then notifies workers on affected queues.
+    ///
+    /// Called from ``StrandClient/requeueTask(id:options:namespaceID:)`` **before**
+    /// ``retryTask(on:namespaceID:taskID:resetHistory:logger:)`` so the parent
+    /// workflow's next activation finds fresh child slots instead of replaying old
+    /// results from `task_completions`.
+    ///
+    /// | Mode                    | Descendants reset                                |
+    /// |-------------------------|--------------------------------------------------|
+    /// | `.failedOnly`           | FAILED and CANCELLED only                        |
+    /// | `.failedAndDependents`  | FAILED/CANCELLED + any created at or after the   |
+    /// |                         | earliest failure (even if they succeeded)         |
+    /// | `.all`                  | Every descendant regardless of state             |
+    ///
+    /// For each selected descendant the function:
+    /// 1. Deletes its `task_completions` row — the parent must not fast-path these
+    ///    on its next activation.
+    /// 2. Updates `strand.tasks` to PENDING (bumps or resets `attempt` based on
+    ///    `resetHistory`).
+    /// 3. Inserts a fresh PENDING run.
+    ///
+    /// Returns immediately when there are no descendants — safe to call for plain
+    /// activity tasks.
+    ///
+    /// Run IDs are generated by `strand.gen_uuid_v7()` inside the CTE, keeping the
+    /// entire operation a single round-trip while still producing time-ordered UUIDs.
+    static func resetChildTasks(
+        on client: PostgresClient,
+        rootTaskID: UUID,
+        namespaceID: String,
+        mode: RetryOptions.Mode,
+        resetHistory: Bool,
+        logger: Logger
+    ) async throws {
+        try await client.withTransaction(logger: logger) { conn in
+            try await resetChildTasks(
+                on: conn,
+                rootTaskID: rootTaskID,
+                namespaceID: namespaceID,
+                mode: mode,
+                resetHistory: resetHistory,
+                logger: logger
+            )
+        }
+    }
+
+    static func resetChildTasks(
+        on conn: PostgresConnection,
+        rootTaskID: UUID,
+        namespaceID: String,
+        mode: RetryOptions.Mode,
+        resetHistory: Bool,
+        logger: Logger
+    ) async throws {
+        let modeRaw = mode.rawValue
+        let stream = try await conn.query(
+            """
+            WITH RECURSIVE
+            all_desc AS (
+                -- Direct children of rootTaskID
+                SELECT id, state, queue, priority, fairness_key, fairness_weight,
+                       attempt, max_attempts, kind, parent_task_id, created_at
+                FROM   strand.tasks
+                WHERE  parent_task_id = \(rootTaskID)
+                  AND  namespace_id   = \(namespaceID)
+                UNION ALL
+                -- Grandchildren and deeper
+                SELECT t.id, t.state, t.queue, t.priority, t.fairness_key, t.fairness_weight,
+                       t.attempt, t.max_attempts, t.kind, t.parent_task_id, t.created_at
+                FROM   strand.tasks t
+                JOIN   all_desc d ON t.parent_task_id = d.id
+            ),
+            -- Earliest point of failure; NULL when there are no failures.
+            earliest_fail_at AS (
+                SELECT MIN(created_at) AS t
+                FROM   all_desc
+                WHERE  state IN ('FAILED', 'CANCELLED')
+            ),
+            -- Which descendants to reset:
+            --   'all'                   -> every descendant
+            --   'failed_only'           -> FAILED / CANCELLED only
+            --   'failed_and_dependents' -> FAILED / CANCELLED + any that were
+            --                             created at or after the earliest failure
+            to_reset AS (
+                SELECT * FROM all_desc
+                WHERE  \(modeRaw) = 'all'
+                    OR state IN ('FAILED', 'CANCELLED')
+                    OR (    \(modeRaw) = 'failed_and_dependents'
+                        AND created_at >= COALESCE(
+                                (SELECT t FROM earliest_fail_at),
+                                'infinity'::timestamptz))
+            ),
+            -- 1. Remove old completion records so the parent workflow does not
+            --    fast-path these children via task_completions on its next activation.
+            del_completions AS (
+                DELETE FROM strand.task_completions
+                WHERE  task_id      IN (SELECT id FROM to_reset)
+                  AND  namespace_id  = \(namespaceID)
+            ),
+            -- 2. Advance the task state and attempt counter.
+            upd_tasks AS (
+                UPDATE strand.tasks t
+                SET    state        = 'PENDING',
+                       attempt      = CASE WHEN \(resetHistory) THEN 1
+                                          ELSE t.attempt + 1
+                                     END,
+                       max_attempts = CASE WHEN \(resetHistory) THEN t.max_attempts
+                                          ELSE GREATEST(
+                                                  COALESCE(t.max_attempts, t.attempt + 1),
+                                                  t.attempt + 1)
+                                     END
+                FROM   to_reset tr
+                WHERE  t.id = tr.id
+            ),
+            -- 3. One fresh PENDING run per reset task.
+            --    strand.gen_uuid_v7() produces time-ordered UUIDs without a
+            --    separate Swift round-trip (requires pgcrypto).
+            new_runs AS (
+                INSERT INTO strand.runs
+                    (namespace_id, id, task_id, queue, attempt, state,
+                     available_at, priority, fairness_key, fairness_weight,
+                     kind, parent_task_id)
+                SELECT \(namespaceID),
+                       strand.gen_uuid_v7(),
+                       tr.id,
+                       tr.queue,
+                       CASE WHEN \(resetHistory) THEN 1 ELSE tr.attempt + 1 END,
+                       'PENDING',
+                       NOW(),
+                       tr.priority,
+                       tr.fairness_key,
+                       tr.fairness_weight,
+                       tr.kind,
+                       tr.parent_task_id
+                FROM   to_reset tr
+                RETURNING queue
+            ),
+            -- 4. When resetting history, remove all terminal run records for
+            --    the selected child tasks so their Runs panels also show a
+            --    clean slate. PostgreSQL CTE snapshot isolation ensures the
+            --    newly-inserted PENDING rows (from new_runs above) are not
+            --    visible to this DELETE — they did not exist at statement start.
+            del_old_runs AS (
+                DELETE FROM strand.runs
+                WHERE  task_id      IN (SELECT id FROM to_reset)
+                  AND  namespace_id  = \(namespaceID)
+                  AND  state        NOT IN ('PENDING', 'RUNNING', 'SLEEPING', 'WAITING')
+                  AND  \(resetHistory)
+            )
+            SELECT DISTINCT queue FROM new_runs
+            """,
+            logger: logger
+        )
+        var notified: Set<String> = []
+        for try await row in stream {
+            var col = row.makeIterator()
+            let queue = try col.next()!.decode(String.self, context: .default)
+            guard notified.insert(queue).inserted else { continue }
+            try await conn.notifyWorkers(namespace: namespaceID, queue: queue, logger: logger)
+        }
     }
 
     // MARK: - Retry
@@ -1876,13 +2115,22 @@ enum Queries {
                 logger: logger
             )
             if resetHistory {
-                // Clear failure_reason on all prior FAILED/CANCELLED runs for a clean slate.
+                // Clear failure_reason on prior runs so the dashboard shows a clean slate.
                 try await conn.query(
                     """
                     UPDATE strand.runs
                     SET failure_reason = NULL
                     WHERE task_id = \(taskID) AND state IN (\(TaskState.failed), \(TaskState.cancelled))
                     """,
+                    logger: logger
+                )
+                // Delete checkpoints, workflow state, pending signals, and history.
+                // clearHistory=true so nextHistorySeq resets to 1 on the new activation.
+                try await clearWorkflowArtefacts(
+                    on: conn,
+                    taskID: taskID,
+                    namespaceID: namespaceID,
+                    clearHistory: true,
                     logger: logger
                 )
             }
@@ -1938,7 +2186,7 @@ enum Queries {
             let cancellation = try col.next()!.decode(ByteBuffer?.self, context: .default)
             let priority = try col.next()!.decode(TaskPriority.self, context: .default)
             let fairnessKey = try col.next()!.decode(String?.self, context: .default)
-            let fairnessWeight = try col.next()!.decode(Float.self, context: .default)
+            let fairnessWeight = try col.next()!.decode(Double.self, context: .default)
             let kind = try col.next()!.decode(TaskKind.self, context: .default)
 
             let newTaskID = UUID.v7()

--- a/Sources/Strand/Enqueue.swift
+++ b/Sources/Strand/Enqueue.swift
@@ -76,7 +76,7 @@ public struct EnqueueOptions: Sendable {
     /// Relative throughput weight for this fairness key. Default `1.0`.
     /// A key with weight `5.0` is dispatched approximately 5× more often than a key with `1.0`.
     /// Only meaningful when multiple keys share the same queue and priority level.
-    public var fairnessWeight: Float
+    public var fairnessWeight: Double
 
     public init(
         queue: String? = nil,
@@ -89,7 +89,7 @@ public struct EnqueueOptions: Sendable {
         delayUntil: Date? = nil,
         maxDuration: Duration? = nil,
         fairnessKey: String? = nil,
-        fairnessWeight: Float = 1.0
+        fairnessWeight: Double = 1.0
     ) {
         self.queue = queue
         self.maxAttempts = maxAttempts
@@ -373,29 +373,50 @@ public struct AwaitEventOptions: Sendable {
 
 /// Options controlling how a failed or cancelled task is retried.
 public struct RetryOptions: Codable, Sendable {
-    /// Which tasks to include in the retry.
+    /// Determines which descendant tasks are reset alongside the selected task.
     ///
-    /// In Strand all three modes produce the same execution behaviour: the
-    /// workflow is re-enqueued and its checkpoint-replay mechanism naturally
-    /// skips already-completed activities. The mode is preserved in the
-    /// request for API compatibility and future use.
+    /// When you retry a workflow, child activities that previously ran are stored in
+    /// `task_completions`. On replay, the workflow would normally fast-path those
+    /// results — returning the old success *or* old failure without re-executing
+    /// the activity. The mode controls which children have their `task_completions`
+    /// entry deleted and a fresh PENDING run created, forcing re-execution.
+    ///
+    /// Activities that are NOT reset replay their cached result instantly.
     public enum Mode: String, Codable, Sendable {
-        /// Re-enqueue every task in the workflow (default).
-        case all
-        /// Re-enqueue only tasks that are in a failed or cancelled state.
+        /// Reset only FAILED and CANCELLED descendants.
+        ///
+        /// The right default for most retries: re-run what failed, skip what
+        /// already succeeded. Completed activities replay from cache; only
+        /// failed/cancelled ones are given fresh PENDING runs.
         case failedOnly = "failed_only"
-        /// Re-enqueue failed tasks plus any downstream tasks that depend on them.
+
+        /// Reset FAILED/CANCELLED descendants **and** any descendant created at
+        /// or after the earliest failure point, even if it completed successfully.
+        ///
+        /// Use this when a failed task may have produced bad side-effects that
+        /// contaminate later activities, making their “completed” results
+        /// unreliable and worth discarding.
         case failedAndDependents = "failed_and_dependents"
+
+        /// Reset **every** descendant regardless of state.
+        ///
+        /// Every child activity re-runs from scratch — no results are replayed
+        /// from cache. Use this when you cannot trust any previously-completed
+        /// result and want a full fresh execution.
+        case all
     }
 
     public var mode: Mode
     /// When `true`, resets the attempt counter to 1 and clears stored failure
     /// reasons — a clean slate with the original `max_attempts` budget intact.
+    /// Also propagates to descendant tasks: their attempt counters are reset to 1
+    /// rather than bumped.
+    ///
     /// When `false` (default), the attempt counter continues from where it
     /// left off and `max_attempts` is bumped by one to allow the next attempt.
     public var resetHistory: Bool
 
-    public init(mode: Mode = .all, resetHistory: Bool = false) {
+    public init(mode: Mode = .failedOnly, resetHistory: Bool = false) {
         self.mode = mode
         self.resetHistory = resetHistory
     }

--- a/Sources/Strand/Internal/WorkflowExecutor.swift
+++ b/Sources/Strand/Internal/WorkflowExecutor.swift
@@ -91,7 +91,7 @@ enum WorkflowCommand: Sendable {
         priority: TaskPriority,  // .normal when unspecified
         maxAttempts: Int?,  // nil = worker default
         fairnessKey: String?,  // nil = no per-tenant isolation
-        fairnessWeight: Float,  // 1.0 = default weight
+        fairnessWeight: Double,  // 1.0 = default weight
         retryStrategy: RetryStrategy?,  // nil = worker default
         scheduledAt: Date?  // nil = immediately
     )

--- a/Sources/Strand/Schedule/SchedulePattern.swift
+++ b/Sources/Strand/Schedule/SchedulePattern.swift
@@ -466,7 +466,142 @@ public enum SchedulePattern: Sendable, Codable, Equatable, Hashable {
 
 extension SchedulePattern {
 
-    // MARK: Daily
+    // MARK: - Private helpers
+
+    /// Maps a ``Weekday`` to its standard cron day-of-week number.
+    /// Cron convention: Sun=0, Mon=1, Tue=2, Wed=3, Thu=4, Fri=5, Sat=6.
+    private static func cronDay(_ day: Weekday) -> Int {
+        switch day {
+        case .sunday: return 0
+        case .monday: return 1
+        case .tuesday: return 2
+        case .wednesday: return 3
+        case .thursday: return 4
+        case .friday: return 5
+        case .saturday: return 6
+        }
+    }
+
+    // MARK: - Weekdays (Mon–Fri)
+
+    /// Fires every weekday (Monday through Friday) at the specified hour and minute.
+    ///
+    /// ```swift
+    /// .weekdays(hour: 9)                    // 09:00 UTC every weekday
+    /// .weekdays(hour: 9, timezone: nyTZ)    // 09:00 Eastern every weekday
+    /// ```
+    public static func weekdays(
+        hour: Int,
+        minute: Int = 0,
+        timezone: TimeZone = TimeZone(identifier: "UTC")!
+    ) -> SchedulePattern {
+        .cron("\(minute) \(hour) * * 1-5", timezone: timezone)
+    }
+
+    /// Fires every weekday (Monday through Friday) at each of the specified hours.
+    ///
+    /// ```swift
+    /// .weekdays(hours: 9, 16)                  // 09:00 and 16:00 UTC every weekday
+    /// .weekdays(hours: 8, 12, 17, minute: 30)  // 08:30, 12:30, 17:30 every weekday
+    /// ```
+    public static func weekdays(
+        hours: Int...,
+        minute: Int = 0,
+        timezone: TimeZone = TimeZone(identifier: "UTC")!
+    ) -> SchedulePattern {
+        let h = hours.sorted().map { String($0) }.joined(separator: ",")
+        return .cron("\(minute) \(h) * * 1-5", timezone: timezone)
+    }
+
+    // MARK: - Specific weekday selection
+
+    /// Fires on the selected weekdays at the specified hour and minute.
+    ///
+    /// ```swift
+    /// .onDays(.monday, .wednesday, .friday, hour: 9)      // MWF at 09:00 UTC
+    /// .onDays(.tuesday, .thursday, hour: 8, minute: 30)   // TuTh at 08:30
+    /// ```
+    public static func onDays(
+        _ days: Weekday...,
+        hour: Int,
+        minute: Int = 0,
+        timezone: TimeZone = TimeZone(identifier: "UTC")!
+    ) -> SchedulePattern {
+        let d = days.map { cronDay($0) }.sorted().map { String($0) }.joined(separator: ",")
+        return .cron("\(minute) \(hour) * * \(d)", timezone: timezone)
+    }
+
+    /// Fires on the selected weekdays at each of the specified hours.
+    ///
+    /// ```swift
+    /// .onDays(.monday, .wednesday, .friday, hours: 8, 14)
+    /// // 08:00 and 14:00 on Mon, Wed, Fri
+    /// ```
+    public static func onDays(
+        _ days: Weekday...,
+        hours: Int...,
+        minute: Int = 0,
+        timezone: TimeZone = TimeZone(identifier: "UTC")!
+    ) -> SchedulePattern {
+        let d = days.map { cronDay($0) }.sorted().map { String($0) }.joined(separator: ",")
+        let h = hours.sorted().map { String($0) }.joined(separator: ",")
+        return .cron("\(minute) \(h) * * \(d)", timezone: timezone)
+    }
+
+    // MARK: - Multiple hours per day
+
+    /// Fires every day at each of the specified hours.
+    ///
+    /// ```swift
+    /// .onHours(8, 12, 17)              // 08:00, 12:00, 17:00 UTC every day
+    /// .onHours(9, 14, minute: 30)      // 09:30 and 14:30 UTC every day
+    /// ```
+    public static func onHours(
+        _ hours: Int...,
+        minute: Int = 0,
+        timezone: TimeZone = TimeZone(identifier: "UTC")!
+    ) -> SchedulePattern {
+        let h = hours.sorted().map { String($0) }.joined(separator: ",")
+        return .cron("\(minute) \(h) * * *", timezone: timezone)
+    }
+
+    // MARK: - Specific dates of the month
+
+    /// Fires on the specified day-of-month values at the given hour and minute.
+    ///
+    /// Days are 1-indexed.
+    ///
+    /// ```swift
+    /// .onDates(1, 15, hour: 9)         // 1st and 15th of each month at 09:00 UTC
+    /// .onDates(1, 8, 15, 22, hour: 0)  // weekly-ish: every 7 days at midnight
+    /// ```
+    public static func onDates(
+        _ dates: Int...,
+        hour: Int,
+        minute: Int = 0,
+        timezone: TimeZone = TimeZone(identifier: "UTC")!
+    ) -> SchedulePattern {
+        let d = dates.sorted().map { String($0) }.joined(separator: ",")
+        return .cron("\(minute) \(hour) \(d) * *", timezone: timezone)
+    }
+
+    // MARK: - Sub-hourly (multiple minutes)
+
+    /// Fires at specific minutes past every hour.
+    ///
+    /// ```swift
+    /// .onMinutes(0, 15, 30, 45)   // every 15 minutes
+    /// .onMinutes(0, 30)           // every 30 minutes
+    /// ```
+    public static func onMinutes(
+        _ minutes: Int...,
+        timezone: TimeZone = TimeZone(identifier: "UTC")!
+    ) -> SchedulePattern {
+        let m = minutes.sorted().map { String($0) }.joined(separator: ",")
+        return .cron("\(m) * * * *", timezone: timezone)
+    }
+
+    // MARK: - Daily
 
     /// Fires every day at the specified hour and minute.
     ///

--- a/Sources/Strand/Schedule/ScheduleTypes.swift
+++ b/Sources/Strand/Schedule/ScheduleTypes.swift
@@ -76,7 +76,7 @@ public struct ScheduleOptions: Sendable {
     public var accuracy: ScheduleAccuracy
 
     public init(
-        maxAttempts: Int? = nil,
+        maxAttempts: Int? = 25,
         retryStrategy: RetryStrategy? = nil,
         cancellation: CancellationPolicy? = nil,
         headers: [String: String] = [:],

--- a/Sources/Strand/Strand.docc/Scheduling.md
+++ b/Sources/Strand/Strand.docc/Scheduling.md
@@ -5,79 +5,89 @@ runs as a `Service` in your `ServiceGroup`.
 
 ## Two modes: static declarations vs. runtime calls
 
-Strand distinguishes between two kinds of schedule registration:
-
 | Mode | When to use | API |
 |---|---|---|
-| **Static declaration** | Schedules known at compile time (boot-time setup) | `StrandScheduler(schedules:)` |
-| **Runtime call** | Schedules created dynamically (HTTP API, user action) | `client.schedule(...)` |
+| **Static declaration** | Schedules known at compile time | `StrandService.addSchedule` / `StrandScheduler(schedules:)` |
+| **Runtime call** | Schedules created from an HTTP handler, a workflow, or a user action | ``StrandClient/schedule(name:pattern:workflowType:input:queue:startsAt:endsAt:options:)`` |
 
 ## Static declarations (boot-time)
 
-Pass schedule definitions directly to ``StrandScheduler`` at construction time.
-The scheduler upserts them to the database as the very first step of `run()` —
-Postgres is guaranteed to be live at that point because the `ServiceGroup` starts
-``PostgresClient`` before any other service.
+The example below is drawn from the **HackerNewsSummary** example in the public
+repository. It schedules a weekday briefing at 09:00 US Eastern time using
+``StrandService``:
 
 ```swift
-let scheduler = StrandScheduler(
-    client: client,
-    schedules: [
-        // Workflow schedule — every hour on the hour
-        .workflow(
-            "hourly-sync",
-            pattern: .interval(.hours(1)),
-            workflowType: DataSyncWorkflow.self,
-            input: SyncInput()
+// HackerNewsSummaryExample.swift
+var strand = StrandService(
+    postgres: postgres,
+    options: .init(
+        queues: [
+            // Orchestrator — top-level workflow + story fetch
+            .init(
+                name: "hn-orchestrator",
+                namespace: "hn-summary",
+                workflows: [HackerNewsSummaryWorkflow.self],
+                activities: [FetchTopStoriesActivity()],
+                workflowConcurrency: 4,
+                activityConcurrency: 8
+            ),
+            // Summariser — child workflows; cap Ollama concurrency at 3
+            .init(
+                name: "hn-summarizer",
+                namespace: "hn-summary",
+                workflows: [SummarizeStoryWorkflow.self],
+                activities: [FetchStoryActivity(), OllamaSummarizeActivity()],
+                workflowConcurrency: 3,
+                activityConcurrency: 3
+            ),
+        ],
+        scheduler: .init(
+            options: .init(sleepCap: .seconds(30)),
+            queue: "hn-orchestrator",
+            namespace: "hn-summary"
         ),
-
-        // Daily at 09:00 UTC
-        .workflow(
-            "daily-report",
-            pattern: .daily(offset: "PT9H"),
-            workflowType: DailyReportWorkflow.self,
-            input: ReportInput()
-        ),
-
-        // Weekdays at 08:30 US Eastern via cron
-        .workflow(
-            "market-open",
-            pattern: .cron("30 8 * * 1-5",
-                           timezone: TimeZone(identifier: "America/New_York")!),
-            workflowType: MarketOpenWorkflow.self,
-            input: StrandVoid()
-        ),
-
-        // Activity fired directly — no wrapping workflow
-        .activity(
-            "cleanup-old-files",
-            pattern: .daily(offset: "PT2H"),
-            activityType: CleanupActivity.self,
-            input: CleanupInput(olderThanDays: 30)
-        ),
-    ]
+        logger: logger
+    )
 )
 
-let group = ServiceGroup(configuration: .init(
-    services: [
-        .init(service: postgres),
-        .init(service: worker),
-        .init(service: scheduler),   // ← schedules are upserted here
-    ],
-    gracefulShutdownSignals: [.sigterm, .sigint]
-))
+// Nine AM Eastern, weekdays only, starting May 2026.
+// ScheduleOptions(accuracy: .last(3)) recovers the three most-recent
+// missed slots if the process was down over a long weekend.
+var estCal = Calendar(identifier: .gregorian)
+estCal.timeZone = TimeZone(identifier: "America/New_York")!
+let may2026 = estCal.date(
+    from: DateComponents(year: 2026, month: 5, day: 1, hour: 0, minute: 0)
+)!
+
+strand.addSchedule(
+    .workflow(
+        "hn-daily-briefing",
+        pattern: .cron("0 9 * * 1-5",
+                       timezone: TimeZone(identifier: "America/New_York")!),
+        workflowType: HackerNewsSummaryWorkflow.self,
+        input: HNInput(storyCount: 5, jobID: "daily"),
+        startsAt: may2026,
+        options: ScheduleOptions(accuracy: .last(3))
+    )
+)
+
+let group = ServiceGroup(
+    services: [postgres, strand],
+    gracefulShutdownSignals: [.sigterm, .sigint],
+    logger: logger
+)
 try await group.run()
 ```
 
-Registering the same name twice upserts the pattern — existing in-flight tasks
-are unaffected.
+Registering the same `name` twice upserts the pattern — existing in-flight
+tasks are unaffected.
 
 ## Runtime calls (dynamic)
 
 For schedules created in response to an external event (an HTTP request, a user
-action, a Strand workflow itself), call ``StrandClient/schedule(name:pattern:workflowType:input:queue:startsAt:endsAt:options:)``
-directly from wherever the event is handled.  Postgres is always live at that
-point, so the call is a straightforward database write:
+action, or from within a workflow activity), call
+``StrandClient/schedule(name:pattern:workflowType:input:queue:startsAt:endsAt:options:)``
+wherever the event is handled:
 
 ```swift
 // Inside a Hummingbird route handler, a workflow activity, etc.
@@ -91,51 +101,215 @@ try await client.schedule(
 
 ## Schedule patterns
 
-| Pattern | Example | Description |
-|---|---|---|
-| `.cron(expression)` | `.cron("0 9 * * 1-5")` | Standard 5-field cron |
-| `.interval(duration)` | `.interval(.hours(1))` | Fixed interval from last fire |
-| `.daily(offset:)` | `.daily(offset: "PT9H")` | Daily at a time-of-day (ISO 8601 duration offset from midnight) |
-| `.weekly(offset:)` | `.weekly(offset: "P1DT9H")` | Weekly on a day + time |
-| `.monthly(offset:)` | `.monthly(offset: "P14DT9H")` | Monthly on a day-of-month + time |
-| `.once(at:)` | `.once(at: someDate)` | Fire exactly once at the given `Date` |
+### Typed constructors (recommended)
+
+The preferred API uses named parameters and the ``Weekday`` and ``Month`` enums
+— no ISO 8601 string arithmetic, and the compiler catches day/month out-of-range
+values that a raw string cannot:
+
+```swift
+// Daily — fire every day at the given hour and minute
+.daily(hour: 9)                          // 09:00 UTC every day
+.daily(hour: 14, minute: 30)             // 14:30 UTC every day
+.daily(hour: 9, timezone: nyTZ)          // 09:00 Eastern, DST-aware
+
+// Weekdays (Mon–Fri)
+.weekdays(hour: 9)                        // 09:00 UTC every weekday
+.weekdays(hours: 9, 16, timezone: nyTZ)   // 09:00 and 16:00 Eastern every weekday
+
+// Specific weekday selection
+.onDays(.monday, .wednesday, .friday, hour: 9)        // MWF at 09:00
+.onDays(.tuesday, .thursday, hour: 8, minute: 30)     // TuTh at 08:30
+.onDays(.monday, .wednesday, .friday, hours: 8, 14)   // MWF at 08:00 and 14:00
+
+// Multiple hours per day
+.onHours(8, 12, 17)                       // 08:00, 12:00, 17:00 UTC every day
+.onHours(9, 14, minute: 30)               // 09:30 and 14:30 UTC every day
+
+// Sub-hourly
+.onMinutes(0, 15, 30, 45)                 // every 15 minutes
+.onMinutes(0, 30)                         // every 30 minutes
+
+// Weekly — fire once per week on a specific weekday
+.weekly(on: .monday, hour: 9)            // Monday 09:00 UTC
+.weekly(on: .friday, hour: 17, minute: 30, timezone: nyTZ)
+
+// Specific dates of the month
+.onDates(1, 15, hour: 9)                // 1st and 15th at 09:00
+.onDates(1, 8, 15, 22, hour: 0)         // four Mondays-ish at midnight
+
+// Monthly — fire on a specific day-of-month
+.monthly(day: 1,  hour: 0)              // 1st of each month at midnight
+.monthly(day: 15, hour: 10, minute: 30)
+
+// Yearly — fire on a specific month and day
+.yearly(month: .january,  day: 1,  hour: 0)          // New Year's Day midnight
+.yearly(month: .march,    day: 15, hour: 10, minute: 30)
+.yearly(month: .december, day: 25, hour: 8, timezone: nyTZ)
+
+// Cron — standard 5-field expression for anything else
+.cron("0 9 * * 1-5")                    // weekdays 09:00 UTC (same as .weekdays)
+.cron("0 9 * * 1-5", timezone: nyTZ)
+
+// Interval — fixed interval from epoch-aligned boundaries
+.interval(.hours(1))                    // every hour on the hour
+.interval(.minutes(15))
+
+// Once — fire exactly once
+.once(at: someDate)
+```
+
+### Pattern summary
+
+| Pattern | `partitionTime` |
+|---|---|
+| `.daily(hour:minute:)` | Midnight of that day |
+| `.weekdays(hour:)` / `.weekdays(hours:)` | Midnight of that day |
+| `.onDays([Weekday], hour:)` / `.onDays([Weekday], hours:)` | Midnight of that day |
+| `.onHours([Int], minute:)` | The epoch-aligned hour boundary |
+| `.onMinutes([Int])` | The current hour (minute = 0) |
+| `.weekly(on:hour:minute:)` | Saturday 00:00 of that week |
+| `.onDates([Int], hour:minute:)` | 1st of that month at 00:00 |
+| `.monthly(day:hour:minute:)` | 1st of that month at 00:00 |
+| `.yearly(month:day:hour:minute:)` | January 1st 00:00 of that year |
+| `.interval(duration)` | Epoch-aligned interval boundary just before fire |
+| `.cron(expr)` | The cron tick itself |
+| `.once(at:)` | The fire date |
+
+See [Partition time](#Partition-time) for why `partitionTime` matters.
+
+### Foundation `Calendar` and holiday awareness
+
+Foundation's `Calendar` already powers Strand's date arithmetic (`calendar.nextDate(after:matching:matchingPolicy:)` drives every typed constructor internally). It handles DST, leap years, and different calendar systems — but it does **not** know about national holidays, NYSE closures, UK bank holidays, or any other region-specific non-working days. That data does not exist in any OS framework.
+
+For patterns that should skip certain dates, two approaches work today:
+
+**1. Use `.cron` to encode the rule directly** when the pattern is expressible in cron:
+```swift
+// First business day of the month (approximately — doesn't handle holidays)
+.cron("0 9 1-7 * 1")   // Monday at 09:00 in the first 7 days of the month
+```
+
+**2. Exclude dates in the workflow handler** when the rule is too complex for cron:
+```swift
+struct DailyTradeWorkflow: Workflow {
+    mutating func run(context: WorkflowContext<Self>, input: TradeInput) async throws -> TradeResult {
+        guard let meta = context.schedulingMetadata else { return .skipped }
+        let day = meta.partitionTime ?? meta.executionTime
+
+        // Skip if today is a known holiday — return early rather than failing.
+        // The next scheduled slot fires tomorrow as normal.
+        if isNYSEHoliday(day) { return .skipped }
+
+        return try await processTradeDay(day)
+    }
+}
+```
+
+This keeps the schedule running on its normal cadence; the workflow simply
+detects the holiday and exits cleanly. The `partitionTime` anchor makes the
+check stable across retries.
+
+**Future: `BusinessCalendar` protocol**
+
+A first-class holiday protocol is planned. The design will follow the same
+registration pattern as workflows — the calendar name is serializable (stored
+in `strand.schedules`), the implementation is application code:
+
+```swift
+// Application registers a named calendar at startup (not yet implemented)
+scheduler.registerCalendar("NYSE", NYSECalendar())
+
+// Schedule references it by name
+strand.addSchedule(
+    .workflow(
+        "daily-trade",
+        pattern: .weekdays(hour: 9, minute: 30, timezone: nyTZ),
+        options: ScheduleOptions(
+            businessCalendar: "NYSE",  // skip NYSE holidays automatically
+            onHoliday: .skipToNext    // or .skip, .fireAnyway
+        )
+    )
+)
+```
+
+Until then, the early-return pattern in the workflow handler is the recommended
+approach for production systems with known holiday calendars.
+
+### Raw offset form (advanced)
+
+Every pattern also has a lower-level form that takes an ISO 8601 duration string
+for the `offset:` parameter. Strand uses this internally and it gives fine-grained
+control over sub-minute timing or staggered firing:
+
+```swift
+// Stagger a daily midnight job by 15 minutes to avoid thundering herd
+// partitionTime stays 00:00; executionTime becomes 00:15
+.cron("0 0 * * *", offset: "PT15M")
+
+// Fire at 00:45, 01:45, 02:45 … (epoch-aligned hourly, shifted 45 min)
+.interval(.hours(1), offset: "PT45M")
+
+// Raw forms of the typed constructors above:
+// .daily(hour: 9)          ≡ .daily(offset: "PT9H")
+// .weekly(on: .monday, hour: 9) ≡ .weekly(offset: "P2DT9H")
+// .monthly(day: 15, hour: 9)    ≡ .monthly(offset: "P14DT9H")
+// .yearly(month: .march, day: 15, hour: 9) ≡ .yearly(offset: "P2MT14DT9H")
+```
+
+Weekly offset origin is **Saturday** (`P0D`): Sun=`P1D`, Mon=`P2D`, … Fri=`P6D`.
+Monthly `P0D` maps to day 1. Yearly `P0M P0D` maps to January 1st.
 
 ## Catch-up behaviour
 
 ``ScheduleAccuracy`` controls what happens when the scheduler restarts after an
-outage:
+outage and there are missed slots:
+
+| Accuracy | Behaviour |
+|---|---|
+| `.latest` | Fire only the single most-recent missed slot. **Default.** Avoids flooding the queue after a long outage. |
+| `.all` | Fire every missed slot in chronological order. Use for financial reconciliation or any process where every execution must happen. |
+| `.last(n)` | Fire only the last `n` missed slots in chronological order. Useful when you want bounded catch-up after an outage. |
 
 ```swift
-// Default: fire only the most-recent missed slot (avoids flooding the queue)
-options: ScheduleOptions(accuracy: .latest)
-
-// Fire all missed slots in order (e.g. financial reconciliation)
-options: ScheduleOptions(accuracy: .all)
-
-// Fire only the last 3 missed slots
+// Fire the 3 most-recent missed briefings after a long weekend outage
 options: ScheduleOptions(accuracy: .last(3))
+
+// Re-run every missed slot since deployment (financial pipelines)
+options: ScheduleOptions(accuracy: .all)
 ```
 
-A past `startsAt` date triggers catch-up recovery automatically:
+A past `startsAt` date triggers catch-up automatically:
 
 ```swift
-.workflow(
-    "iss-telemetry",
-    pattern: .interval(.seconds(90 * 60)),
-    workflowType: TelemetryWorkflow.self,
-    input: TelemetryInput(),
-    startsAt: Date(timeIntervalSince1970: 0),   // active since epoch
-    options: ScheduleOptions(accuracy: .last(3)) // recover last 3 slots
+strand.addSchedule(
+    .workflow(
+        "iss-telemetry",
+        pattern: .interval(.minutes(90)),
+        workflowType: TelemetryWorkflow.self,
+        input: TelemetryInput(),
+        startsAt: Date(timeIntervalSince1970: 0),    // active since epoch
+        options: ScheduleOptions(accuracy: .last(3)) // recover last 3 slots
+    )
 )
 ```
 
 ## Time zones
 
-Pass a `timezone:` argument to `.cron` or any pattern that accepts one:
+Pass `timezone:` to `.cron` or any pattern that accepts one:
 
 ```swift
 .workflow(
-    "new-york-open",
+    "market-open",
+    // Typed constructor is clearer than cron for a simple weekday+time pattern
+    pattern: .weekly(on: .monday,    hour: 9, timezone: nyTZ),  // one line per day
+    workflowType: MarketOpenWorkflow.self,
+    input: StrandVoid()
+)
+
+// Or use cron when the schedule has complex day-of-week logic:
+.workflow(
+    "market-open",
     pattern: .cron("30 9 * * 1-5",
                    timezone: TimeZone(identifier: "America/New_York")!),
     workflowType: MarketOpenWorkflow.self,
@@ -143,10 +317,79 @@ Pass a `timezone:` argument to `.cron` or any pattern that accepts one:
 )
 ```
 
+Civil-day patterns (`.daily`, `.weekly`, `.monthly`) are DST-aware when a
+timezone is provided — a "09:00 daily" schedule fires at 09:00 local time
+regardless of whether the clock has moved forward or back.
+
+## Partition time
+
+Every task fired by a schedule carries three timestamps inside
+``SchedulingMetadata``:
+
+| Field | What it is | Example for `.daily(offset: "PT9H")` at 09:00 ET |
+|---|---|---|
+| `partitionTime` | Start of the **period** the task covers (offset stripped) | May 13 00:00 ET (midnight) |
+| `executionTime` | Wall-clock time the **scheduler actually fired** the task | May 13 09:00:00.123 ET |
+| `scheduleOffset` | The raw offset string from the pattern | `"PT9H"` |
+
+The relationship is: `partitionTime + scheduleOffset ≈ executionTime`.
+
+### Why `partitionTime` is the right anchor
+
+Always use `partitionTime` — not `executionTime` — as the canonical date for:
+
+- **Fetching data**: "which day's HN stories should I fetch?" → `partitionTime`
+  is May 13 midnight, consistently, whether this is a live run or a backfill
+  re-running that slot weeks later.
+- **Idempotency keys**: a retry of the same slot has the same `partitionTime`
+  but a different `executionTime`.
+- **Backfills**: when the scheduler fires a historical slot, `executionTime` is
+  now (the actual firing time) but `partitionTime` is the historical period
+  being re-processed.
+
+`executionTime` is useful for **SLA monitoring** ("did this job run on time?") and
+logging, but not for data logic.
+
+```swift
+mutating func run(
+    context: WorkflowContext<Self>,
+    input: HNInput
+) async throws -> HNDailySummary {
+    guard let meta = context.schedulingMetadata else {
+        // Directly enqueued (e.g. `startWorkflow`) — use activationTime.
+        return try await runBriefing(for: context.activationTime)
+    }
+
+    // ✓ Correct: partitionTime is the day boundary regardless of when we run.
+    // Works for live runs, retries, and backfill re-runs alike.
+    let briefingDay = meta.partitionTime ?? meta.executionTime
+
+    // ✗ Wrong: executionTime drifts with poll latency and is "now" for backfills.
+    // let briefingDay = meta.executionTime
+
+    // ✓ Detect backfill runs
+    let isBackfill = meta.backfillId != nil
+
+    return try await runBriefing(for: briefingDay, isBackfill: isBackfill)
+}
+```
+
+### Partition time by pattern
+
+| Pattern | `partitionTime` |
+|---|---|
+| `.daily(offset: "PT9H")` — fires 09:00 | Midnight of that day |
+| `.weekly(offset: "P6DT9H")` — fires Friday 09:00 | Saturday 00:00 of that week |
+| `.monthly(offset: "P14DT9H")` — fires 15th 09:00 | 1st of that month at 00:00 |
+| `.yearly(offset: "P2MT14DT9H")` — fires Mar 15 | January 1st 00:00 of that year |
+| `.interval(.minutes(90))` — fires 01:45 | 01:30 (the 90-min boundary) |
+| `.cron("0 0 * * *", offset: "PT15M")` — fires 00:15 | 00:00 (the cron tick) |
+| `.cron("0 9 * * 1-5")` (no offset) | 09:00 (the cron tick itself) |
+
 ## Manage schedules at runtime
 
 ```swift
-// List all schedules
+// List all schedules for this namespace
 let schedules = try await client.listSchedules()
 
 // Pause / resume / delete by UUID
@@ -155,20 +398,120 @@ try await client.resumeSchedule(id: scheduleID)
 try await client.deleteSchedule(id: scheduleID)
 ```
 
-## Reading schedule metadata inside a workflow
+## Backfill
 
-When a workflow is triggered by a schedule, ``SchedulingMetadata`` is available
-via the context:
+A **backfill** retroactively executes a scheduled workflow or activity for every
+slot in a historical date range. Use it when:
+
+- The scheduler was not running during a period and `.all` catch-up is too
+  aggressive (e.g. thousands of hourly slots — you want controlled, concurrent
+  execution, not a queue flood).
+- You deployed a new scheduled workflow and need to populate historical data.
+- A bug corrupted a range of executions and you need to re-run them.
+
+For the HN briefing example: if the service was down for two weeks you missed
+ten weekday briefings. Rather than recovering them through the normal scheduler
+(which would serialise them one by one), a backfill enqueues them with
+configurable concurrency:
 
 ```swift
-mutating func run(context: WorkflowContext<Self>, input: ReportInput) async throws -> ReportResult {
-    if let meta = context.schedulingMetadata {
-        // meta.scheduleName  — "daily-report"
-        // meta.scheduledAt   — wall-clock time the slot was due
-        // meta.executionTime — time the task was actually dispatched
-    }
-    // ...
-}
+let client = strand.client(queue: "hn-orchestrator", namespace: "hn-summary")
+
+let cal = Calendar(identifier: .gregorian)
+let rangeStart = cal.date(from: DateComponents(year: 2026, month: 5, day: 5))!
+let rangeEnd   = cal.date(from: DateComponents(year: 2026, month: 5, day: 19))!
+
+let handle = try await client.createBackfill(
+    HackerNewsSummaryWorkflow.self,
+    input: HNInput(storyCount: 5, jobID: "backfill"),
+    schedule: .cron("0 9 * * 1-5",
+                    timezone: TimeZone(identifier: "America/New_York")!),
+    range: rangeStart ..< rangeEnd,
+    options: BackfillOptions(
+        concurrency: 3,           // at most 3 slots executing simultaneously
+        allowOverwrite: false,    // skip slots that already completed successfully
+        description: "Re-run missed briefings May 5–18"
+    )
+)
+print("Backfill started:", handle.id)
+```
+
+### BackfillOptions
+
+| Property | Default | Description |
+|---|---|---|
+| `concurrency` | `1` | Maximum number of slots executing at the same time. Increase carefully — each slot enqueues its own child activities. |
+| `allowOverwrite` | `false` | When `false`, slots that already have a completed task with the matching idempotency key are skipped. Set `true` to force re-execution. |
+| `description` | `nil` | Human-readable note shown in the Loom dashboard explaining why this backfill was created. |
+
+### Monitoring progress
+
+`createBackfill` returns a ``BackfillHandle``. Call `status()` to poll progress:
+
+```swift
+let status = try await handle.status()
+print("\(status.completedSlots) / \(status.totalSlots) slots done")
+print("Progress:", status.progressFraction)  // 0.0 – 1.0
+```
+
+``BackfillStatus`` fields:
+
+| Field | Description |
+|---|---|
+| `state` | `.running`, `.halted`, `.completed`, or `.failed` |
+| `totalSlots` | Total number of slots in the requested range |
+| `completedSlots` | Slots dispatched so far |
+| `progressFraction` | `completedSlots / totalSlots` (0.0 – 1.0) |
+| `nextSlotTime` | Wall-clock time of the next slot to be dispatched |
+| `completedAt` | Set when `state == .completed` |
+
+### Pausing and resuming a backfill
+
+```swift
+// Pause — stops the scheduler from dispatching more slots.
+// Already-running slots complete normally.
+try await handle.halt()
+
+// Resume from where it stopped.
+try await handle.resume()
+```
+
+### Tying a backfill to an existing schedule
+
+Pass the schedule's UUID to `scheduleId:` so the Loom dashboard links the
+backfill to the schedule:
+
+```swift
+let schedules = try await client.listSchedules()
+let hnSchedule = schedules.first { $0.name == "hn-daily-briefing" }!
+
+let handle = try await client.createBackfill(
+    HackerNewsSummaryWorkflow.self,
+    input: HNInput(storyCount: 5, jobID: "backfill"),
+    schedule: .cron("0 9 * * 1-5",
+                    timezone: TimeZone(identifier: "America/New_York")!),
+    range: rangeStart ..< rangeEnd,
+    scheduleId: hnSchedule.id,          // ← links to the schedule in Loom
+    options: BackfillOptions(concurrency: 3)
+)
+```
+
+### Running a single historical slot
+
+To fire exactly one past slot — for example, to replay a specific date's
+briefing — use ``StrandClient/runScheduleSlot(scheduleID:partitionTime:allowOverwrite:namespaceID:)``:
+
+```swift
+// Replay the May 12th briefing
+let may12 = cal.date(from: DateComponents(
+    year: 2026, month: 5, day: 12, hour: 9, minute: 0
+))!
+
+let (taskID, _) = try await client.runScheduleSlot(
+    scheduleID: hnSchedule.id,
+    partitionTime: may12,
+    allowOverwrite: true   // re-run even if it previously completed
+)
 ```
 
 ## Scheduler options
@@ -177,11 +520,27 @@ mutating func run(context: WorkflowContext<Self>, input: ReportInput) async thro
 let scheduler = StrandScheduler(
     client: client,
     options: SchedulerOptions(
-        sleepCap: .seconds(60)   // max sleep between polls; default 60 s
+        sleepCap:        .seconds(30), // max sleep between polls; default 60 s
+        maxCatchupSlots: 500,           // slots per fire() call during catch-up; default 1 000
+        pollLimit:       50             // schedules claimed per poll cycle; default 100
     ),
     schedules: [ ... ]
 )
 ```
 
-The scheduler sleeps precisely until the next known fire time, but wakes at
-least every `sleepCap` seconds to detect newly-added schedules.
+| Option | Default | Description |
+|---|---|---|
+| `sleepCap` | `60 s` | Maximum sleep between polls. The scheduler sleeps precisely until the next fire time, but wakes at least this often to detect newly-added schedules and backfills. Lower values mean faster detection of runtime `schedule(...)` calls; higher values reduce DB load. |
+| `maxCatchupSlots` | `1 000` | Maximum missed slots enqueued in a single `fire()` invocation when `accuracy` is `.all` or `.last(n)`. After this limit the remaining slots are picked up on the next poll cycle, bounding per-call latency regardless of backlog size. |
+| `pollLimit` | `100` | Maximum due schedules claimed per poll cycle. When more schedules fire simultaneously than this limit (e.g. after a long outage), the remainder are left for the next cycle, preventing burst overload. |
+
+## Topics
+
+### Reference
+- ``StrandScheduler``
+- ``ScheduleOptions``
+- ``ScheduleAccuracy``
+- ``SchedulingMetadata``
+- ``BackfillOptions``
+- ``StrandClient/createBackfill(_:input:schedule:range:queue:scheduleId:options:)``
+- ``StrandClient/runScheduleSlot(scheduleID:partitionTime:allowOverwrite:namespaceID:)``

--- a/Sources/Strand/Strand.docc/Strand.md
+++ b/Sources/Strand/Strand.docc/Strand.md
@@ -48,6 +48,7 @@ struct OrderWorkflow: Workflow {
 - <doc:Scheduling>
 - <doc:SignalsAndEvents>
 - <doc:RetryStrategies>
+- <doc:VersioningGuide>
 - <doc:TestingWorkflows>
 
 ### Recipes

--- a/Sources/Strand/Strand.docc/VersioningGuide.md
+++ b/Sources/Strand/Strand.docc/VersioningGuide.md
@@ -1,0 +1,251 @@
+# Versioning workflows
+
+Three strategies for safely changing workflow logic in a running system.
+
+## Overview
+
+Strand replays every workflow activation from its checkpoint history. That
+replay is only correct if the Swift code produces the same sequence of
+`runActivity` / `sleep` / `waitForEvent` calls on every activation of the
+same workflow instance. Changing that sequence mid-flight — by deploying new
+code while workflows are in-flight — can corrupt checkpoint mapping and cause
+replays to resume at the wrong suspension point.
+
+Three strategies address this problem. Choose the one that fits your workflow's
+lifetime.
+
+## Strategy 1 — Type-name versioning
+
+Define a new workflow type (`OrderWorkflowV2`) alongside the original. Register
+both types on workers during the transition window so that in-flight V1
+instances can continue draining while new enqueues already use V2.
+
+```swift
+// Both types registered on workers during the transition window:
+StrandWorker(
+    workflows: [OrderWorkflowV1.self, OrderWorkflowV2.self],
+    ...
+)
+
+// A typealias keeps all enqueue call sites unchanged:
+typealias OrderWorkflow = OrderWorkflowV2
+
+try await client.startWorkflow(OrderWorkflow.self, ...)   // enqueues V2
+```
+
+Once all V1 instances reach a terminal state, remove `OrderWorkflowV1` and the
+`typealias`, and stop registering the old type.
+
+**Best for:** short-lived workflows where the old fleet drains within hours.
+
+## Strategy 2 — Queue-name versioning
+
+Old workers listen on `"orders-v1"`, new workers on `"orders-v2"`. Route new
+tasks to the new queue at enqueue time.
+
+```swift
+// Enqueue new tasks onto the v2 queue:
+try await client.startWorkflow(
+    OrderWorkflow.self,
+    options: WorkflowOptions(queue: "orders-v2"),
+    input: order
+)
+```
+
+In-flight instances on `"orders-v1"` drain naturally; old workers can be
+retired once that queue is empty.
+
+**Best for:** cases where many workflow types share a queue and a single queue
+rename covers all of them.
+
+## Strategy 3 — Inline patching with `context.version(changeID:)`
+
+Add a version guard inside the handler. New workflow instances take the new
+code path and store `true` as a checkpoint. In-flight instances that have
+already passed the guard replay whatever value was stored on their first
+encounter.
+
+```swift
+struct OrderWorkflow: Workflow {
+    mutating func run(
+        context: WorkflowContext<Self>,
+        input: OrderInput
+    ) async throws -> OrderResult {
+        let charge = try await context.runActivity(
+            ChargeCardActivity.self,
+            input: .init(amount: input.total)
+        )
+
+        // Deploying a fraud-check step. New workflows run it; in-flight
+        // workflows that ran past this point before the deploy skip it.
+        if try context.version(changeID: "add-fraud-check") {
+            try await context.runActivity(
+                FraudCheckActivity.self,
+                input: .init(paymentID: charge.paymentID)
+            )
+        }
+
+        return try await context.runActivity(
+            ShipOrderActivity.self,
+            input: .init(paymentID: charge.paymentID)
+        )
+    }
+}
+```
+
+**Best for:** long-running workflows that cannot be drained and restarted
+within a reasonable window (days or weeks).
+
+### Deployment procedure
+
+1. Add the `context.version(changeID:)` guard and the new code path.
+2. Deploy the updated binary to a canary worker.
+3. Optionally mark all in-flight workflows to use the old path (see below).
+4. Roll out the remaining workers.
+5. Once all pre-deploy instances complete, remove the `else` branch and the
+   version guard in a follow-up deploy.
+
+### Marking in-flight workflows
+
+``StrandClient/markVersion(changeID:value:taskID:callSiteIndex:)`` writes a
+version checkpoint directly into the database. Call it while the workflow is
+SLEEPING — between activations — so the checkpoint is in place when the next
+activation loads its cache.
+
+```swift
+// Find in-flight task IDs from the Loom dashboard, a query, or your own
+// bookkeeping, then pin each one to the pre-deploy code path:
+for id in inFlightTaskIDs {
+    try await client.markVersion(
+        changeID: "add-fraud-check",
+        value: false,    // false → old path; true → new path
+        taskID: id
+    )
+}
+```
+
+> **Tip:** Poll the workflow's state until it is `.sleeping` before calling
+> `markVersion`. If the workflow hasn't yet reached the `version(changeID:)`
+> call point, `markVersion` estimates the target sequence number. That
+> estimate is reliable as long as you call `markVersion` while the workflow is
+> in a sleep — not while it is actively running.
+
+## Determinism: always call `version` unconditionally
+
+``WorkflowContext/version(changeID:)`` consumes a **sequence number** from the
+same monotonic counter as ``WorkflowContext/runActivity(_:input:options:fileID:line:)``,
+``WorkflowContext/sleep(for:fileID:line:)`` and
+``WorkflowContext/waitForEvent(_:as:timeout:fileID:line:)``. Every context call
+must appear in the same position in the control flow on every activation of the
+same workflow instance.
+
+Placing `version(changeID:)` inside a branch whose condition changes between
+activations shifts all downstream sequence numbers and corrupts checkpoint
+replay.
+
+```swift
+// ✗ WRONG — version() only reached when isPaused is true.
+//   If isPaused changes between activations, downstream seqNums shift.
+if isPaused {
+    let _ = try context.version(changeID: "v2-feature")
+}
+let result = try await context.runActivity(A.self, input: x)  // ← wrong seqNum
+
+// ✓ CORRECT — version() is always reached; its return value drives branching.
+let useV2 = try context.version(changeID: "v2-feature")
+if isPaused && useV2 { ... }
+let result = try await context.runActivity(A.self, input: x)  // ← stable seqNum
+```
+
+The same rule applies to all context calls. `version(changeID:)` is no
+different — it is just easy to overlook because it doesn't `await`.
+
+## Multi-step migrations
+
+For two successive breaking changes, use two independent `changeID` strings and
+call both unconditionally. The latest changeID takes precedence in the
+branching logic.
+
+```swift
+// Both calls are unconditional. Each gets its own stable sequence number.
+let isV2 = try context.version(changeID: "add-fraud-check")
+let isV3 = try context.version(changeID: "parallel-charge")
+
+if isV3 {
+    // current code path — both new changes applied
+    let fraud = try await context.runActivity(FraudCheckActivity.self, input: x)
+    async let charge = context.runActivity(ChargeCardActivity.self, input: x)
+    async let ship   = context.runActivity(ShipOrderActivity.self, input: x)
+    _ = try await (charge, ship)
+} else if isV2 {
+    // intermediate path — only the fraud-check change applied
+    let fraud = try await context.runActivity(FraudCheckActivity.self, input: x)
+    let charge = try await context.runActivity(ChargeCardActivity.self, input: x)
+    _ = try await context.runActivity(ShipOrderActivity.self, input: x)
+} else {
+    // original path
+    let charge = try await context.runActivity(ChargeCardActivity.self, input: x)
+    _ = try await context.runActivity(ShipOrderActivity.self, input: x)
+}
+```
+
+### `callSiteIndex` for multi-step `markVersion`
+
+When marking in-flight workflows that haven't yet reached any version call,
+the sequence-number estimate is:
+
+```
+seqNum = (count of already-written checkpoints) + callSiteIndex
+```
+
+To mark two consecutive version calls in the same sleep window, call
+`markVersion` for the earlier changeID first (with `callSiteIndex: 1`),
+then for the later one (also `callSiteIndex: 1` — the count has advanced):
+
+```swift
+// Workflow structure: sleep(seqNum 1), version("add-fraud-check", seqNum 2),
+//                    version("parallel-charge", seqNum 3)
+// While sleeping (1 checkpoint written):
+try await client.markVersion(changeID: "add-fraud-check",  value: false, taskID: id)
+// ↑ count=1, callSiteIndex=1 → seqNum=2 ✓. Count is now 2.
+try await client.markVersion(changeID: "parallel-charge", value: false, taskID: id)
+// ↑ count=2, callSiteIndex=1 → seqNum=3 ✓
+```
+
+To mark only the second changeID without touching the first, pass
+`callSiteIndex: 2` in a single call (before any prior `markVersion` has run):
+
+```swift
+try await client.markVersion(changeID: "parallel-charge", value: false,
+                              taskID: id, callSiteIndex: 2)
+// count=1, callSiteIndex=2 → seqNum=3 ✓
+```
+
+## Build-ID-based worker routing — not needed
+
+Some workflow engines route task-queue polls to workers that advertise a
+specific build ID, maintaining a version-sets graph per queue in a coordination
+service that makes the routing decision at dispatch time.
+
+Strand has no separate coordination service. Equivalent routing would require
+embedding a version graph into the PostgreSQL claim query — significant
+operational complexity for a problem that Strategy 2 already solves at enqueue
+time. When you write `WorkflowOptions(queue: "orders-v2")`, the routing
+decision is stored durably in `strand.tasks.queue` and requires no in-flight
+state in any server process. That is simpler, not weaker.
+
+## Choosing a strategy
+
+| Situation | Recommended strategy |
+|---|---|
+| Workflow completes in < 1 hour | 1 — type-name or 2 — queue-name |
+| Many workflow types share a queue | 2 — queue-name |
+| Workflow can run for days or weeks | 3 — inline patching |
+| Breaking change touches only one of N workflow types on a queue | 3 — inline patching |
+| You need an audit trail of which code path each instance took | 3 — checkpoint is visible in the Loom dashboard |
+
+## Topics
+
+### Versioning API
+- ``WorkflowContext/version(changeID:)``
+- ``StrandClient/markVersion(changeID:value:taskID:callSiteIndex:)``

--- a/Sources/Strand/Workflow.swift
+++ b/Sources/Strand/Workflow.swift
@@ -314,7 +314,7 @@ public struct WorkflowOptions: Sendable {
     /// Relative throughput weight for this fairness key. Default `1.0`.
     /// A key with weight `5.0` is dispatched approximately 5× more often than a key with `1.0`.
     /// Only meaningful when `fairnessKey` is set.
-    public var fairnessWeight: Float
+    public var fairnessWeight: Double
 
     public init(
         id: String? = nil,
@@ -325,7 +325,7 @@ public struct WorkflowOptions: Sendable {
         retryStrategy: RetryStrategy? = nil,
         headers: [String: String] = [:],
         fairnessKey: String? = nil,
-        fairnessWeight: Float = 1.0
+        fairnessWeight: Double = 1.0
     ) {
         self.id = id
         self.queue = queue
@@ -355,7 +355,7 @@ public struct ChildWorkflowOptions: Sendable {
     /// Fairness group key for this child workflow. See ``WorkflowOptions/fairnessKey``.
     public var fairnessKey: String?
     /// Relative throughput weight for this child's fairness key. Default `1.0`.
-    public var fairnessWeight: Float
+    public var fairnessWeight: Double
     /// Retry policy on failure. `nil` inherits the worker default.
     public var retryStrategy: RetryStrategy?
     /// Earliest time this child workflow may be claimed. `nil` = immediately.
@@ -367,7 +367,7 @@ public struct ChildWorkflowOptions: Sendable {
         maxAttempts: Int? = nil,
         headers: [String: String] = [:],
         fairnessKey: String? = nil,
-        fairnessWeight: Float = 1.0,
+        fairnessWeight: Double = 1.0,
         retryStrategy: RetryStrategy? = nil,
         delayUntil: Date? = nil
     ) {

--- a/Sources/Strand/WorkflowContext.swift
+++ b/Sources/Strand/WorkflowContext.swift
@@ -948,6 +948,29 @@ public struct WorkflowContext<W: Workflow>: Sendable {
     /// }
     /// ```
     ///
+    /// ## Determinism constraint
+    ///
+    /// `version(changeID:)` consumes a **sequence number** from the same monotonic
+    /// counter as `runActivity`, `sleep`, and `waitForEvent`. It must be called at the
+    /// **same unconditional position** in the control flow on every activation of this
+    /// workflow instance. Placing it inside a branch whose condition can change between
+    /// activations (e.g. a signal-mutated flag) shifts all downstream sequence numbers
+    /// and corrupts checkpoint replay.
+    ///
+    /// ```swift
+    /// // ✗ WRONG — only reached when isPaused is true; downstream seqNums shift.
+    /// if isPaused {
+    ///     let _ = try context.version(changeID: "v2-feature")
+    /// }
+    ///
+    /// // ✓ CORRECT — always reached; return value drives the branch.
+    /// let useV2 = try context.version(changeID: "v2-feature")
+    /// if isPaused && useV2 { ... }
+    /// ```
+    ///
+    /// For a full deployment guide — including `markVersion`, multi-step migrations,
+    /// and strategy selection — see <doc:VersioningGuide>.
+    ///
     /// - Parameter changeID: A stable, unique string identifying this code change point.
     ///   Use a descriptive name like `"v2-add-notification"` — it must never be reused
     ///   for a different change in the same workflow.

--- a/Sources/StrandServer/Routes/QueueRoutes.swift
+++ b/Sources/StrandServer/Routes/QueueRoutes.swift
@@ -10,10 +10,12 @@ struct QueueRoutes {
 
     func register(on router: some RouterMethods<StrandRequestContext>) {
 
-        router.get("queues") { _, ctx -> [QueueResponse] in
+        router.get("queues") { req, ctx -> [QueueResponse] in
+            let rootOnly = req.uri.queryParameters.get("rootOnly").map { $0 == "true" } ?? false
             let rows = try await ManagementQueries.listQueueStats(
                 on: self.postgres,
                 namespaceID: ctx.namespaceID,
+                rootOnly: rootOnly,
                 logger: self.client.logger
             )
             return rows.map(QueueResponse.init)
@@ -25,13 +27,15 @@ struct QueueRoutes {
             return SimpleResponse(message: "created", id: body.name)
         }
 
-        router.get("queues/:queue") { _, ctx -> QueueResponse in
+        router.get("queues/:queue") { req, ctx -> QueueResponse in
             let queue = try ctx.parameters.require("queue")
+            let rootOnly = req.uri.queryParameters.get("rootOnly").map { $0 == "true" } ?? false
             guard
                 let row = try await ManagementQueries.queueStats(
                     on: self.postgres,
                     namespaceID: ctx.namespaceID,
                     queue: queue,
+                    rootOnly: rootOnly,
                     logger: self.client.logger
                 )
             else {

--- a/Tests/StrandTests/Schedule/ScheduleCalculatorTests.swift
+++ b/Tests/StrandTests/Schedule/ScheduleCalculatorTests.swift
@@ -497,3 +497,232 @@ struct ScheduleCalculatorTests {
         #expect(c.hour == 0)
     }
 }
+
+// MARK: - Typed constructor tests
+//
+// Reference week: 2024-03-11 (Mon) – 2024-03-17 (Sun) UTC.
+// Foundation Gregorian weekday numbers: Sun=1 Mon=2 Tue=3 Wed=4 Thu=5 Fri=6 Sat=7.
+//
+// Epoch-second anchors used by sub-hourly tests (UTC Jan 1 1970):
+//   00:00 =     0 s   00:07 =   420 s   00:15 =   900 s
+//   00:30 = 1 800 s   00:47 = 2 820 s   01:00 = 3 600 s
+//   10:00 = 36 000 s  18:00 = 64 800 s
+
+@Suite("Typed pattern constructors")
+struct TypedPatternConstructorTests {
+
+    // Shared UTC calendar used in every test.
+    private var utc: Calendar {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(identifier: "UTC")!
+        return c
+    }
+
+    /// Build a UTC Date at the given date and time.
+    private func date(
+        _ year: Int,
+        _ month: Int,
+        _ day: Int,
+        hour: Int = 0,
+        minute: Int = 0
+    ) -> Date {
+        utc.date(
+            from: DateComponents(
+                year: year,
+                month: month,
+                day: day,
+                hour: hour,
+                minute: minute,
+                second: 0
+            )
+        )!
+    }
+
+    // MARK: weekdays(hour:)
+
+    @Test(".weekdays(hour:) skips Saturday and Sunday to next Monday")
+    func weekdaysSkipsWeekend() throws {
+        let p = SchedulePattern.weekdays(hour: 9)
+        // Saturday 2024-03-16 08:00 UTC — next slot is Monday 09:00
+        let next = try #require(try p.nextRunTime(after: date(2024, 3, 16, hour: 8)))
+        let c = utc.dateComponents([.weekday, .hour, .minute], from: next)
+        #expect(c.weekday == 2)  // Monday
+        #expect(c.hour == 9)
+        #expect(c.minute == 0)
+    }
+
+    @Test(".weekdays(hour:) fires same day when still before the hour")
+    func weekdaysSameDayBeforeHour() throws {
+        let p = SchedulePattern.weekdays(hour: 9)
+        // Monday 2024-03-11 08:00 UTC — still before 09:00
+        let next = try #require(try p.nextRunTime(after: date(2024, 3, 11, hour: 8)))
+        let c = utc.dateComponents([.year, .month, .day, .hour], from: next)
+        #expect(c.year == 2024 && c.month == 3 && c.day == 11)
+        #expect(c.hour == 9)
+    }
+
+    @Test(".weekdays(hour:) advances to next weekday when hour is past")
+    func weekdaysNextDayAfterHour() throws {
+        let p = SchedulePattern.weekdays(hour: 9)
+        // Monday 2024-03-11 10:00 UTC — past 09:00, next is Tuesday
+        let next = try #require(try p.nextRunTime(after: date(2024, 3, 11, hour: 10)))
+        let c = utc.dateComponents([.day, .weekday, .hour], from: next)
+        #expect(c.day == 12)  // Tuesday the 12th
+        #expect(c.weekday == 3)  // Tuesday
+        #expect(c.hour == 9)
+    }
+
+    @Test(".weekdays(hour:) skips Sunday to Monday")
+    func weekdaysSkipsSunday() throws {
+        let p = SchedulePattern.weekdays(hour: 9)
+        // Sunday 2024-03-17 12:00 UTC
+        let next = try #require(try p.nextRunTime(after: date(2024, 3, 17, hour: 12)))
+        let c = utc.dateComponents([.weekday, .hour], from: next)
+        #expect(c.weekday == 2)  // Monday
+        #expect(c.hour == 9)
+    }
+
+    // MARK: weekdays(hours:)
+
+    @Test(".weekdays(hours:) picks the later-hour slot on the same day")
+    func weekdaysMultiHourSameDay() throws {
+        let p = SchedulePattern.weekdays(hours: 9, 16)
+        // Monday 10:00 — 09:00 is past, next is 16:00 same day
+        let next = try #require(try p.nextRunTime(after: date(2024, 3, 11, hour: 10)))
+        let c = utc.dateComponents([.day, .hour], from: next)
+        #expect(c.day == 11)  // same Monday
+        #expect(c.hour == 16)
+    }
+
+    @Test(".weekdays(hours:) rolls to the first listed hour on the next weekday")
+    func weekdaysMultiHourRollover() throws {
+        let p = SchedulePattern.weekdays(hours: 9, 16)
+        // Monday 17:00 — both hours past, next is Tuesday 09:00
+        let next = try #require(try p.nextRunTime(after: date(2024, 3, 11, hour: 17)))
+        let c = utc.dateComponents([.weekday, .hour], from: next)
+        #expect(c.weekday == 3)  // Tuesday
+        #expect(c.hour == 9)
+    }
+
+    // MARK: onDays(Weekday..., hour:)
+
+    @Test(".onDays fires on the next selected weekday, skipping unselected ones")
+    func onDaysNextSelectedDay() throws {
+        // From Tuesday, next selected day is Wednesday
+        let p = SchedulePattern.onDays(.monday, .wednesday, .friday, hour: 9)
+        let next = try #require(try p.nextRunTime(after: date(2024, 3, 12, hour: 10)))  // Tue 10:00
+        let c = utc.dateComponents([.weekday, .hour], from: next)
+        #expect(c.weekday == 4)  // Wednesday
+        #expect(c.hour == 9)
+    }
+
+    @Test(".onDays wraps to next week when all selected days in current week are past")
+    func onDaysWeekWrap() throws {
+        // Friday 10:00 — Fri is last selected day, next selection is Monday next week
+        let p = SchedulePattern.onDays(.monday, .wednesday, .friday, hour: 9)
+        let next = try #require(try p.nextRunTime(after: date(2024, 3, 15, hour: 10)))  // Fri 10:00
+        let c = utc.dateComponents([.weekday, .hour], from: next)
+        #expect(c.weekday == 2)  // Monday
+        #expect(c.hour == 9)
+    }
+
+    // MARK: onDays(Weekday..., hours:)
+
+    @Test(".onDays with multiple hours picks the correct remaining hour on the same day")
+    func onDaysMultiHourSameDay() throws {
+        // Monday 09:00 — 08:00 is past, next is 14:00 same day
+        let p = SchedulePattern.onDays(.monday, .wednesday, .friday, hours: 8, 14)
+        let next = try #require(try p.nextRunTime(after: date(2024, 3, 11, hour: 9)))
+        let c = utc.dateComponents([.day, .hour], from: next)
+        #expect(c.day == 11)  // same Monday
+        #expect(c.hour == 14)
+    }
+
+    @Test(".onDays with multiple hours rolls to first hour on the next selected day")
+    func onDaysMultiHourRollover() throws {
+        // Monday 15:00 — both 08:00 and 14:00 past; next is Wednesday 08:00
+        let p = SchedulePattern.onDays(.monday, .wednesday, .friday, hours: 8, 14)
+        let next = try #require(try p.nextRunTime(after: date(2024, 3, 11, hour: 15)))
+        let c = utc.dateComponents([.weekday, .hour], from: next)
+        #expect(c.weekday == 4)  // Wednesday
+        #expect(c.hour == 8)
+    }
+
+    // MARK: onHours
+
+    @Test(".onHours fires at the next listed hour within the same day")
+    func onHoursNextHour() throws {
+        let p = SchedulePattern.onHours(8, 12, 17)
+        // 10:00 UTC epoch day 0 (= 36 000 s); next is 12:00
+        let next = try #require(try p.nextRunTime(after: Date(timeIntervalSince1970: 36_000)))
+        let c = utc.dateComponents([.hour, .minute], from: next)
+        #expect(c.hour == 12)
+        #expect(c.minute == 0)
+    }
+
+    @Test(".onHours wraps to the first listed hour the next day after the last slot")
+    func onHoursWrapNextDay() throws {
+        let p = SchedulePattern.onHours(8, 12, 17)
+        // 18:00 UTC epoch day 0 (= 64 800 s); next is 08:00 on day 1
+        let next = try #require(try p.nextRunTime(after: Date(timeIntervalSince1970: 64_800)))
+        let c = utc.dateComponents([.hour, .minute], from: next)
+        #expect(c.hour == 8)
+        #expect(c.minute == 0)
+        #expect(next.timeIntervalSince1970 >= 86_400)  // must be day 1 or later
+    }
+
+    // MARK: onDates
+
+    @Test(".onDates fires on the next listed date within the same month")
+    func onDatesNextDate() throws {
+        let p = SchedulePattern.onDates(1, 15, hour: 9)
+        // 3rd of March — next listed date is the 15th
+        let next = try #require(try p.nextRunTime(after: date(2024, 3, 3, hour: 8)))
+        let c = utc.dateComponents([.day, .hour], from: next)
+        #expect(c.day == 15)
+        #expect(c.hour == 9)
+    }
+
+    @Test(".onDates wraps to the first listed date in the next month when all are past")
+    func onDatesNextMonth() throws {
+        let p = SchedulePattern.onDates(1, 15, hour: 9)
+        // 20th of March — both 1st and 15th are past; next is April 1st
+        let next = try #require(try p.nextRunTime(after: date(2024, 3, 20, hour: 8)))
+        let c = utc.dateComponents([.month, .day, .hour], from: next)
+        #expect(c.month == 4)  // April
+        #expect(c.day == 1)
+        #expect(c.hour == 9)
+    }
+
+    // MARK: onMinutes
+
+    @Test(".onMinutes fires at the next listed minute within the current hour")
+    func onMinutesNextMinute() throws {
+        let p = SchedulePattern.onMinutes(0, 15, 30, 45)
+        // 00:07:00 UTC (= 420 s) — next listed minute is 00:15
+        let next = try #require(try p.nextRunTime(after: Date(timeIntervalSince1970: 420)))
+        let c = utc.dateComponents([.hour, .minute], from: next)
+        #expect(c.hour == 0)
+        #expect(c.minute == 15)
+    }
+
+    @Test(".onMinutes rolls to the top of the next hour when past all listed minutes")
+    func onMinutesWrapToNextHour() throws {
+        let p = SchedulePattern.onMinutes(0, 15, 30, 45)
+        // 00:47:00 UTC (= 2 820 s) — past :45, next is 01:00
+        let next = try #require(try p.nextRunTime(after: Date(timeIntervalSince1970: 2_820)))
+        let c = utc.dateComponents([.hour, .minute], from: next)
+        #expect(c.hour == 1)
+        #expect(c.minute == 0)
+    }
+
+    @Test(".onMinutes picks the correct minute in a 30-minute schedule")
+    func onMinutesThirtyMin() throws {
+        let p = SchedulePattern.onMinutes(0, 30)
+        // 00:15:00 UTC (= 900 s) — next is 00:30
+        let next = try #require(try p.nextRunTime(after: Date(timeIntervalSince1970: 900)))
+        let c = utc.dateComponents([.hour, .minute], from: next)
+        #expect(c.hour == 0)
+        #expect(c.minute == 30)
+    }
+}

--- a/Tests/StrandTests/VersionTests.swift
+++ b/Tests/StrandTests/VersionTests.swift
@@ -34,6 +34,47 @@ private struct VersionedWorkflow: Workflow {
     }
 }
 
+// ── VersionBeforeSleepWorkflow ────────────────────────────────────────────────
+// The version checkpoint is written BEFORE the sleep, so a worker crash during
+// the sleep still has the checkpoint on disk. The fresh-path recovery on the
+// next worker must replay the stored value.
+// seqNum 1 = version checkpoint, seqNum 2 = sleep.
+// Used by: versionCheckpointSurvivesWorkerRestart
+
+private struct VersionBeforeSleepWorkflow: Workflow {
+    typealias Input = String
+    typealias Output = String
+
+    mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
+        // Version call is BEFORE the sleep — checkpoint written before sleep fires.
+        let isNew = try context.version(changeID: "v2-before-sleep")
+        try await context.sleep(for: .milliseconds(200))
+        return isNew ? "new-path" : "old-path"
+    }
+}
+
+// ── TwoVersionWorkflow ────────────────────────────────────────────────────────
+// Demonstrates the multi-step migration pattern: two independent changeIDs
+// called unconditionally, each consuming its own stable sequence number.
+// seqNum 1 = sleep, seqNum 2 = v2-feature, seqNum 3 = v3-feature.
+// Used by: multiStepBothDefault, multiStepMarkV3False, multiStepBothFalse
+
+private struct TwoVersionWorkflow: Workflow {
+    typealias Input = String
+    typealias Output = String
+
+    mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
+        // Sleep first so the test can mark version values before they are read.
+        try await context.sleep(for: .milliseconds(200))
+        // Both calls are UNCONDITIONAL — determinism requires this.
+        let isV2 = try context.version(changeID: "multi-v2")
+        let isV3 = try context.version(changeID: "multi-v3")
+        if isV3 { return "v3-path" }  // current code (both patches applied)
+        if isV2 { return "v2-path" }  // intermediate (only first patch)
+        return "original-path"  // neither patch applied
+    }
+}
+
 // MARK: - Test suite
 
 @Suite("Integration — Version checkpoints", .tags(.integration), .serialized)
@@ -65,7 +106,7 @@ struct VersionTests {
         }
     }
 
-    // ── 2 ───────────────────────────────────────────────────────────────────
+    // ── 2 ───────────────────────────────────────────────────────────────────────
     // `StrandClient.markVersion` writes a version checkpoint directly into the
     // DB while the workflow is SLEEPING (during its 200 ms sleep). When the
     // next activation loads its checkpoint cache it finds `false` for
@@ -115,6 +156,182 @@ struct VersionTests {
 
             let result = try await handle.result(timeout: .seconds(10))
             #expect(result == "old-path")
+        }
+    }
+
+    // ── 3 ───────────────────────────────────────────────────────────────────────
+    // The version checkpoint is written on the FIRST activation (before the sleep).
+    // Cancelling the first worker while the workflow sleeps simulates a crash.
+    // The second worker's fresh-path recovery loads checkpoints from the DB;
+    // version() must return the stored `true` value rather than `true` from
+    // a default — confirming the checkpoint survives a worker restart.
+    @Test("version checkpoint written before sleep survives worker restart")
+    func versionCheckpointSurvivesWorkerRestart() async throws {
+        try await withTestEnvironment { client in
+            // First worker runs the workflow until it enters the sleep.
+            let firstWorker = startWorker(
+                postgres: client.postgres,
+                queueName: client.queueName,
+                logger: client.logger,
+                workflows: [VersionBeforeSleepWorkflow.self]
+            )
+
+            let handle = try await client.startWorkflow(
+                VersionBeforeSleepWorkflow.self,
+                options: .init(),
+                input: "start"
+            )
+
+            // Wait until the workflow is SLEEPING (version checkpoint persisted,
+            // now suspended on the sleep timer).
+            let sleepDeadline = ContinuousClock.now + .seconds(5)
+            while ContinuousClock.now < sleepDeadline {
+                if let snap = try await handle.snapshot(), snap.state == .sleeping {
+                    break
+                }
+                try await Task.sleep(for: .milliseconds(20))
+            }
+
+            // Simulate a worker crash by cancelling the first worker.
+            // The run is now SLEEPING in the DB with a persisted version checkpoint.
+            firstWorker.cancel()
+
+            // Start a fresh worker. It will do a fresh-path activation: load
+            // checkpoints from DB, populate the checkpoint cache, then drain.
+            // version(changeID:) must return the stored `true` from the cache,
+            // not the default `true` from a new write — but the observable
+            // result is the same. The important thing is the checkpoint survives.
+            let secondWorker = startWorker(
+                postgres: client.postgres,
+                queueName: client.queueName,
+                logger: client.logger,
+                workflows: [VersionBeforeSleepWorkflow.self]
+            )
+            defer { secondWorker.cancel() }
+
+            let result = try await handle.result(timeout: .seconds(10))
+            // version checkpoint stored `true` before crash — new-path after recovery.
+            #expect(result == "new-path")
+        }
+    }
+
+    // ── 4 ───────────────────────────────────────────────────────────────────────
+    // Multi-step migration — both changeIDs default to `true`.
+    // Neither markVersion call is made: isV2=true, isV3=true → "v3-path".
+    @Test("multi-step: both version gates default to true and take the v3 path")
+    func multiStepBothDefault() async throws {
+        try await withTestEnvironment { client in
+            let workerTask = startWorker(
+                postgres: client.postgres,
+                queueName: client.queueName,
+                logger: client.logger,
+                workflows: [TwoVersionWorkflow.self]
+            )
+            defer { workerTask.cancel() }
+
+            let handle = try await client.startWorkflow(
+                TwoVersionWorkflow.self,
+                options: .init(),
+                input: "start"
+            )
+            let result = try await handle.result(timeout: .seconds(10))
+            // Both default to true; v3 wins the cascading check.
+            #expect(result == "v3-path")
+        }
+    }
+
+    // ── 5 ───────────────────────────────────────────────────────────────────────
+    // Multi-step migration — only the LATEST (v3) gate is forced to false.
+    // seqNum layout: sleep=1, multi-v2=2, multi-v3=3.
+    // While sleeping (1 checkpoint written), v3 is the second unwritten version
+    // call → callSiteIndex: 2 → seqNum = 1+2 = 3.
+    // Result: isV2=true (default), isV3=false → "v2-path".
+    @Test("multi-step: marking only the v3 gate false takes the intermediate v2 path")
+    func multiStepMarkV3False() async throws {
+        try await withTestEnvironment { client in
+            let workerTask = startWorker(
+                postgres: client.postgres,
+                queueName: client.queueName,
+                logger: client.logger,
+                workflows: [TwoVersionWorkflow.self]
+            )
+            defer { workerTask.cancel() }
+
+            let handle = try await client.startWorkflow(
+                TwoVersionWorkflow.self,
+                options: .init(),
+                input: "start"
+            )
+
+            let sleepDeadline = ContinuousClock.now + .seconds(5)
+            while ContinuousClock.now < sleepDeadline {
+                if let snap = try await handle.snapshot(), snap.state == .sleeping {
+                    break
+                }
+                try await Task.sleep(for: .milliseconds(20))
+            }
+
+            // 1 checkpoint written (sleep at seqNum 1).
+            // v3 is the 2nd unwritten version call → callSiteIndex: 2 → seqNum 3.
+            try await client.markVersion(
+                changeID: "multi-v3",
+                value: false,
+                taskID: handle.taskID,
+                callSiteIndex: 2
+            )
+
+            let result = try await handle.result(timeout: .seconds(10))
+            #expect(result == "v2-path")
+        }
+    }
+
+    // ── 6 ───────────────────────────────────────────────────────────────────────
+    // Multi-step migration — BOTH gates forced to false.
+    // Mark v2 first (callSiteIndex: 1 → seqNum=2), which writes a checkpoint and
+    // advances the count to 2. Then mark v3 (callSiteIndex: 1 → seqNum=3).
+    // Result: isV2=false, isV3=false → "original-path".
+    @Test("multi-step: marking both gates false takes the original path")
+    func multiStepBothFalse() async throws {
+        try await withTestEnvironment { client in
+            let workerTask = startWorker(
+                postgres: client.postgres,
+                queueName: client.queueName,
+                logger: client.logger,
+                workflows: [TwoVersionWorkflow.self]
+            )
+            defer { workerTask.cancel() }
+
+            let handle = try await client.startWorkflow(
+                TwoVersionWorkflow.self,
+                options: .init(),
+                input: "start"
+            )
+
+            let sleepDeadline = ContinuousClock.now + .seconds(5)
+            while ContinuousClock.now < sleepDeadline {
+                if let snap = try await handle.snapshot(), snap.state == .sleeping {
+                    break
+                }
+                try await Task.sleep(for: .milliseconds(20))
+            }
+
+            // Mark v2 first: count=1, callSiteIndex=1 → seqNum=2. Count becomes 2.
+            try await client.markVersion(
+                changeID: "multi-v2",
+                value: false,
+                taskID: handle.taskID,
+                callSiteIndex: 1
+            )
+            // Mark v3 next: count=2, callSiteIndex=1 → seqNum=3.
+            try await client.markVersion(
+                changeID: "multi-v3",
+                value: false,
+                taskID: handle.taskID,
+                callSiteIndex: 1
+            )
+
+            let result = try await handle.result(timeout: .seconds(10))
+            #expect(result == "original-path")
         }
     }
 }

--- a/loom/src/api/queues.ts
+++ b/loom/src/api/queues.ts
@@ -1,29 +1,42 @@
 import { api } from "./client";
 import type { Queue } from "./types";
 
-export const getQueues = (namespace: string) =>
-  api.get<Queue[]>(`/api/${namespace}/queues`).then((r) => r.data);
+export const getQueues = (
+    namespace: string,
+    opts: { rootOnly?: boolean } = {},
+) =>
+    api
+        .get<Queue[]>(`/api/${namespace}/queues`, { params: opts })
+        .then((r) => r.data);
 
-export const getQueue = (namespace: string, queue: string) =>
-  api.get<Queue>(`/api/${namespace}/queues/${queue}`).then((r) => r.data);
+export const getQueue = (
+    namespace: string,
+    queue: string,
+    opts: { rootOnly?: boolean } = {},
+) =>
+    api
+        .get<Queue>(`/api/${namespace}/queues/${queue}`, { params: opts })
+        .then((r) => r.data);
 
 export const createQueue = (namespace: string, name: string) =>
-  api.post(`/api/${namespace}/queues`, { name }).then((r) => r.data);
+    api.post(`/api/${namespace}/queues`, { name }).then((r) => r.data);
 
 export const deleteQueue = (namespace: string, queue: string) =>
-  api.delete(`/api/${namespace}/queues/${queue}`).then((r) => r.data);
+    api.delete(`/api/${namespace}/queues/${queue}`).then((r) => r.data);
 
 export const cleanupQueue = (
-  namespace: string,
-  queue: string,
-  opts: { olderThan?: number; limit?: number } = {},
+    namespace: string,
+    queue: string,
+    opts: { olderThan?: number; limit?: number } = {},
 ) =>
-  api
-    .post(`/api/${namespace}/queues/${queue}/cleanup`, null, { params: opts })
-    .then((r) => r.data);
+    api
+        .post(`/api/${namespace}/queues/${queue}/cleanup`, null, {
+            params: opts,
+        })
+        .then((r) => r.data);
 
 export const pauseQueue = (namespace: string, queue: string) =>
-  api.post(`/api/${namespace}/queues/${queue}/pause`).then((r) => r.data);
+    api.post(`/api/${namespace}/queues/${queue}/pause`).then((r) => r.data);
 
 export const resumeQueue = (namespace: string, queue: string) =>
-  api.post(`/api/${namespace}/queues/${queue}/resume`).then((r) => r.data);
+    api.post(`/api/${namespace}/queues/${queue}/resume`).then((r) => r.data);

--- a/loom/src/api/tasks.ts
+++ b/loom/src/api/tasks.ts
@@ -12,7 +12,12 @@ import type { TraceSpan } from "@/components/TraceTree";
 export const getTasks = (
     namespace: string,
     queue: string,
-    opts: { state?: string; cursor?: string; limit?: number } = {},
+    opts: {
+        state?: string;
+        cursor?: string;
+        limit?: number;
+        rootOnly?: boolean;
+    } = {},
 ) =>
     api
         .get<CursorPage<TaskSummary>>(

--- a/loom/src/components/RetryDialog.tsx
+++ b/loom/src/components/RetryDialog.tsx
@@ -6,194 +6,201 @@ import type { RetryMode, RetryOptions } from "@/api/types";
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 interface RetryDialogProps {
-  open: boolean;
-  onClose: () => void;
-  onConfirm: (opts: RetryOptions) => void;
-  isPending: boolean;
-  taskState: string; // "FAILED" | "CANCELLED" | "COMPLETED" | etc.
+    open: boolean;
+    onClose: () => void;
+    onConfirm: (opts: RetryOptions) => void;
+    isPending: boolean;
+    taskState: string; // "FAILED" | "CANCELLED" | "COMPLETED" | etc.
 }
 
 // ─── Mode options ─────────────────────────────────────────────────────────────
 
 interface ModeOption {
-  value: RetryMode;
-  label: string;
-  description: string;
+    value: RetryMode;
+    label: string;
+    description: string;
 }
 
 const MODE_OPTIONS: ModeOption[] = [
-  {
-    value: "all",
-    label: "All tasks",
-    description: "Retry every task in the workflow.",
-  },
-  {
-    value: "failed_only",
-    label: "Only failed tasks",
-    description: "Only retry tasks that failed or were cancelled.",
-  },
-  {
-    value: "failed_and_dependents",
-    label: "Failed tasks + dependents",
-    description:
-      "Retry failed tasks and any downstream tasks that depend on them, even if they previously succeeded.",
-  },
+    {
+        value: "failed_only",
+        label: "Only failed tasks",
+        description:
+            "Re-run only tasks that failed or were cancelled. Completed activities replay their cached results instantly.",
+    },
+    {
+        value: "failed_and_dependents",
+        label: "Failed tasks + dependents",
+        description:
+            "Re-run failed tasks and any tasks that ran after the first failure, even if they completed successfully.",
+    },
+    {
+        value: "all",
+        label: "All tasks",
+        description:
+            "Reset every task in the workflow to PENDING. Completed activities will re-run — no results are replayed from cache.",
+    },
 ];
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function RetryDialog({
-  open,
-  onClose,
-  onConfirm,
-  isPending,
-  taskState: _taskState,
+    open,
+    onClose,
+    onConfirm,
+    isPending,
+    taskState: _taskState,
 }: RetryDialogProps) {
-  const [mode, setMode] = useState<RetryMode>("all");
-  const [resetHistory, setResetHistory] = useState(false);
+    const [mode, setMode] = useState<RetryMode>("failed_only");
+    const [resetHistory, setResetHistory] = useState(false);
 
-  if (!open) return null;
+    if (!open) return null;
 
-  const handleConfirm = () => {
-    onConfirm({ mode, resetHistory });
-  };
+    const handleConfirm = () => {
+        onConfirm({ mode, resetHistory });
+    };
 
-  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (e.target === e.currentTarget && !isPending) {
-      onClose();
-    }
-  };
+    const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+        if (e.target === e.currentTarget && !isPending) {
+            onClose();
+        }
+    };
 
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      onClick={handleBackdropClick}
-    >
-      <div
-        className="relative w-full max-w-md rounded-xl border border-border bg-background shadow-2xl"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="retry-dialog-title"
-      >
-        {/* ── Header ────────────────────────────────────────────────── */}
-        <div className="px-6 pt-6 pb-4">
-          <h2
-            id="retry-dialog-title"
-            className="text-base font-semibold text-foreground"
-          >
-            Retry workflow
-          </h2>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Choose how to retry this workflow.
-          </p>
-        </div>
-
-        {/* ── Body ──────────────────────────────────────────────────── */}
-        <div className="px-6 pb-4 space-y-4">
-          {/* Mode selector */}
-          <div className="space-y-2">
-            {MODE_OPTIONS.map((opt) => {
-              const isSelected = mode === opt.value;
-              return (
-                <button
-                  key={opt.value}
-                  type="button"
-                  onClick={() => setMode(opt.value)}
-                  className={`w-full rounded-lg border px-4 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
-                    isSelected
-                      ? "border-primary/60 bg-primary/10"
-                      : "border-border bg-card/40 hover:bg-secondary/30"
-                  }`}
-                >
-                  <div className="flex items-center gap-3">
-                    {/* Radio indicator */}
-                    <span
-                      className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-2 transition-colors ${
-                        isSelected
-                          ? "border-primary"
-                          : "border-muted-foreground/40"
-                      }`}
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+            onClick={handleBackdropClick}
+        >
+            <div
+                className="relative w-full max-w-md rounded-xl border border-border bg-background shadow-2xl"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="retry-dialog-title"
+            >
+                {/* ── Header ────────────────────────────────────────────────── */}
+                <div className="px-6 pt-6 pb-4">
+                    <h2
+                        id="retry-dialog-title"
+                        className="text-base font-semibold text-foreground"
                     >
-                      {isSelected && (
-                        <span className="block h-1.5 w-1.5 rounded-full bg-primary" />
-                      )}
-                    </span>
-                    <div className="min-w-0">
-                      <p className="text-sm font-medium text-foreground">
-                        {opt.label}
-                      </p>
-                      <p className="text-xs text-muted-foreground mt-0.5">
-                        {opt.description}
-                      </p>
+                        Retry workflow
+                    </h2>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                        Choose how to retry this workflow.
+                    </p>
+                </div>
+
+                {/* ── Body ──────────────────────────────────────────────────── */}
+                <div className="px-6 pb-4 space-y-4">
+                    {/* Mode selector */}
+                    <div className="space-y-2">
+                        {MODE_OPTIONS.map((opt) => {
+                            const isSelected = mode === opt.value;
+                            return (
+                                <button
+                                    key={opt.value}
+                                    type="button"
+                                    onClick={() => setMode(opt.value)}
+                                    className={`w-full rounded-lg border px-4 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
+                                        isSelected
+                                            ? "border-primary/60 bg-primary/10"
+                                            : "border-border bg-card/40 hover:bg-secondary/30"
+                                    }`}
+                                >
+                                    <div className="flex items-center gap-3">
+                                        {/* Radio indicator */}
+                                        <span
+                                            className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-2 transition-colors ${
+                                                isSelected
+                                                    ? "border-primary"
+                                                    : "border-muted-foreground/40"
+                                            }`}
+                                        >
+                                            {isSelected && (
+                                                <span className="block h-1.5 w-1.5 rounded-full bg-primary" />
+                                            )}
+                                        </span>
+                                        <div className="min-w-0">
+                                            <p className="text-sm font-medium text-foreground">
+                                                {opt.label}
+                                            </p>
+                                            <p className="text-xs text-muted-foreground mt-0.5">
+                                                {opt.description}
+                                            </p>
+                                        </div>
+                                    </div>
+                                </button>
+                            );
+                        })}
                     </div>
-                  </div>
-                </button>
-              );
-            })}
-          </div>
 
-          {/* Strand note */}
-          <div className="rounded-md border border-border/60 bg-muted/20 px-3.5 py-2.5">
-            <p className="text-xs text-muted-foreground leading-relaxed">
-              In Strand, completed activities are automatically skipped via
-              checkpoint replay regardless of mode — retrying a cancelled
-              workflow always resumes from the last completed step.
-            </p>
-          </div>
+                    {/* Strand note */}
+                    <div className="rounded-md border border-border/60 bg-muted/20 px-3.5 py-2.5">
+                        <p className="text-xs text-muted-foreground leading-relaxed">
+                            Activities not selected by the mode replay their
+                            cached results instantly — no re-execution, no extra
+                            cost. Only the selected tasks are reset to PENDING
+                            and re-run.
+                        </p>
+                    </div>
 
-          {/* Reset history checkbox */}
-          <div>
-            <p className="text-[10px] uppercase tracking-wide font-medium text-muted-foreground mb-2">
-              Options
-            </p>
-            <label className="flex cursor-pointer items-start gap-3">
-              <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center">
-                <input
-                  type="checkbox"
-                  checked={resetHistory}
-                  onChange={(e) => setResetHistory(e.target.checked)}
-                  className="h-4 w-4 rounded border-border bg-background accent-primary cursor-pointer"
-                />
-              </span>
-              <div className="min-w-0">
-                <p className="text-sm font-medium text-foreground leading-tight">
-                  Reset history
-                </p>
-                <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">
-                  Resets attempt counts and clears error history. If unchecked,
-                  attempt count continues from where it left off and max
-                  attempts is extended by one.
-                </p>
-              </div>
-            </label>
-          </div>
+                    {/* Reset history checkbox */}
+                    <div>
+                        <p className="text-[10px] uppercase tracking-wide font-medium text-muted-foreground mb-2">
+                            Options
+                        </p>
+                        <label className="flex cursor-pointer items-start gap-3">
+                            <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center">
+                                <input
+                                    type="checkbox"
+                                    checked={resetHistory}
+                                    onChange={(e) =>
+                                        setResetHistory(e.target.checked)
+                                    }
+                                    className="h-4 w-4 rounded border-border bg-background accent-primary cursor-pointer"
+                                />
+                            </span>
+                            <div className="min-w-0">
+                                <p className="text-sm font-medium text-foreground leading-tight">
+                                    Reset history
+                                </p>
+                                <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">
+                                    Restarts from attempt 1 with a fully clean
+                                    slate — removes all prior run records,
+                                    timeline history, and workflow state. If
+                                    unchecked, the attempt counter increments
+                                    and max attempts is extended by one.
+                                </p>
+                            </div>
+                        </label>
+                    </div>
+                </div>
+
+                {/* ── Footer ────────────────────────────────────────────────── */}
+                <div className="flex items-center justify-end gap-2 border-t border-border px-6 py-4">
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={onClose}
+                        disabled={isPending}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        variant="default"
+                        size="sm"
+                        onClick={handleConfirm}
+                        disabled={isPending}
+                    >
+                        {isPending ? (
+                            <Loader2 size={13} className="animate-spin" />
+                        ) : (
+                            <RefreshCw size={13} />
+                        )}
+                        Retry
+                    </Button>
+                </div>
+            </div>
         </div>
-
-        {/* ── Footer ────────────────────────────────────────────────── */}
-        <div className="flex items-center justify-end gap-2 border-t border-border px-6 py-4">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onClose}
-            disabled={isPending}
-          >
-            Cancel
-          </Button>
-          <Button
-            variant="default"
-            size="sm"
-            onClick={handleConfirm}
-            disabled={isPending}
-          >
-            {isPending ? (
-              <Loader2 size={13} className="animate-spin" />
-            ) : (
-              <RefreshCw size={13} />
-            )}
-            Retry
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
+    );
 }

--- a/loom/src/components/TraceTree.tsx
+++ b/loom/src/components/TraceTree.tsx
@@ -25,6 +25,7 @@ import {
 } from "lucide-react";
 import { cn, fmtDuration } from "@/lib/utils";
 import { TimeBrush } from "@/components/TimeBrush";
+import { JsonView } from "@/components/JsonView";
 
 // ── Public types ─────────────────────────────────────────────────────────────
 
@@ -1620,15 +1621,9 @@ export function TraceTree({
                                                 {isDetailLoading ? (
                                                     <JsonSkeleton />
                                                 ) : spanDetail?.input ? (
-                                                    <pre className="bg-secondary/30 border border-border/40 rounded p-2 text-[10px] font-mono text-foreground/80 overflow-x-auto whitespace-pre-wrap break-all leading-relaxed select-text transition-opacity duration-150">
-                                                        {JSON.stringify(
-                                                            JSON.parse(
-                                                                spanDetail.input,
-                                                            ),
-                                                            null,
-                                                            2,
-                                                        )}
-                                                    </pre>
+                                                    <JsonView
+                                                        value={spanDetail.input}
+                                                    />
                                                 ) : (
                                                     <p className="text-[10px] text-muted-foreground/50 italic">
                                                         —
@@ -1644,15 +1639,11 @@ export function TraceTree({
                                                 {isDetailLoading ? (
                                                     <JsonSkeleton />
                                                 ) : spanDetail?.output ? (
-                                                    <pre className="bg-secondary/30 border border-border/40 rounded p-2 text-[10px] font-mono text-foreground/80 overflow-x-auto whitespace-pre-wrap break-all leading-relaxed select-text transition-opacity duration-150">
-                                                        {JSON.stringify(
-                                                            JSON.parse(
-                                                                spanDetail.output,
-                                                            ),
-                                                            null,
-                                                            2,
-                                                        )}
-                                                    </pre>
+                                                    <JsonView
+                                                        value={
+                                                            spanDetail.output
+                                                        }
+                                                    />
                                                 ) : (
                                                     <p className="text-[10px] text-muted-foreground/50 italic">
                                                         —

--- a/loom/src/routes/queues_/$queue.tsx
+++ b/loom/src/routes/queues_/$queue.tsx
@@ -13,14 +13,80 @@ import { Button } from "@/components/ui/button";
 import { CalendarClock, ArrowLeft, Pause, Play } from "lucide-react";
 import type { Queue, TaskState, TaskSummary } from "@/api/types";
 
-const STATES = [
-    "PENDING",
-    "RUNNING",
-    "SLEEPING",
-    "COMPLETED",
-    "FAILED",
-    "CANCELLED",
-];
+// State config mirrors runs.tsx — label, stats key, accent colour
+const STATE_CONFIG = [
+    {
+        state: "RUNNING",
+        key: "running" as const,
+        accent: "bg-yellow-500/20 text-yellow-300",
+    },
+    {
+        state: "PENDING",
+        key: "pending" as const,
+        accent: "bg-blue-500/15   text-blue-400",
+    },
+    {
+        state: "SLEEPING",
+        key: "sleeping" as const,
+        accent: "bg-slate-500/20  text-slate-300",
+    },
+    {
+        state: "WAITING",
+        key: "waiting" as const,
+        accent: "bg-violet-500/20 text-violet-300",
+    },
+    {
+        state: "COMPLETED",
+        key: "completed" as const,
+        accent: "bg-green-500/15  text-green-400",
+    },
+    {
+        state: "FAILED",
+        key: "failed" as const,
+        accent: "bg-red-500/20    text-red-400",
+    },
+    {
+        state: "CANCELLED",
+        key: "cancelled" as const,
+        accent: "bg-slate-500/15  text-slate-400",
+    },
+] as const;
+
+function StatePill({
+    label,
+    count,
+    active,
+    accent,
+    onClick,
+}: {
+    label: string;
+    count: number;
+    active: boolean;
+    accent: string;
+    onClick: () => void;
+}) {
+    return (
+        <button
+            onClick={onClick}
+            className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+                active
+                    ? "bg-secondary text-foreground"
+                    : "text-muted-foreground hover:text-foreground hover:bg-secondary/60"
+            }`}
+        >
+            {label.charAt(0) + label.slice(1).toLowerCase()}
+            {count > 0 && (
+                <span
+                    className={`rounded px-1 py-px text-[10px] font-mono leading-none ${
+                        active ? "bg-white/10 text-foreground" : accent
+                    }`}
+                >
+                    {count >= 1000 ? `${Math.floor(count / 1000)}k` : count}
+                </span>
+            )}
+        </button>
+    );
+}
 
 function QueueBar({ stats }: { stats: Queue["stats"] }) {
     const total =
@@ -40,47 +106,23 @@ function QueueBar({ stats }: { stats: Queue["stats"] }) {
         { count: stats.running, cls: "bg-yellow-400" },
         { count: stats.pending, cls: "bg-blue-400" },
         { count: stats.sleeping, cls: "bg-indigo-400" },
+        { count: stats.waiting, cls: "bg-violet-400" },
         { count: stats.failed, cls: "bg-red-400" },
         { count: stats.cancelled, cls: "bg-orange-400" },
         { count: stats.completed, cls: "bg-green-400" },
     ].filter((s) => s.count > 0);
 
-    const items = [
-        { label: "Running", count: stats.running, dot: "bg-yellow-400" },
-        { label: "Pending", count: stats.pending, dot: "bg-blue-400" },
-        { label: "Sleeping", count: stats.sleeping, dot: "bg-indigo-400" },
-        { label: "Failed", count: stats.failed, dot: "bg-red-400" },
-        { label: "Cancelled", count: stats.cancelled, dot: "bg-orange-400" },
-        { label: "Completed", count: stats.completed, dot: "bg-green-400" },
-    ].filter((i) => i.count > 0);
-
+    // Legend is intentionally omitted — the StatePill filter bar below shows
+    // the same counts and doubles as the click-to-filter control.
     return (
-        <div className="space-y-2">
-            <div className="flex h-1.5 w-full overflow-hidden rounded-full bg-muted">
-                {segments.map((seg, i) => (
-                    <div
-                        key={i}
-                        className={`${seg.cls} opacity-80`}
-                        style={{ width: `${(seg.count / total) * 100}%` }}
-                    />
-                ))}
-            </div>
-            <div className="flex flex-wrap gap-x-4 gap-y-0.5">
-                {items.map((item) => (
-                    <span
-                        key={item.label}
-                        className="flex items-center gap-1.5 text-xs text-muted-foreground"
-                    >
-                        <span
-                            className={`size-1.5 rounded-full ${item.dot} opacity-80`}
-                        />
-                        {item.label}:{" "}
-                        <strong className="text-foreground font-medium">
-                            {item.count.toLocaleString()}
-                        </strong>
-                    </span>
-                ))}
-            </div>
+        <div className="flex h-1.5 w-full overflow-hidden rounded-full bg-muted">
+            {segments.map((seg, i) => (
+                <div
+                    key={i}
+                    className={`${seg.cls} opacity-80`}
+                    style={{ width: `${(seg.count / total) * 100}%` }}
+                />
+            ))}
         </div>
     );
 }
@@ -98,9 +140,11 @@ export function QueueDetailPage() {
     const [history, setHistory] = useState<string[]>([]);
 
     // ── Queue detail (stats + paused) ───────────────────────────────────────
+    // Queue detail always shows root tasks only — child activities are spawned
+    // automatically by workflows and are not the primary concern of this view.
     const { data: queueData } = useQuery({
         queryKey: qk.queues.detail(namespace, queue),
-        queryFn: () => getQueue(namespace, queue),
+        queryFn: () => getQueue(namespace, queue, { rootOnly: true }),
         refetchInterval: 5_000,
     });
 
@@ -128,6 +172,7 @@ export function QueueDetailPage() {
                 state: stateFilter,
                 cursor,
                 limit: 50,
+                rootOnly: true,
             }),
         refetchInterval: (query) => {
             const items = query.state.data?.items as
@@ -219,38 +264,37 @@ export function QueueDetailPage() {
                 </div>
             )}
 
-            {/* State filter tabs */}
-            <div className="flex gap-1.5 mb-4 flex-wrap">
-                <button
+            {/* Filter bar: state pills with live counts from queueData.stats */}
+            <div className="flex gap-1.5 mb-4 flex-wrap items-center">
+                {/* All */}
+                <StatePill
+                    label="All"
+                    count={0}
+                    active={stateFilter === undefined}
+                    accent=""
                     onClick={() => {
                         setStateFilter(undefined);
                         setCursor(undefined);
                         setHistory([]);
                     }}
-                    className={`px-3 py-1 rounded text-xs font-medium transition-colors ${
-                        stateFilter === undefined
-                            ? "bg-secondary text-secondary-foreground"
-                            : "text-muted-foreground hover:text-foreground hover:bg-secondary/60"
-                    }`}
-                >
-                    All
-                </button>
-                {STATES.map((s) => (
-                    <button
-                        key={s}
+                />
+
+                {/* Per-state pills with counts from queueData.stats */}
+                {STATE_CONFIG.map(({ state, key, accent }) => (
+                    <StatePill
+                        key={state}
+                        label={state}
+                        count={queueData?.stats[key] ?? 0}
+                        active={stateFilter === state}
+                        accent={accent}
                         onClick={() => {
-                            setStateFilter(s);
+                            setStateFilter(
+                                stateFilter === state ? undefined : state,
+                            );
                             setCursor(undefined);
                             setHistory([]);
                         }}
-                        className={`px-3 py-1 rounded text-xs font-medium transition-colors ${
-                            stateFilter === s
-                                ? "bg-secondary text-secondary-foreground"
-                                : "text-muted-foreground hover:text-foreground hover:bg-secondary/60"
-                        }`}
-                    >
-                        {s.charAt(0) + s.slice(1).toLowerCase()}
-                    </button>
+                    />
                 ))}
             </div>
 

--- a/loom/src/routes/runs.tsx
+++ b/loom/src/routes/runs.tsx
@@ -251,8 +251,9 @@ export function RunsPage() {
 
     // ── Data fetching ──────────────────────────────────────────────────────
     const { data: queues = [] } = useQuery({
-        queryKey: qk.queues.list(namespace),
-        queryFn: () => getQueues(namespace),
+        queryKey: [...qk.queues.list(namespace), rootOnly],
+        queryFn: () =>
+            getQueues(namespace, { rootOnly: rootOnly || undefined }),
         refetchInterval: 10_000,
     });
 
@@ -380,22 +381,6 @@ export function RunsPage() {
                     ))}
                 </div>
 
-                {/* Root only toggle */}
-                <button
-                    onClick={() => {
-                        setRootOnly((v) => !v);
-                        setCursor(undefined);
-                    }}
-                    className={`inline-flex items-center gap-1.5 rounded border px-2.5 py-1 text-xs font-medium transition-colors ${
-                        rootOnly
-                            ? "bg-brand/15 text-brand border-brand/30"
-                            : "border-border text-muted-foreground hover:text-foreground"
-                    }`}
-                    title="Hide child activities spawned by workflows"
-                >
-                    Root only
-                </button>
-
                 <div className="h-4 w-px bg-border/50 hidden sm:block" />
 
                 {/* "All states" pill */}
@@ -421,6 +406,22 @@ export function RunsPage() {
                         }
                     />
                 ))}
+
+                {/* Root only toggle — lives next to state filters, not kind filters */}
+                <button
+                    onClick={() => {
+                        setRootOnly((v) => !v);
+                        setCursor(undefined);
+                    }}
+                    className={`inline-flex items-center gap-1.5 rounded border px-2.5 py-1 text-xs font-medium transition-colors ${
+                        rootOnly
+                            ? "bg-brand/15 text-brand border-brand/30"
+                            : "border-border text-muted-foreground hover:text-foreground"
+                    }`}
+                    title="Hide child activities spawned by workflows"
+                >
+                    Root only
+                </button>
 
                 {/* Clear-all indicator */}
                 {hasActiveFilters && (

--- a/loom/src/routes/tasks_/$taskId.tsx
+++ b/loom/src/routes/tasks_/$taskId.tsx
@@ -900,9 +900,6 @@ export function TaskDetailPage() {
     const [retryDialogOpen, setRetryDialogOpen] = useState(false);
     const [signalDialogOpen, setSignalDialogOpen] = useState(false);
     const [triggerOpen, setTriggerOpen] = useState(false);
-    const [triggerMode, setTriggerMode] = useState<"template" | "exact">(
-        "template",
-    );
 
     const signalMutation = useMutation({
         mutationFn: ({ name, payload }: { name: string; payload?: string }) =>
@@ -1149,32 +1146,15 @@ export function TaskDetailPage() {
                         </Button>
                     )}
                     {isWorkflow && (
-                        <div className="flex">
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={() => {
-                                    setTriggerMode("template");
-                                    setTriggerOpen(true);
-                                }}
-                                className="gap-1.5 rounded-r-none border-r-0"
-                            >
-                                <Zap size={12} />
-                                Run Again
-                            </Button>
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={() => {
-                                    setTriggerMode("exact");
-                                    setTriggerOpen(true);
-                                }}
-                                className="rounded-l-none px-2"
-                                title="Replay with exact input from this run"
-                            >
-                                ↺
-                            </Button>
-                        </div>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setTriggerOpen(true)}
+                            className="gap-1.5"
+                        >
+                            <Zap size={12} />
+                            Run Again
+                        </Button>
                     )}
                 </div>
             </div>
@@ -1459,11 +1439,7 @@ export function TaskDetailPage() {
                 namespace={namespace}
                 initialWorkflowName={task.name}
                 initialQueue={task.queue}
-                initialInput={
-                    triggerMode === "exact"
-                        ? (task.params ?? "{}")
-                        : paramsTemplate(task.params)
-                }
+                initialInput={paramsTemplate(task.params)}
             />
         </div>
     );

--- a/strand.sql
+++ b/strand.sql
@@ -17,6 +17,46 @@
 
 CREATE SCHEMA IF NOT EXISTS strand;
 
+-- pgcrypto: required by strand.gen_uuid_v7() for gen_random_bytes().
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- UUIDv7 generator (PostgreSQL < 18 compatibility shim)
+--
+-- PostgreSQL 18 shipped a built-in gen_uuid_v7(). This function provides the
+-- same semantics for PostgreSQL 15–17 using pgcrypto's gen_random_bytes().
+--
+-- RFC 9562 layout:
+--   bits  0-47  unix_ts_ms   48-bit millisecond timestamp (big-endian)
+--   bits 48-51  ver          0b0111 (version 7)
+--   bits 52-63  rand_a       12 random bits
+--   bits 64-65  var          0b10   (RFC 4122 variant)
+--   bits 66-127 rand_b       62 random bits
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION strand.gen_uuid_v7()
+RETURNS UUID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    unix_ms BIGINT;
+    rand_b  BYTEA;
+BEGIN
+    unix_ms := (extract(epoch FROM clock_timestamp()) * 1000)::BIGINT;
+    rand_b  := gen_random_bytes(10);
+    RETURN encode(
+        -- bytes 0-5: 48-bit millisecond timestamp
+        substring(int8send(unix_ms) FROM 3)
+        -- bytes 6-7: version nibble 7 (0x7) || 12 random bits
+        || set_byte(substring(rand_b FROM 1 FOR 2), 0,
+                    (get_byte(rand_b, 0) & 15) | 112)
+        -- bytes 8-15: variant 10xxxxxx || 62 random bits
+        || set_byte(substring(rand_b FROM 3 FOR 8), 0,
+                    (get_byte(rand_b, 2) & 63) | 128),
+        'hex')::UUID;
+END;
+$$;
+
 -- ─────────────────────────────────────────────────────────────────────────────
 -- Namespaces — top-level isolation boundary.
 --
@@ -433,7 +473,7 @@ CREATE TABLE IF NOT EXISTS strand.workflow_state (
 -- ─────────────────────────────────────────────────────────────────────────────
 
 CREATE TABLE IF NOT EXISTS strand.workflow_signals (
-    id           UUID        NOT NULL DEFAULT gen_random_uuid(),
+    id           UUID        NOT NULL DEFAULT strand.gen_uuid_v7(),
     seq          BIGSERIAL   NOT NULL,   -- monotonic total order, unaffected by transaction commit ordering
     namespace_id TEXT        NOT NULL DEFAULT 'default',
     task_id      UUID        NOT NULL REFERENCES strand.tasks(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary

Document Versioning workflows and Schedules

## Changes

- Workflow Versioning document
- Schedule document
- Fixed Re-run workflow options to allow complete reset
- Added Version tests 
- Schedule helpers to make defining schedules easier

## Testing

<!-- How did you verify this works? Did you run `swift test`? -->

- [x] `swift test` passes locally

## AI Disclosure

<!--
  REQUIRED if any AI assistance was used — see CONTRIBUTING.md.
  Delete this section entirely if no AI was involved.
-->

- [ ] I used AI assistance while working on this PR

**Tool(s) used:** <!-- e.g. Claude, Copilot, ChatGPT -->

**Extent of use:**
<!-- Describe honestly. Examples:
  - Generated first draft of WorkflowDag.tsx, reviewed and edited manually.
  - Used for commit message suggestions only.
  - Pair-programmed the entire feature; all output was reviewed.
-->

**Was the PR description itself AI-generated?** No
