### PR TITLE
Add per-task deadline and RNG utilities

### DIFF
--- a/Sources/Strand/Activity.swift
+++ b/Sources/Strand/Activity.swift
@@ -173,7 +173,32 @@ public struct ActivityContext: Sendable {
     public let schedulingMetadata: SchedulingMetadata?
 
     // Package-internal: the parent workflow's task UUID (for parent_task_id FK).
-    package let parentWorkflowID: UUID?
+    public let parentWorkflowID: UUID?
+
+    /// The namespace this activity is executing in.
+    public let namespace: String
+    /// The UUID of the current run attempt (`strand.runs.id`).
+    /// Each retry gets a new `runID`; `activityID` stays the same across retries.
+    ///
+    /// For regular activities this is the exact `strand.runs.id` primary key — safe
+    /// to query, log, or use as a correlation token.
+    ///
+    /// For local activities this is a freshly generated UUID that is **not** backed
+    /// by a database row. It changes on every activation (including replays), so it
+    /// must not be used for deduplication or DB lookups.
+    public let runID: UUID
+    /// Per-attempt execution cap. `nil` defers to the worker's claim timeout.
+    public let timeout: Duration?
+    /// Heartbeat window. When set, a missed heartbeat re-queues the activity after
+    /// this duration rather than waiting the full `timeout`. `nil` = worker default.
+    public let heartbeatTimeout: Duration?
+    /// Maximum execution attempts configured for this activity. `nil` = worker default.
+    public let maxAttempts: Int?
+    /// Key-value metadata forwarded from the enqueue call site.
+    public let headers: [String: String]
+    /// Absolute deadline across all retry attempts. `nil` = no total budget.
+    /// Use `deadlineAt.map { $0.timeIntervalSince(.now) }` to compute remaining budget.
+    public let deadlineAt: Date?
 
     // Package-internal: heartbeat details from the previous attempt.
     private let _heartbeatDetailsBuffer: ByteBuffer?
@@ -187,8 +212,15 @@ public struct ActivityContext: Sendable {
         queueName: String,
         attempt: Int,
         logger: Logger,
+        namespace: String,
+        runID: UUID,
         schedulingMetadata: SchedulingMetadata? = nil,
         parentWorkflowID: UUID?,
+        timeout: Duration? = nil,
+        heartbeatTimeout: Duration? = nil,
+        maxAttempts: Int? = nil,
+        headers: [String: String] = [:],
+        deadlineAt: Date? = nil,
         heartbeatDetailsBuffer: ByteBuffer? = nil,
         heartbeatImpl: @escaping @Sendable (ByteBuffer?) async throws -> Void = { _ in }  // default no-op
     ) {
@@ -197,8 +229,15 @@ public struct ActivityContext: Sendable {
         self.queueName = queueName
         self.attempt = attempt
         self.logger = logger
+        self.namespace = namespace
+        self.runID = runID
         self.schedulingMetadata = schedulingMetadata
         self.parentWorkflowID = parentWorkflowID
+        self.timeout = timeout
+        self.heartbeatTimeout = heartbeatTimeout
+        self.maxAttempts = maxAttempts
+        self.headers = headers
+        self.deadlineAt = deadlineAt
         self._heartbeatDetailsBuffer = heartbeatDetailsBuffer
         self._heartbeatImpl = heartbeatImpl
     }
@@ -368,6 +407,8 @@ extension Activity {
             queueName: exec.queue,
             attempt: 1,
             logger: exec.logger,
+            namespace: exec.namespace,
+            runID: UUID.v7(),  // ephemeral — not backed by a strand.runs row
             parentWorkflowID: parentWorkflowID,
             heartbeatImpl: { _ in }  // no-op: local activities run synchronously in the activation
         )
@@ -415,8 +456,15 @@ extension Activity {
             queueName: exec.queue,
             attempt: claimed.attempt,
             logger: exec.logger,
+            namespace: exec.namespace,
+            runID: claimed.runID,
             schedulingMetadata: claimed.schedulingMetadata,
             parentWorkflowID: claimed.parentWorkflowID,
+            timeout: claimed.timeoutSeconds.map { .seconds($0) },
+            heartbeatTimeout: claimed.heartbeatTimeoutSeconds.map { .seconds($0) },
+            maxAttempts: claimed.maxAttempts,
+            headers: claimed.headers,
+            deadlineAt: claimed.deadlineAt,
             heartbeatDetailsBuffer: claimed.heartbeatDetails,
             heartbeatImpl: { details in
                 // Extend the Postgres lease to signal that the activity is still alive.

--- a/Sources/Strand/Client.swift
+++ b/Sources/Strand/Client.swift
@@ -183,6 +183,7 @@ public struct StrandClient: Sendable {
         // Use the caller-supplied ID when provided; otherwise delegate to the workflow
         // type's own ID generator (overridable per type via WorkflowRegistrable).
         let resolvedID = options.id ?? W.generateWorkflowID()
+        let workflowDeadlineAt: Date? = options.maxDuration.map { Date.now.addingDuration($0) }
 
         let row = try await Queries.enqueueTask(
             on: postgres,
@@ -197,6 +198,7 @@ public struct StrandClient: Sendable {
             idempotencyKey: resolvedID,  // always set — enables client.workflow(id:) lookup
             priority: options.priority,
             scheduledAt: options.delayUntil,
+            deadlineAt: workflowDeadlineAt,
             fairnessKey: options.fairnessKey,
             fairnessWeight: options.fairnessWeight,
             kind: .workflow,
@@ -333,12 +335,7 @@ public struct StrandClient: Sendable {
         kind: TaskKind = .workflow,
         parentTaskID: UUID? = nil
     ) async throws -> EnqueueResult {
-        let deadlineAt: Date? = maxDuration.map {
-            Date.now.addingTimeInterval(
-                Double($0.components.seconds)
-                    + Double($0.components.attoseconds) / 1_000_000_000_000_000_000
-            )
-        }
+        let deadlineAt: Date? = maxDuration.map { Date.now.addingDuration($0) }
         // Producer span: wraps the DB insert so that the context injected into
         // task headers IS this span's context. The worker's consumer span then
         // addLink-s back here, completing the producer → consumer trace link.

--- a/Sources/Strand/DB/Queries.swift
+++ b/Sources/Strand/DB/Queries.swift
@@ -626,7 +626,7 @@ enum Queries {
                    t.name, t.params, t.retry_strategy, t.max_attempts, t.headers,
                    c.wake_event, c.event_payload,
                    t.parent_task_id, t.kind, t.timeout_seconds, t.heartbeat_timeout_seconds,
-                   t.scheduling_metadata, c.available_at, c.heartbeat_details
+                   t.scheduling_metadata, c.available_at, c.heartbeat_details, t.deadline_at
             FROM claimed c JOIN strand.tasks t ON t.id = c.task_id
             ORDER BY c.id
             """,

--- a/Sources/Strand/DB/RowDecoding.swift
+++ b/Sources/Strand/DB/RowDecoding.swift
@@ -63,6 +63,10 @@ struct ClaimedTask: Sendable {
     /// Exposed to the activity handler via `ActivityContext.heartbeatDetails(as:)`.
     let heartbeatDetails: ByteBuffer?
 
+    /// The absolute deadline for this task (`strand.tasks.deadline_at`). `nil` means no total budget.
+    /// Used by activities to compute remaining budget: `deadlineAt.map { $0.timeIntervalSince(.now) }`.
+    let deadlineAt: Date?
+
     /// `true` when this attempt is the last one allowed.
     ///
     /// Used to decide whether a thrown error should mark the OTel span `ERROR`.
@@ -76,10 +80,10 @@ struct ClaimedTask: Sendable {
 
 extension ClaimedTask {
     /// Decode from the column order returned by the claim CTE:
-    /// run_id, task_id, attempt, version, task_name, params,
+    /// Columns: run_id, task_id, attempt, version, task_name, params,
     /// retry_strategy, max_attempts, headers, wake_event, event_payload,
     /// parent_task_id, kind, timeout_seconds, heartbeat_timeout_seconds,
-    /// scheduling_metadata, available_at, heartbeat_details
+    /// scheduling_metadata, available_at, heartbeat_details, deadline_at
     init(row: PostgresRow) throws {
         var col = row.makeIterator()
         runID = try col.next()!.decode(UUID.self, context: .default)
@@ -108,6 +112,7 @@ extension ClaimedTask {
         schedulingMetadata = try col.next()!.decode(SchedulingMetadata?.self, context: .default)
         availableAt = try col.next()!.decode(Date.self, context: .default)
         heartbeatDetails = try col.next()!.decode(ByteBuffer?.self, context: .default)
+        deadlineAt = try col.next()!.decode(Date?.self, context: .default)
     }
 }
 

--- a/Sources/Strand/Internal/WorkflowExecutor.swift
+++ b/Sources/Strand/Internal/WorkflowExecutor.swift
@@ -93,7 +93,8 @@ enum WorkflowCommand: Sendable {
         fairnessKey: String?,  // nil = no per-tenant isolation
         fairnessWeight: Double,  // 1.0 = default weight
         retryStrategy: RetryStrategy?,  // nil = worker default
-        scheduledAt: Date?  // nil = immediately
+        scheduledAt: Date?,  // nil = immediately
+        deadlineAt: Date?  // nil = no total execution budget
     )
 }
 

--- a/Sources/Strand/Internal/WorkflowScheduling.swift
+++ b/Sources/Strand/Internal/WorkflowScheduling.swift
@@ -273,13 +273,7 @@ extension WorkflowRegistration {
                             scheduledAt: options.delayUntil,
                             timeoutSeconds: options.timeout.map { Int($0.components.seconds) },
                             heartbeatTimeoutSeconds: options.heartbeatTimeout.map { Int($0.components.seconds) },
-                            deadlineAt: options.maxDuration.map {
-                                Date.now.addingTimeInterval(
-                                    Double($0.components.seconds)
-                                        + Double($0.components.attoseconds)
-                                        / 1_000_000_000_000_000_000
-                                )
-                            },
+                            deadlineAt: options.maxDuration.map { activation.activationTime.addingDuration($0) },
                             fairnessKey: options.fairnessKey,
                             fairnessWeight: options.fairnessWeight,
                             kind: .activity
@@ -453,7 +447,8 @@ extension WorkflowRegistration {
                     let childFairnessKey,
                     let childFairnessWeight,
                     let childRetryStrategy,
-                    let childScheduledAt
+                    let childScheduledAt,
+                    let childDeadlineAt
                 ):
                     let targetQueue = childQueue ?? exec.queue
                     pendingChildren.append(
@@ -472,7 +467,7 @@ extension WorkflowRegistration {
                             scheduledAt: childScheduledAt,
                             timeoutSeconds: nil,
                             heartbeatTimeoutSeconds: nil,
-                            deadlineAt: nil,
+                            deadlineAt: childDeadlineAt,
                             fairnessKey: childFairnessKey,
                             fairnessWeight: childFairnessWeight,
                             kind: .workflow

--- a/Sources/Strand/Schedule/Duration+Extras.swift
+++ b/Sources/Strand/Schedule/Duration+Extras.swift
@@ -59,3 +59,23 @@ extension Duration {
         }
     }
 }
+
+// MARK: - Date + Duration arithmetic
+
+extension Date {
+    /// Returns a new `Date` by adding the given `Duration` to this date.
+    ///
+    /// Mirrors Foundation's `addingTimeInterval(_:)` but accepts `Duration`
+    /// directly, keeping the attoseconds-to-seconds conversion in one place.
+    /// Commonly used to compute absolute deadlines from a relative budget:
+    /// ```swift
+    /// // Anchored to the stable activation timestamp — safe across replays.
+    /// let deadline = activationTime.addingDuration(options.maxDuration)
+    ///
+    /// // Anchored to wall-clock now — correct for external enqueue calls.
+    /// let deadline = Date.now.addingDuration(options.maxDuration)
+    /// ```
+    package func addingDuration(_ duration: Duration) -> Date {
+        addingTimeInterval(duration.timeInterval)
+    }
+}

--- a/Sources/Strand/Worker.swift
+++ b/Sources/Strand/Worker.swift
@@ -732,7 +732,7 @@ public struct StrandWorker: Service {
         // a new task type doesn't spin-loop on workers that haven't updated yet.
         guard let reg = _registry.lookup(claimed.taskName) else {
             let delay = unknownTaskDelay(seed: claimed.runID.uuidString)
-            let wakeAt = Date.now.addingTimeInterval(Double(delay.components.seconds))
+            let wakeAt = Date.now.addingDuration(delay)
             do {
                 try await Queries.scheduleRun(
                     on: postgres,

--- a/Sources/Strand/Workflow.swift
+++ b/Sources/Strand/Workflow.swift
@@ -315,6 +315,24 @@ public struct WorkflowOptions: Sendable {
     /// A key with weight `5.0` is dispatched approximately 5× more often than a key with `1.0`.
     /// Only meaningful when `fairnessKey` is set.
     public var fairnessWeight: Double
+    /// Maximum total wall-clock duration from when the workflow is first enqueued until
+    /// it permanently completes, across **all** retries and `continueAsNew` transitions.
+    ///
+    /// When this deadline is reached, `failRun` refuses to schedule another retry
+    /// regardless of remaining `maxAttempts`. The task is immediately marked `FAILED`
+    /// and workers skip claiming it once the deadline has elapsed.
+    ///
+    /// `nil` = no total budget; only `maxAttempts` limits the workflow.
+    ///
+    /// ```swift
+    /// // Subscription workflow must complete within 10 minutes:
+    /// try await client.startWorkflow(
+    ///     SubscriptionWorkflow.self,
+    ///     options: WorkflowOptions(id: "sub-\(customerID)", maxDuration: .seconds(600)),
+    ///     input: customer
+    /// )
+    /// ```
+    public var maxDuration: Duration?
 
     public init(
         id: String? = nil,
@@ -325,7 +343,8 @@ public struct WorkflowOptions: Sendable {
         retryStrategy: RetryStrategy? = nil,
         headers: [String: String] = [:],
         fairnessKey: String? = nil,
-        fairnessWeight: Double = 1.0
+        fairnessWeight: Double = 1.0,
+        maxDuration: Duration? = nil
     ) {
         self.id = id
         self.queue = queue
@@ -336,6 +355,7 @@ public struct WorkflowOptions: Sendable {
         self.headers = headers
         self.fairnessKey = fairnessKey
         self.fairnessWeight = max(fairnessWeight, 0.001)
+        self.maxDuration = maxDuration
     }
 }
 
@@ -360,6 +380,10 @@ public struct ChildWorkflowOptions: Sendable {
     public var retryStrategy: RetryStrategy?
     /// Earliest time this child workflow may be claimed. `nil` = immediately.
     public var delayUntil: Date?
+    /// Maximum total wall-clock duration for this child workflow across all retries
+    /// and `continueAsNew` transitions. `nil` = no total budget.
+    /// Equivalent to ``WorkflowOptions/maxDuration`` for top-level workflows.
+    public var maxDuration: Duration?
 
     public init(
         queue: String? = nil,
@@ -369,7 +393,8 @@ public struct ChildWorkflowOptions: Sendable {
         fairnessKey: String? = nil,
         fairnessWeight: Double = 1.0,
         retryStrategy: RetryStrategy? = nil,
-        delayUntil: Date? = nil
+        delayUntil: Date? = nil,
+        maxDuration: Duration? = nil
     ) {
         self.queue = queue
         self.priority = priority
@@ -379,5 +404,6 @@ public struct ChildWorkflowOptions: Sendable {
         self.fairnessWeight = max(fairnessWeight, 0.001)
         self.retryStrategy = retryStrategy
         self.delayUntil = delayUntil
+        self.maxDuration = maxDuration
     }
 }

--- a/Sources/Strand/WorkflowContext.swift
+++ b/Sources/Strand/WorkflowContext.swift
@@ -48,6 +48,35 @@ struct ConditionResultSentinel: Codable {
     }
 }
 
+// MARK: - WorkflowRandomNumberGenerator
+
+/// A deterministic, replay-safe random number generator for use inside workflow handlers.
+///
+/// Each call to `next()` consumes one checkpoint slot. On the first activation the value is
+/// generated with `SystemRandomNumberGenerator` and stored as a checkpoint. On every subsequent
+/// replay the stored checkpoint value is returned — the same sequence is produced regardless of
+/// how many times the workflow replays.
+///
+/// Obtain an instance via ``WorkflowContext/randomNumberGenerator``:
+/// ```swift
+/// var rng = context.randomNumberGenerator
+/// let jitter = Int.random(in: 0...500, using: &rng)   // stable across replays
+/// let pick   = items.randomElement(using: &rng)!       // same pick on replay
+/// ```
+///
+/// - Important: Store the generator in a `var` — `next()` is `mutating`.
+public struct WorkflowRandomNumberGenerator: RandomNumberGenerator {
+    private let _next: @Sendable () -> UInt64
+
+    init(_ next: @escaping @Sendable () -> UInt64) {
+        self._next = next
+    }
+
+    public mutating func next() -> UInt64 {
+        _next()
+    }
+}
+
 // MARK: - _WorkflowActivation
 
 /// Holds all mutable per-activation state for a single workflow execution attempt.
@@ -317,6 +346,19 @@ public struct WorkflowContext<W: Workflow>: Sendable {
     /// ```
     public var schedulingMetadata: SchedulingMetadata? { _impl.schedulingMetadata }
 
+    /// The queue this workflow is executing on.
+    public var queueName: String { _impl.queueName }
+
+    /// The namespace this workflow is executing in.
+    public var namespace: String { _impl.namespace }
+
+    /// The registered workflow type name (e.g. `"FulfillOrderWorkflow"`).
+    public var workflowName: String { _impl.taskName }
+
+    /// Key-value metadata forwarded from the enqueue call site.
+    /// Read-only; set at enqueue time via ``WorkflowOptions/headers``.
+    public var headers: [String: String] { _impl.headers }
+
     // MARK: - runActivity
 
     /// Schedules an activity and suspends until it completes, then returns the decoded result.
@@ -496,6 +538,36 @@ public struct WorkflowContext<W: Workflow>: Sendable {
         try _checkpoint(label: "random") { Double.random(in: range) }
     }
 
+    /// A deterministic, replay-safe random number generator.
+    ///
+    /// Each call to `next()` on the returned generator consumes one checkpoint slot —
+    /// the same approach used by ``uuid()`` and ``random(in:)``. On replay the stored
+    /// checkpoint value is returned so the sequence is always identical.
+    ///
+    /// ```swift
+    /// var rng = context.randomNumberGenerator
+    /// let jitter  = Int.random(in: 0...500, using: &rng)
+    /// let shuffle = myArray.shuffled(using: &rng)
+    /// ```
+    ///
+    /// - Important: Assign to a `var` — `RandomNumberGenerator.next()` is `mutating`.
+    public var randomNumberGenerator: WorkflowRandomNumberGenerator {
+        WorkflowRandomNumberGenerator { [_impl] in
+            let seqNum = _impl.nextSeqNum()
+            if let cached = _impl.checkpointCache[seqNum],
+                let value = try? JSON.decode(UInt64.self, from: cached)
+            {
+                return value
+            }
+            let value = UInt64.random(in: .min ... .max)
+            // UInt64 is always Codable — force-unwrap is safe here.
+            let buf = try! JSON.encode(value)
+            _impl.checkpointCache[seqNum] = buf
+            _impl.executor.emit(.writeCheckpoint(seqNum: seqNum, name: "rng", value: buf))
+            return value
+        }
+    }
+
     // MARK: - sleep
 
     /// Suspends the workflow for at least `duration` before continuing.
@@ -510,10 +582,7 @@ public struct WorkflowContext<W: Workflow>: Sendable {
         async throws
     {
         _impl.lastCallSite = (fileID, line)
-        let seconds =
-            Double(duration.components.seconds)
-            + Double(duration.components.attoseconds) / 1_000_000_000_000_000_000
-        try await sleep(until: Date.now.addingTimeInterval(seconds), fileID: fileID, line: line)
+        try await sleep(until: Date.now.addingDuration(duration), fileID: fileID, line: line)
     }
 
     /// Suspends the workflow until at least `wakeAt` before continuing.
@@ -612,12 +681,7 @@ public struct WorkflowContext<W: Workflow>: Sendable {
         }
 
         // ── Slow path: event not yet received — emit command and suspend ─────────────────
-        let timeoutAt: Date? = timeout.map { dur in
-            Date.now.addingTimeInterval(
-                Double(dur.components.seconds)
-                    + Double(dur.components.attoseconds) / 1_000_000_000_000_000_000
-            )
-        }
+        let timeoutAt: Date? = timeout.map { Date.now.addingDuration($0) }
 
         _impl.executor.emit(
             .awaitEvent(
@@ -806,10 +870,7 @@ public struct WorkflowContext<W: Workflow>: Sendable {
             let ts = (try? JSON.decode(Double.self, from: cached)) ?? 0
             wakeAt = Date(timeIntervalSince1970: ts)
         } else {
-            let seconds =
-                Double(timeout.components.seconds)
-                + Double(timeout.components.attoseconds) / 1_000_000_000_000_000_000
-            wakeAt = Date.now.addingTimeInterval(seconds)
+            wakeAt = Date.now.addingDuration(timeout)
             let buf = try JSON.encode(wakeAt.timeIntervalSince1970)
             _impl.checkpointCache[seqNum] = buf
             _impl.executor.emit(
@@ -1044,6 +1105,7 @@ public struct WorkflowContext<W: Workflow>: Sendable {
         // Note: options.headers forwarding intentionally omitted from the command —
         // the worker injects parent context headers when enqueuing the child task.
 
+        let childDeadlineAt: Date? = options.maxDuration.map { _impl.activationTime.addingDuration($0) }
         _impl.executor.emit(
             .scheduleChildWorkflow(
                 name: CW.workflowName,
@@ -1056,7 +1118,8 @@ public struct WorkflowContext<W: Workflow>: Sendable {
                 fairnessKey: options.fairnessKey,
                 fairnessWeight: options.fairnessWeight,
                 retryStrategy: options.retryStrategy,
-                scheduledAt: options.delayUntil
+                scheduledAt: options.delayUntil,
+                deadlineAt: childDeadlineAt
             )
         )
 


### PR DESCRIPTION
## Summary

Continuing with cleaning up and exposing useful information to activities and workflows

## Changes

- runID
- deadlineAt
- maxAttempt

## Testing

<!-- How did you verify this works? Did you run `swift test`? -->

- [x] `swift test` passes locally

## AI Disclosure

<!--
  REQUIRED if any AI assistance was used — see CONTRIBUTING.md.
  Delete this section entirely if no AI was involved.
-->

- [ ] I used AI assistance while working on this PR

**Tool(s) used:** <!-- e.g. Claude, Copilot, ChatGPT -->

**Extent of use:**
<!-- Describe honestly. Examples:
  - Generated first draft of WorkflowDag.tsx, reviewed and edited manually.
  - Used for commit message suggestions only.
  - Pair-programmed the entire feature; all output was reviewed.
-->

**Was the PR description itself AI-generated?** No
