### PR TITLE
Rename ActivityDefinition to Activity

### DIFF
--- a/Examples/Sources/CIPipeline/Activities.swift
+++ b/Examples/Sources/CIPipeline/Activities.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // ── Stage 1: Checkout ──────────────────────────────────────────────────────
 
-struct CheckoutActivity: ActivityDefinition {
+struct CheckoutActivity: Activity {
     typealias Input = PipelineInput
     typealias Output = StageResult
     static let name = "ci.checkout"
@@ -29,7 +29,7 @@ struct CheckoutActivity: ActivityDefinition {
 
 // ── Stage 2a: Lint ─────────────────────────────────────────────────────────
 
-struct LintActivity: ActivityDefinition {
+struct LintActivity: Activity {
     typealias Input = PipelineInput
     typealias Output = StageResult
     static let name = "ci.lint"
@@ -55,7 +55,7 @@ struct LintActivity: ActivityDefinition {
 // Kill the process during the retry window and restart: Strand will resume
 // from exactly this stage.
 
-struct UnitTestActivity: ActivityDefinition {
+struct UnitTestActivity: Activity {
     typealias Input = PipelineInput
     typealias Output = StageResult
     static let name = "ci.unit-tests"
@@ -82,7 +82,7 @@ struct UnitTestActivity: ActivityDefinition {
 
 // ── Stage 2c: Security scan ────────────────────────────────────────────────
 
-struct SecurityScanActivity: ActivityDefinition {
+struct SecurityScanActivity: Activity {
     typealias Input = PipelineInput
     typealias Output = StageResult
     static let name = "ci.security-scan"
@@ -102,7 +102,7 @@ struct SecurityScanActivity: ActivityDefinition {
 
 // ── Stage 3: Build ─────────────────────────────────────────────────────────
 
-struct BuildActivity: ActivityDefinition {
+struct BuildActivity: Activity {
     typealias Input = PipelineInput
     typealias Output = StageResult
     static let name = "ci.build"
@@ -122,7 +122,7 @@ struct BuildActivity: ActivityDefinition {
 
 // ── Stage 5: Deploy ────────────────────────────────────────────────────────
 
-struct DeployActivity: ActivityDefinition {
+struct DeployActivity: Activity {
     typealias Input = PipelineInput
     typealias Output = StageResult
     static let name = "ci.deploy"

--- a/Examples/Sources/DevServer/MonthlyBilling/Activities/CalculateInvoiceActivity.swift
+++ b/Examples/Sources/DevServer/MonthlyBilling/Activities/CalculateInvoiceActivity.swift
@@ -6,7 +6,7 @@ import FoundationEssentials
 import Foundation
 #endif
 
-struct CalculateInvoiceActivity: ActivityDefinition {
+struct CalculateInvoiceActivity: Activity {
     struct Input: Codable, Sendable {
         let userID: Int
     }

--- a/Examples/Sources/DevServer/MonthlyBilling/Activities/ChargeCreditCardActivity.swift
+++ b/Examples/Sources/DevServer/MonthlyBilling/Activities/ChargeCreditCardActivity.swift
@@ -1,6 +1,6 @@
 import Strand
 
-struct ChargeCreditCardActivity: ActivityDefinition {
+struct ChargeCreditCardActivity: Activity {
     struct Input: Codable, Sendable {
         let invoiceID: String
         let amount: Double

--- a/Examples/Sources/DevServer/MonthlyBilling/Activities/GeneratePDFActivity.swift
+++ b/Examples/Sources/DevServer/MonthlyBilling/Activities/GeneratePDFActivity.swift
@@ -1,6 +1,6 @@
 import Strand
 
-struct GeneratePDFActivity: ActivityDefinition {
+struct GeneratePDFActivity: Activity {
     struct Input: Codable, Sendable {
         let invoiceID: String
         let chargeID: String

--- a/Examples/Sources/DevServer/MonthlyBilling/Activities/SendEmailActivity.swift
+++ b/Examples/Sources/DevServer/MonthlyBilling/Activities/SendEmailActivity.swift
@@ -1,6 +1,6 @@
 import Strand
 
-struct SendEmailActivity: ActivityDefinition {
+struct SendEmailActivity: Activity {
     struct Input: Codable, Sendable {
         let to: String
         let subject: String

--- a/Examples/Sources/DevServer/PodcastTranscription/Activities/DownloadEpisodeActivity.swift
+++ b/Examples/Sources/DevServer/PodcastTranscription/Activities/DownloadEpisodeActivity.swift
@@ -4,7 +4,7 @@ import Strand
 /// Simulates fetching a podcast audio file from a CDN.
 /// Returns the episode ID and the number of ~15-minute segments the
 /// workflow will fan out to (capped at 8 so dev runs stay snappy).
-struct DownloadEpisodeActivity: ActivityDefinition {
+struct DownloadEpisodeActivity: Activity {
     struct Input: Codable, Sendable {
         let showName: String
         let episodeTitle: String

--- a/Examples/Sources/DevServer/PodcastTranscription/Activities/GenerateChaptersActivity.swift
+++ b/Examples/Sources/DevServer/PodcastTranscription/Activities/GenerateChaptersActivity.swift
@@ -1,7 +1,7 @@
 import Strand
 
 /// Simulates an LLM pass over the full transcript to extract chapter markers.
-struct GenerateChaptersActivity: ActivityDefinition {
+struct GenerateChaptersActivity: Activity {
     typealias Input = ChapterInput
     typealias Output = ChaptersResult
 

--- a/Examples/Sources/DevServer/PodcastTranscription/Activities/MergeTranscriptActivity.swift
+++ b/Examples/Sources/DevServer/PodcastTranscription/Activities/MergeTranscriptActivity.swift
@@ -2,7 +2,7 @@ import Strand
 
 /// Joins all parallel segment transcripts into one document.
 /// This is the bottom point of the diamond — N parallel results converge here.
-struct MergeTranscriptActivity: ActivityDefinition {
+struct MergeTranscriptActivity: Activity {
     typealias Input = MergeInput
     typealias Output = FullTranscript
 

--- a/Examples/Sources/DevServer/PodcastTranscription/Activities/TranscribeSegmentActivity.swift
+++ b/Examples/Sources/DevServer/PodcastTranscription/Activities/TranscribeSegmentActivity.swift
@@ -3,7 +3,7 @@ import Strand
 /// Simulates running speech-to-text on one ~15-minute audio segment.
 /// Multiple instances of this activity run in parallel — they form the wide
 /// part of the diamond fan-out.
-struct TranscribeSegmentActivity: ActivityDefinition {
+struct TranscribeSegmentActivity: Activity {
     typealias Input = SegmentInput
     typealias Output = SegmentTranscript
 

--- a/Examples/Sources/DevServer/TrainVoiceAssistant/Activities/AnalyzeTextCorpusActivity.swift
+++ b/Examples/Sources/DevServer/TrainVoiceAssistant/Activities/AnalyzeTextCorpusActivity.swift
@@ -1,6 +1,6 @@
 import Strand
 
-struct AnalyzeTextCorpusActivity: ActivityDefinition {
+struct AnalyzeTextCorpusActivity: Activity {
     struct Input: Codable, Sendable {
         let country: String
         let variant: Int

--- a/Examples/Sources/DevServer/TrainVoiceAssistant/Activities/GenerateVoiceModelActivity.swift
+++ b/Examples/Sources/DevServer/TrainVoiceAssistant/Activities/GenerateVoiceModelActivity.swift
@@ -1,6 +1,6 @@
 import Strand
 
-struct GenerateVoiceModelActivity: ActivityDefinition {
+struct GenerateVoiceModelActivity: Activity {
     struct Input: Codable, Sendable {
         let country: String
         let analysisPaths: [String]

--- a/Examples/Sources/DevServer/TrainVoiceAssistant/Activities/IngestTextCorpusActivity.swift
+++ b/Examples/Sources/DevServer/TrainVoiceAssistant/Activities/IngestTextCorpusActivity.swift
@@ -1,6 +1,6 @@
 import Strand
 
-struct IngestTextCorpusActivity: ActivityDefinition {
+struct IngestTextCorpusActivity: Activity {
     struct Input: Codable, Sendable {
         let country: String
         let partition: Int

--- a/Examples/Sources/DevServer/TrainVoiceAssistant/Activities/PublishModelsActivity.swift
+++ b/Examples/Sources/DevServer/TrainVoiceAssistant/Activities/PublishModelsActivity.swift
@@ -1,6 +1,6 @@
 import Strand
 
-struct PublishModelsActivity: ActivityDefinition {
+struct PublishModelsActivity: Activity {
     typealias Input = PublishInput
     typealias Output = PublishResult
 

--- a/Examples/Sources/GroundwaterPipeline/Activities/ComputeCountyStatsActivity.swift
+++ b/Examples/Sources/GroundwaterPipeline/Activities/ComputeCountyStatsActivity.swift
@@ -16,7 +16,7 @@ import Foundation
 ///   Positive → water table is deeper (declining)
 ///   Negative → water table is shallower (recovering)
 ///   Near zero → stable
-struct ComputeCountyStatsActivity: ActivityDefinition {
+struct ComputeCountyStatsActivity: Activity {
     typealias Input = ComputeStatsInput
     typealias Output = ComputeStatsOutput
 

--- a/Examples/Sources/GroundwaterPipeline/Activities/DiscoverActivity.swift
+++ b/Examples/Sources/GroundwaterPipeline/Activities/DiscoverActivity.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Queries the CKAN datastore API to get the exact row count without downloading
 /// any data, then creates the pipeline_runs record for progress tracking.
-struct DiscoverActivity: ActivityDefinition {
+struct DiscoverActivity: Activity {
     typealias Input = DiscoverInput
     typealias Output = DiscoverOutput
 

--- a/Examples/Sources/GroundwaterPipeline/Activities/DiscoverCountiesActivity.swift
+++ b/Examples/Sources/GroundwaterPipeline/Activities/DiscoverCountiesActivity.swift
@@ -4,7 +4,7 @@ import Strand
 /// Queries `cnra.groundwater_measurements` for distinct county names.
 /// Used by StatsWorkflow to drive fan-out — the county list is data-driven,
 /// not hardcoded, so it adapts to whatever counties appear in the ingested data.
-struct DiscoverCountiesActivity: ActivityDefinition {
+struct DiscoverCountiesActivity: Activity {
     typealias Input = String  // jobID
     typealias Output = [String]
 

--- a/Examples/Sources/GroundwaterPipeline/Activities/DownloadAndInsertActivity.swift
+++ b/Examples/Sources/GroundwaterPipeline/Activities/DownloadAndInsertActivity.swift
@@ -21,7 +21,7 @@ import Foundation
 ///   single UNNEST transaction, balancing round-trips against memory usage.
 /// - **Idempotent progress tracking**: `cnra.chunk_progress` uses ON CONFLICT so
 ///   a retried activity updates the existing row rather than inserting a duplicate.
-struct DownloadAndInsertActivity: ActivityDefinition {
+struct DownloadAndInsertActivity: Activity {
     typealias Input = IngestChunkInput
     typealias Output = IngestChunkOutput
 

--- a/Examples/Sources/GroundwaterPipeline/Activities/OllamaTrendActivity.swift
+++ b/Examples/Sources/GroundwaterPipeline/Activities/OllamaTrendActivity.swift
@@ -12,7 +12,7 @@ import Foundation
 ///
 /// Uses `format: "json"` to get structured output instead of tool calling —
 /// faster and more reliable for simple classification tasks.
-struct OllamaTrendActivity: ActivityDefinition {
+struct OllamaTrendActivity: Activity {
     typealias Input = OllamaTrendInput
     typealias Output = OllamaTrendOutput
 

--- a/Examples/Sources/GroundwaterPipeline/Workflows/AIAnalysisWorkflow.swift
+++ b/Examples/Sources/GroundwaterPipeline/Workflows/AIAnalysisWorkflow.swift
@@ -102,7 +102,7 @@ struct FetchStatsOutput: Codable, Sendable {
     let latestMsmt: String?
 }
 
-struct FetchCountyStatsActivity: ActivityDefinition {
+struct FetchCountyStatsActivity: Activity {
     typealias Input = FetchStatsInput
     typealias Output = FetchStatsOutput
 

--- a/Examples/Sources/HackerNewsSummary/Activities/FetchStoryActivity.swift
+++ b/Examples/Sources/HackerNewsSummary/Activities/FetchStoryActivity.swift
@@ -2,7 +2,7 @@ import Foundation
 import Strand
 
 /// Fetches a single HN story from the Firebase REST API.
-struct FetchStoryActivity: ActivityDefinition {
+struct FetchStoryActivity: Activity {
     struct Input: Codable, Sendable { let storyID: Int }
     typealias Output = HNStory
 

--- a/Examples/Sources/HackerNewsSummary/Activities/FetchTopStoriesActivity.swift
+++ b/Examples/Sources/HackerNewsSummary/Activities/FetchTopStoriesActivity.swift
@@ -3,7 +3,7 @@ import Strand
 
 /// Calls the HN Firebase REST API and returns the top-N story IDs.
 /// No browser or Puppeteer required — the HN API returns JSON directly.
-struct FetchTopStoriesActivity: ActivityDefinition {
+struct FetchTopStoriesActivity: Activity {
     struct Input: Codable, Sendable { let count: Int }
     typealias Output = [Int]
 

--- a/Examples/Sources/HackerNewsSummary/Activities/OllamaSummarizeActivity.swift
+++ b/Examples/Sources/HackerNewsSummary/Activities/OllamaSummarizeActivity.swift
@@ -4,7 +4,7 @@ import Strand
 /// Sends an HN story to a locally running Ollama instance and returns a
 /// 2–3 sentence summary.  Requires `ollama serve` to be running and a
 /// model (e.g. `qwen3:latest`) to be pulled.
-struct OllamaSummarizeActivity: ActivityDefinition {
+struct OllamaSummarizeActivity: Activity {
     struct Input: Codable, Sendable {
         let title: String
         let content: String  // url or self-post text, truncated to 1500 chars

--- a/Examples/Sources/SmartBuilding/Activities.swift
+++ b/Examples/Sources/SmartBuilding/Activities.swift
@@ -14,7 +14,7 @@ struct ReadSensorsInput: Codable, Sendable {
 
 /// Simulates reading all sensors in a room.
 /// The server room (roomId == "server-room") has a temperature spike on cycle 3.
-struct ReadSensorsActivity: ActivityDefinition {
+struct ReadSensorsActivity: Activity {
     typealias Input = ReadSensorsInput
     typealias Output = [SensorReading]
     static let name = "iot.read-sensors"
@@ -60,7 +60,7 @@ struct AlertInput: Codable, Sendable {
 
 /// Handles a sensor threshold breach — in production this would page on-call,
 /// trigger HVAC adjustments, etc. Here it logs the alert clearly.
-struct SendAlertActivity: ActivityDefinition {
+struct SendAlertActivity: Activity {
     typealias Input = AlertInput
     typealias Output = String  // alert description
     static let name = "iot.send-alert"

--- a/Sources/Strand/Activity.swift
+++ b/Sources/Strand/Activity.swift
@@ -11,11 +11,11 @@ public import Foundation
 
 // MARK: - StrandVoid
 
-/// A `Codable`, `Sendable` unit type used as the `Output` of an ``ActivityDefinition``
+/// A `Codable`, `Sendable` unit type used as the `Output` of an ``Activity``
 /// that performs a side effect and returns no meaningful value.
 ///
 /// ```swift
-/// struct SendEmailActivity: ActivityDefinition {
+/// struct SendEmailActivity: Activity {
 ///     func run(input: EmailInput, context: ActivityContext) async throws -> StrandVoid {
 ///         try await smtp.send(to: input.address, body: input.body)
 ///         return .done
@@ -150,6 +150,28 @@ public struct ActivityContext: Sendable {
     /// at zero cost without an extra DB column or init parameter.
     public var queuedAt: Date { activityID.v7CreatedAt ?? Date() }
 
+    /// Scheduling metadata injected by ``StrandScheduler`` when this activity was
+    /// triggered directly by a schedule (`.activity(...)` declaration). `nil` when
+    /// the activity was enqueued via ``StrandClient/enqueueActivity(_:input:options:)``
+    /// or spawned as a child of a workflow.
+    ///
+    /// Use `partitionTime` as the canonical anchor for what data period this
+    /// execution covers — it is stable across retries and backfill re-runs:
+    ///
+    /// ```swift
+    /// func run(input: Input, context: ActivityContext) async throws -> StrandVoid {
+    ///     guard let meta = context.schedulingMetadata else {
+    ///         // Directly enqueued — use queuedAt or input-supplied date
+    ///         return try await processDay(input.date)
+    ///     }
+    ///     // Scheduled execution: partitionTime = data interval start (stable across retries)
+    ///     // executionTime        = when the scheduler actually fired (wall-clock)
+    ///     let day = meta.partitionTime ?? meta.executionTime
+    ///     return try await processDay(day)
+    /// }
+    /// ```
+    public let schedulingMetadata: SchedulingMetadata?
+
     // Package-internal: the parent workflow's task UUID (for parent_task_id FK).
     package let parentWorkflowID: UUID?
 
@@ -165,6 +187,7 @@ public struct ActivityContext: Sendable {
         queueName: String,
         attempt: Int,
         logger: Logger,
+        schedulingMetadata: SchedulingMetadata? = nil,
         parentWorkflowID: UUID?,
         heartbeatDetailsBuffer: ByteBuffer? = nil,
         heartbeatImpl: @escaping @Sendable (ByteBuffer?) async throws -> Void = { _ in }  // default no-op
@@ -174,6 +197,7 @@ public struct ActivityContext: Sendable {
         self.queueName = queueName
         self.attempt = attempt
         self.logger = logger
+        self.schedulingMetadata = schedulingMetadata
         self.parentWorkflowID = parentWorkflowID
         self._heartbeatDetailsBuffer = heartbeatDetailsBuffer
         self._heartbeatImpl = heartbeatImpl
@@ -234,57 +258,17 @@ public struct ActivityContext: Sendable {
 
 // MARK: - Activity
 
-/// A self-contained, independently retryable unit of work.
-///
-/// Closure-based standalone activity for use with `StrandClient.enqueue(_:params:)`
-/// and `StrandClient.runActivity(_:params:)`. For worker-registered activities that
-/// hold dependencies, use ``ActivityDefinition`` instead.
-///
-/// ```swift
-/// let chargeCard = Activity<ChargeInput, ChargeResult>(name: "charge-card") { input, _ in
-///     ChargeResult(paymentID: try await stripe.charge(input.amount))
-/// }
-/// // Fire-and-forget from the client:
-/// let enq = try await client.enqueue(chargeCard, params: ChargeInput(amount: 99.99))
-/// ```
-public struct Activity<P: Codable & Sendable, R: Codable & Sendable>: Sendable {
-
-    public let name: String
-    public let queue: String?
-    public let defaultMaxAttempts: Int?
-
-    /// Package-internal: the typed handler.
-    package let handler: @Sendable (P, ActivityContext) async throws -> R
-
-    /// Package-internal: the execution kind stored in strand.tasks.kind.
-    package let executionKind: TaskKind = .activity
-
-    public init(
-        name: String,
-        queue: String? = nil,
-        maxAttempts: Int? = nil,
-        run handler: @escaping @Sendable (P, ActivityContext) async throws -> R
-    ) {
-        self.name = name
-        self.queue = queue
-        self.defaultMaxAttempts = maxAttempts
-        self.handler = handler
-    }
-}
-
-// MARK: - ActivityDefinition
-
 /// A dependency-injected, independently-retried unit of I/O.
 ///
 /// Activities hold their dependencies as stored properties and are registered
 /// on ``StrandWorker`` via `activities:` or `activityContainers:`. The worker
 /// claims, executes, and retries them independently.
 ///
-/// `ActivityDefinition` automatically satisfies ``ActivityBox``, so instances
+/// `Activity` automatically satisfies ``ActivityBox``, so instances
 /// can be passed directly in the `activities:` array without any wrapper.
 ///
 /// ```swift
-/// struct ChargeCardActivity: ActivityDefinition {
+/// struct ChargeCardActivity: Activity {
 ///     typealias Input  = ChargeInput
 ///     typealias Output = ChargeResult
 ///
@@ -295,7 +279,7 @@ public struct Activity<P: Codable & Sendable, R: Codable & Sendable>: Sendable {
 ///     }
 /// }
 /// ```
-public protocol ActivityDefinition: ActivityBox {
+public protocol Activity: ActivityBox {
     associatedtype Input: Codable & Sendable
     associatedtype Output: Codable & Sendable
     /// The typed error this activity can throw.
@@ -304,7 +288,7 @@ public protocol ActivityDefinition: ActivityBox {
     /// `WorkflowContext.runActivity` — no `ActivityError` wrapper, no `.cause` cast.
     ///
     /// ```swift
-    /// struct AddBankAccountActivity: ActivityDefinition {
+    /// struct AddBankAccountActivity: Activity {
     ///     typealias Failure = BankAccountError   // BankAccountError: Codable
     ///     func run(input: Input, context: ActivityContext) async throws(BankAccountError) -> Output {
     ///         throw .invalidDetails
@@ -342,7 +326,7 @@ public protocol ActivityDefinition: ActivityBox {
     func run(input: Input, context: ActivityContext) async throws -> Output
 }
 
-extension ActivityDefinition {
+extension Activity {
     public static var name: String { String(describing: Self.self) }
     public static var defaultMaxAttempts: Int? { nil }
     public static var defaultTimeout: Duration? { nil }
@@ -354,8 +338,8 @@ extension ActivityDefinition {
 }
 
 // Internal _makeToken() and _run() entry point.
-// Every ActivityDefinition gets these for free — no manual implementation needed.
-extension ActivityDefinition {
+// Every Activity gets these for free — no manual implementation needed.
+extension Activity {
 
     public func _makeToken() -> _ActivityToken {
         _ActivityToken(
@@ -431,6 +415,7 @@ extension ActivityDefinition {
             queueName: exec.queue,
             attempt: claimed.attempt,
             logger: exec.logger,
+            schedulingMetadata: claimed.schedulingMetadata,
             parentWorkflowID: claimed.parentWorkflowID,
             heartbeatDetailsBuffer: claimed.heartbeatDetails,
             heartbeatImpl: { details in

--- a/Sources/Strand/Client.swift
+++ b/Sources/Strand/Client.swift
@@ -76,61 +76,9 @@ public struct StrandClient: Sendable {
         )
     }
 
-    // MARK: - Activity enqueue / run
+    // MARK: - Activity (standalone Activity dispatch)
 
-    /// Enqueues an ``Activity`` as a standalone unit of work — no workflow required.
-    ///
-    /// The activity runs independently with `kind = 'ACTIVITY'` so the dashboard can
-    /// distinguish leaf executions from orchestrators.
-    ///
-    /// ```swift
-    /// // Fire-and-forget:
-    /// let enq = try await client.enqueue(chargeCard, params: ChargeInput(amount: 99.99))
-    /// // Wait for the result later:
-    /// let result: ChargeResult = try await client.awaitTaskResult(id: enq.taskID)
-    /// ```
-    @discardableResult
-    public func enqueue<P: Codable & Sendable, R: Codable & Sendable>(
-        _ activity: Activity<P, R>,
-        params: P,
-        options: ActivityOptions = .init()
-    ) async throws -> EnqueueResult {
-        try await _enqueue(
-            queue: options.queue ?? activity.queue ?? queueName,
-            taskName: activity.name,
-            params: params,
-            maxAttempts: options.maxAttempts ?? activity.defaultMaxAttempts
-                ?? self.options.defaultMaxAttempts,
-            retryStrategy: options.retryStrategy ?? self.options.defaultRetryStrategy,
-            cancellation: options.cancellation,
-            headers: options.headers,
-            idempotencyKey: options.idempotencyKey,
-            priority: options.priority,
-            delayUntil: options.delayUntil,
-            maxDuration: options.maxDuration,
-            heartbeatTimeoutSeconds: options.heartbeatTimeout.map { Int($0.components.seconds) },
-            fairnessKey: options.fairnessKey,
-            fairnessWeight: options.fairnessWeight,
-            kind: .activity,
-            parentTaskID: nil
-        )
-    }
-
-    /// Enqueues an ``Activity`` and polls until it completes, returning the decoded result.
-    ///
-    /// Equivalent to a standalone activity call from outside a workflow handler.
-    public func runActivity<P: Codable & Sendable, R: Decodable & Sendable>(
-        _ activity: Activity<P, R>,
-        params: P,
-        options: ActivityOptions = .init()
-    ) async throws -> R {
-        let enq = try await enqueue(activity, params: params, options: options)
-        return try await awaitTaskResult(id: enq.taskID)
-    }
-
-    // MARK: - Standalone ActivityDefinition dispatch
-
-    /// Enqueues an ``ActivityDefinition`` as a standalone unit of work without a
+    /// Enqueues an ``Activity`` as a standalone unit of work without a
     /// parent workflow. The activity is claimed and executed by any worker that has
     /// it registered in its `activities:` array.
     ///
@@ -146,7 +94,7 @@ public struct StrandClient: Sendable {
     ///                                   taskID: enq.taskID, client: client)
     /// ```
     @discardableResult
-    public func enqueueActivity<A: ActivityDefinition>(
+    public func enqueueActivity<A: Activity>(
         _ type: A.Type,
         input: A.Input,
         options: ActivityOptions = .init()
@@ -172,7 +120,7 @@ public struct StrandClient: Sendable {
         )
     }
 
-    /// Enqueues an ``ActivityDefinition`` and polls until it completes, returning
+    /// Enqueues an ``Activity`` and polls until it completes, returning
     /// the decoded result. The worker must have this activity registered.
     ///
     /// ```swift
@@ -183,7 +131,7 @@ public struct StrandClient: Sendable {
     ///     options: .init(maxAttempts: 3, priority: .high)
     /// )
     /// ```
-    public func runActivity<A: ActivityDefinition>(
+    public func runActivity<A: Activity>(
         _ type: A.Type,
         input: A.Input,
         options: ActivityOptions = .init()
@@ -852,12 +800,12 @@ public struct StrandClient: Sendable {
         )
     }
 
-    /// Schedules an ``ActivityDefinition``-conforming activity on a recurring pattern.
+    /// Schedules an ``Activity``-conforming activity on a recurring pattern.
     ///
     /// The activity fires directly — no wrapping workflow is created.
     /// Buffering / lifecycle semantics are identical to the workflow overload.
     @discardableResult
-    public func schedule<A: ActivityDefinition>(
+    public func schedule<A: Activity>(
         name: String,
         pattern: SchedulePattern,
         activityType: A.Type,
@@ -873,34 +821,6 @@ public struct StrandClient: Sendable {
             taskName: A.name,
             params: input,
             queue: queue,
-            startsAt: startsAt,
-            endsAt: endsAt,
-            kind: .activity,
-            options: options
-        )
-    }
-
-    /// Schedules an ``Activity`` instance on a recurring pattern.
-    ///
-    /// The activity fires directly — no wrapping workflow is created.
-    /// Buffering / lifecycle semantics are identical to the workflow overload.
-    @discardableResult
-    public func schedule<P: Codable & Sendable, R: Codable & Sendable>(
-        name scheduleName: String,
-        pattern: SchedulePattern,
-        _ activity: Activity<P, R>,
-        params: P,
-        queue: String? = nil,
-        startsAt: Date? = nil,
-        endsAt: Date? = nil,
-        options: ScheduleOptions = .init()
-    ) async throws -> UUID {
-        try await _schedule(
-            name: scheduleName,
-            pattern: pattern,
-            taskName: activity.name,
-            params: params,
-            queue: queue ?? activity.queue,
             startsAt: startsAt,
             endsAt: endsAt,
             kind: .activity,
@@ -1304,7 +1224,7 @@ public struct StrandClient: Sendable {
 
     /// Creates a backfill for a standalone activity.
     @discardableResult
-    public func createBackfill<A: ActivityDefinition>(
+    public func createBackfill<A: Activity>(
         _ activityType: A.Type,
         input: A.Input,
         schedule: SchedulePattern,

--- a/Sources/Strand/DB/RowDecoding.swift
+++ b/Sources/Strand/DB/RowDecoding.swift
@@ -95,7 +95,7 @@ extension ClaimedTask {
         eventPayloadBuffer = try col.next()!.decode(ByteBuffer?.self, context: .default)
 
         // Decode typed fields from headers once here.
-        // All downstream consumers (WorkflowRegistration, ActivityDefinition._run, etc.)
+        // All downstream consumers (WorkflowRegistration, Activity._run, etc.)
         // read from these typed fields instead of re-parsing the raw buffer.
         let h: [String: String] =
             headersBuffer.flatMap { try? JSON.decode([String: String].self, from: $0) } ?? [:]

--- a/Sources/Strand/Errors.swift
+++ b/Sources/Strand/Errors.swift
@@ -178,7 +178,7 @@ public protocol NonRetryableError: Error {}
 
 // MARK: - Internal failure signals
 
-/// Pre-encoded activity failure reason thrown from `ActivityDefinition._run`.
+/// Pre-encoded activity failure reason thrown from `Activity._run`.
 /// Carries the JSON BYTEA that should be stored verbatim in `strand.runs.failure_reason`.
 /// `StrandWorker.runTask` catches this to bypass re-encoding in `FailureReason`.
 struct _TypedActivityFailure: Error, CustomStringConvertible {

--- a/Sources/Strand/Schedule/StrandScheduler.swift
+++ b/Sources/Strand/Schedule/StrandScheduler.swift
@@ -85,12 +85,12 @@ public struct StrandSchedule: Sendable {
         }
     }
 
-    // MARK: ActivityDefinition
+    // MARK: Activity
 
     /// Declares a recurring activity schedule.
     ///
     /// The activity fires directly — no wrapping workflow is created.
-    public static func activity<A: ActivityDefinition>(
+    public static func activity<A: Activity>(
         _ name: String,
         pattern: SchedulePattern,
         activityType: A.Type,

--- a/Sources/Strand/Strand.docc/Activities.md
+++ b/Sources/Strand/Strand.docc/Activities.md
@@ -5,11 +5,11 @@ calls, and database writes live.
 
 ## Protocol-based definition
 
-Implement ``ActivityDefinition`` to define a dependency-injected, independently
+Implement ``Activity`` to define a dependency-injected, independently
 retried unit of work:
 
 ```swift
-struct FetchWeatherActivity: ActivityDefinition {
+struct FetchWeatherActivity: Activity {
     typealias Input  = WeatherInput
     typealias Output = WeatherResult
 
@@ -91,7 +91,7 @@ before the StartToClose deadline would fire.
 Set defaults on the activity type itself to avoid repeating options at every call-site:
 
 ```swift
-struct FetchWeatherActivity: ActivityDefinition {
+struct FetchWeatherActivity: Activity {
     static var defaultMaxAttempts: Int? { 5 }
     static var defaultTimeout: Duration? { .seconds(10) }
     // ...
@@ -125,7 +125,7 @@ returns that value so the activity can resume mid-stream instead of restarting
 from the beginning:
 
 ```swift
-struct IngestFileActivity: ActivityDefinition {
+struct IngestFileActivity: Activity {
     typealias Input  = FileInput
     typealias Output = StrandVoid
 
@@ -173,7 +173,7 @@ Use ``StrandVoid`` as the `Output` type when the activity performs a side effect
 and returns no meaningful value:
 
 ```swift
-struct SendEmailActivity: ActivityDefinition {
+struct SendEmailActivity: Activity {
     typealias Input  = EmailInput
     typealias Output = StrandVoid
 

--- a/Sources/Strand/Strand.docc/Concepts.md
+++ b/Sources/Strand/Strand.docc/Concepts.md
@@ -9,7 +9,7 @@ is the orchestration logic. It calls `context.runActivity(...)` to dispatch leaf
 units of work, and `context.sleep(for:)` / `context.waitForEvent(...)` to
 suspend until external events arrive.
 
-An **activity** is a Swift struct that conforms to ``ActivityDefinition`` and
+An **activity** is a Swift struct that conforms to ``Activity`` and
 performs I/O: database queries, HTTP calls, file operations. Activities are the
 only place where side effects should live.
 

--- a/Sources/Strand/Strand.docc/GettingStarted.md
+++ b/Sources/Strand/Strand.docc/GettingStarted.md
@@ -33,7 +33,7 @@ import ServiceLifecycle
 
 // ── Activity: does the actual I/O ───────────────────────────────────────────
 
-struct SendEmailActivity: ActivityDefinition {
+struct SendEmailActivity: Activity {
     typealias Input  = EmailInput
     typealias Output = EmailResult
 

--- a/Sources/Strand/StrandService.swift
+++ b/Sources/Strand/StrandService.swift
@@ -76,7 +76,7 @@ public struct StrandService: Service {
         /// (e.g. a database client or API key). Implement `ActivityContainerProtocol`
         /// to bundle related activities and inject shared resources once.
         public var activityContainers: [any ActivityContainerProtocol]
-        /// Individual activity instances. Any `ActivityDefinition` satisfies
+        /// Individual activity instances. Any `Activity` satisfies
         /// `ActivityBox` automatically; use this for standalone activities.
         public var activities: [any ActivityBox]
         public var workflowConcurrency: Int

--- a/Sources/Strand/Worker.swift
+++ b/Sources/Strand/Worker.swift
@@ -990,7 +990,7 @@ public struct StrandWorker: Service {
                 taskLogger.error("continue-as-new failed", metadata: .forError(error))
             }
         } catch let typed as _TypedActivityFailure {
-            // Pre-encoded failure reason from ActivityDefinition._run — use verbatim.
+            // Pre-encoded failure reason from Activity._run — use verbatim.
             await failAndRecord(
                 reasonBuffer: typed.reasonBuffer,
                 claimed: claimed,

--- a/Sources/Strand/Workflow.swift
+++ b/Sources/Strand/Workflow.swift
@@ -64,7 +64,7 @@ extension WorkflowRegistrable {
 /// A durable workflow orchestrator implemented as a value-type struct.
 ///
 /// The handler **must be deterministic**: no I/O, no `Date.now`, no `UUID()`.
-/// All I/O belongs in ``ActivityDefinition`` implementations.
+/// All I/O belongs in ``Activity`` implementations.
 ///
 /// ```swift
 /// struct OrderWorkflow: Workflow {
@@ -242,14 +242,14 @@ extension WorkflowSignalDefinition {
 
 /// Marker protocol that enables activity instances in the `activities:` array.
 ///
-/// Every type conforming to ``ActivityDefinition`` automatically satisfies this
+/// Every type conforming to ``Activity`` automatically satisfies this
 /// protocol. You never need to implement it manually.
 public protocol ActivityBox: Sendable {
     /// The registered activity name — shown in logs and the dashboard.
     var activityName: String { get }
 
     /// Infrastructure used by ``StrandWorker``. Do not call or implement manually;
-    /// a default is provided via `extension ActivityDefinition`.
+    /// a default is provided via `extension Activity`.
     func _makeToken() -> _ActivityToken
 }
 

--- a/Sources/Strand/WorkflowContext.swift
+++ b/Sources/Strand/WorkflowContext.swift
@@ -325,12 +325,12 @@ public struct WorkflowContext<W: Workflow>: Sendable {
     /// re-executing the activity or touching the DB (beyond a fast checkpoint lookup).
     ///
     /// - Parameters:
-    ///   - type: The `ActivityDefinition` conforming type to schedule.
+    ///   - type: The `Activity` conforming type to schedule.
     ///   - input: Encoded and forwarded to the activity handler.
     ///   - options: Routing, retry, and timeout overrides. Inherits from workflow defaults if omitted.
     /// - Throws: `A.Failure` directly when the activity failed with a typed failure (if declared).
     ///           `ActivityError` when the activity reached a terminal error state (all retries exhausted or cancelled).
-    public func runActivity<A: ActivityDefinition>(
+    public func runActivity<A: Activity>(
         _ type: A.Type,
         input: A.Input,
         options: ActivityOptions = .init(),
@@ -414,7 +414,7 @@ public struct WorkflowContext<W: Workflow>: Sendable {
     /// ```swift
     /// let result = try await context.runActivity(SendEmailActivity.self)
     /// ```
-    public func runActivity<A: ActivityDefinition>(
+    public func runActivity<A: Activity>(
         _ type: A.Type,
         options: ActivityOptions = .init(),
         fileID: String = #fileID,
@@ -891,10 +891,10 @@ public struct WorkflowContext<W: Workflow>: Sendable {
     /// ```
     ///
     /// - Parameters:
-    ///   - type: The `ActivityDefinition` conforming type to execute.
+    ///   - type: The `Activity` conforming type to execute.
     ///   - input: Forwarded verbatim to the activity handler.
     ///   - options: Execution options (reserved for future use).
-    public func runLocalActivity<A: ActivityDefinition>(
+    public func runLocalActivity<A: Activity>(
         _ type: A.Type,
         input: A.Input,
         options: LocalActivityOptions = .init()
@@ -921,7 +921,7 @@ public struct WorkflowContext<W: Workflow>: Sendable {
     }
 
     /// Convenience overload for activities with no input (`StrandVoid`).
-    public func runLocalActivity<A: ActivityDefinition>(
+    public func runLocalActivity<A: Activity>(
         _ type: A.Type,
         options: LocalActivityOptions = .init()
     ) async throws -> A.Output where A.Input == StrandVoid {

--- a/Tests/StrandTests/ActivityFailureTests.swift
+++ b/Tests/StrandTests/ActivityFailureTests.swift
@@ -27,7 +27,7 @@ import Foundation
 
 /// An activity that unconditionally throws on every attempt.
 /// Used to exercise the FAILED activity fast-path without waiting for retries.
-private struct AlwaysFailingActivity: ActivityDefinition {
+private struct AlwaysFailingActivity: Activity {
     typealias Input = String
     typealias Output = String
     typealias Failure = AlwaysFailingError

--- a/Tests/StrandTests/FairnessTests.swift
+++ b/Tests/StrandTests/FairnessTests.swift
@@ -80,9 +80,9 @@ private final class CompletionLog: Sendable {
 /// Records which `tenantKey` completed each slot and optionally fires a
 /// `TestExpectation` when a specific key is seen.
 ///
-/// Must be defined at file scope so `ActivityDefinition.name` (the Swift type
+/// Must be defined at file scope so `Activity.name` (the Swift type
 /// name) is stable — the registry looks up handlers by this string.
-private struct TenantSlotActivity: ActivityDefinition {
+private struct TenantSlotActivity: Activity {
     struct Input: Codable, Sendable { let tenantKey: String }
     typealias Output = StrandVoid
 

--- a/Tests/StrandTests/HeartbeatTests.swift
+++ b/Tests/StrandTests/HeartbeatTests.swift
@@ -40,7 +40,7 @@ private final class HeartbeatObserver: @unchecked Sendable {
 /// On attempt 1: fails after processing `failAfter` items, leaving the last
 /// heartbeat at `failAfter`.
 /// On attempt 2: resumes from `heartbeatDetails`, processes remaining items.
-private struct ProgressActivity: ActivityDefinition {
+private struct ProgressActivity: Activity {
     typealias Input = ProgressInput
     typealias Output = Int  // total items processed
 
@@ -85,7 +85,7 @@ private struct HeartbeatTestError: Error, Codable, Sendable {
 
 /// Wraps ProgressActivity and calls liveness-only `heartbeat()` (no details)
 /// between items to verify it does NOT overwrite stored progress.
-private struct LivenessHeartbeatActivity: ActivityDefinition {
+private struct LivenessHeartbeatActivity: Activity {
     typealias Input = ProgressInput
     typealias Output = Int
 

--- a/Tests/StrandTests/IntegrationTests.swift
+++ b/Tests/StrandTests/IntegrationTests.swift
@@ -180,7 +180,7 @@ private struct SignalledWorkflow: Workflow {
 // A simple activity plus the workflow that calls it.
 // Used by: activityExecution test.
 
-private struct ReverseActivity: ActivityDefinition {
+private struct ReverseActivity: Activity {
     typealias Input = String
     typealias Output = String
 
@@ -205,7 +205,7 @@ private struct ActivityWorkflow: Workflow {
 // The workflow passes `maxAttempts: 3` so the activity is retried.
 // Used by: activityRetryOnFailure test.
 
-private struct FlakyActivity: ActivityDefinition {
+private struct FlakyActivity: Activity {
     typealias Input = String
     typealias Output = String
     typealias Failure = DeliberateFailure
@@ -676,7 +676,7 @@ struct LeaseExpiryTests {
 
 // MARK: - Standalone activity dispatch
 
-private struct StandaloneGreetActivity: ActivityDefinition {
+private struct StandaloneGreetActivity: Activity {
     typealias Input = String
     typealias Output = String
     func run(input: String, context: ActivityContext) async throws -> String {
@@ -772,7 +772,7 @@ struct StandaloneActivityTests {
 
 // MARK: - Parallel activities (Phase 2 executor)
 
-private struct DoubleActivity: ActivityDefinition {
+private struct DoubleActivity: Activity {
     typealias Input = String
     typealias Output = String
 
@@ -784,7 +784,7 @@ private struct DoubleActivity: ActivityDefinition {
     }
 }
 
-private struct TripleActivity: ActivityDefinition {
+private struct TripleActivity: Activity {
     typealias Input = String
     typealias Output = String
 

--- a/Tests/StrandTests/LocalActivityTests.swift
+++ b/Tests/StrandTests/LocalActivityTests.swift
@@ -13,7 +13,7 @@ import Foundation
 
 // MARK: - Activity fixtures
 
-private struct UppercaseActivity: ActivityDefinition {
+private struct UppercaseActivity: Activity {
     typealias Input = String
     typealias Output = String
     func run(input: String, context: ActivityContext) async throws -> String {
@@ -21,7 +21,7 @@ private struct UppercaseActivity: ActivityDefinition {
     }
 }
 
-private struct AddOneActivity: ActivityDefinition {
+private struct AddOneActivity: Activity {
     typealias Input = Int
     typealias Output = Int
     func run(input: Int, context: ActivityContext) async throws -> Int {
@@ -29,7 +29,7 @@ private struct AddOneActivity: ActivityDefinition {
     }
 }
 
-private struct FailingLocalActivity: ActivityDefinition {
+private struct FailingLocalActivity: Activity {
     typealias Input = String
     typealias Output = String
     typealias Failure = LocalError
@@ -75,7 +75,7 @@ private struct MixedWorkflow: Workflow {
 }
 
 // Simple regular activity used by MixedWorkflow.
-private struct ReverseLocalActivity: ActivityDefinition {
+private struct ReverseLocalActivity: Activity {
     typealias Input = String
     typealias Output = String
     var onRan: (@Sendable () -> Void)?

--- a/Tests/StrandTests/MetricsTests.swift
+++ b/Tests/StrandTests/MetricsTests.swift
@@ -169,7 +169,7 @@ private struct SimpleWorkflow: Workflow {
     }
 }
 
-private struct SimpleActivity: ActivityDefinition {
+private struct SimpleActivity: Activity {
     typealias Input = String
     typealias Output = String
     var onRan: (@Sendable () -> Void)?

--- a/Tests/StrandTests/TestHelpers.swift
+++ b/Tests/StrandTests/TestHelpers.swift
@@ -45,7 +45,7 @@ final class AtomicInt: @unchecked Sendable {
 /// no fixed delay and no 2-second backoff window.
 ///
 /// ```swift
-/// private struct MyActivity: ActivityDefinition {
+/// private struct MyActivity: Activity {
 ///     let done: TestExpectation
 ///     func run(input: String, context: ActivityContext) async throws -> String {
 ///         defer { done.trigger() }

--- a/Tests/StrandTests/WorkerLifecycleTests.swift
+++ b/Tests/StrandTests/WorkerLifecycleTests.swift
@@ -41,7 +41,7 @@ private struct WltEchoWorkflow: Workflow {
 //
 // Used by: expiredLeaseRetriedByNewWorker.
 
-private struct WltHungActivity: ActivityDefinition {
+private struct WltHungActivity: Activity {
     typealias Input = String
     typealias Output = String
 
@@ -64,7 +64,7 @@ private struct WltHungActivity: ActivityDefinition {
 //
 // Used by: cancelWorkflowCascadesToChildren.
 
-private struct WltSlowActivity: ActivityDefinition {
+private struct WltSlowActivity: Activity {
     typealias Input = StrandVoid
     typealias Output = StrandVoid
 


### PR DESCRIPTION
## Summary

Renamed ActivityDefinition to just Activity

## Changes

Propagate the change to the examples too 

## Testing

<!-- How did you verify this works? Did you run `swift test`? -->

- [x] `swift test` passes locally

## AI Disclosure

<!--
  REQUIRED if any AI assistance was used — see CONTRIBUTING.md.
  Delete this section entirely if no AI was involved.
-->

- [ ] I used AI assistance while working on this PR

**Tool(s) used:** <!-- e.g. Claude, Copilot, ChatGPT -->

**Extent of use:**
<!-- Describe honestly. Examples:
  - Generated first draft of WorkflowDag.tsx, reviewed and edited manually.
  - Used for commit message suggestions only.
  - Pair-programmed the entire feature; all output was reviewed.
-->

**Was the PR description itself AI-generated?** No