### PR TITLE
Clean up public api and improved pruner service

### DIFF
--- a/Examples/Sources/DevServer/DevServer.swift
+++ b/Examples/Sources/DevServer/DevServer.swift
@@ -525,11 +525,14 @@ private func seedOnePodcast(client: StrandClient, logger: Logger) async {
             logger: logger
         )
 
+        let pruner = StrandPruner(postgres: postgres, logger: logger)
+
         app.addServices(observability)  // OTel must be first so spans are emitted correctly
         app.addServices(postgres)
         app.addServices(notifier)  // one LISTEN connection, fans out to workers + listener
         app.addServices(ordersWorker)
         app.addServices(reportsWorker)
+        app.addServices(pruner)  // prunes all namespaces, reads retention_days from DB
         app.addServices(metricsListener)  // receives strand_metrics broadcasts→ updates cache
         app.addServices(metricsLoop)  // broadcasts live counts every 5 s
 

--- a/Sources/Strand/Client.swift
+++ b/Sources/Strand/Client.swift
@@ -430,15 +430,13 @@ public struct StrandClient: Sendable {
         )
     }
 
-    /// Typed overload — derives the event name from the ``WorkflowEvent`` type.
-    ///
-    /// The compiler enforces that the payload type matches what the workflow
-    /// declared in its ``WorkflowEvent`` conformance.
+    /// Emits a typed event by name. Any workflow waiting for `E.name` whose
+    /// `matching:` predicate is satisfied by this payload will be woken.
     ///
     /// ```swift
-    /// try await client.emit(OrderShippedEvent.self,
-    ///     payload: TrackingInfo(number: "1Z999"),
-    ///     queue: "orders")
+    /// // From an HTTP handler — routing is done by the waiter's predicate:
+    /// try await client.emit(OrderApprovedEvent.self,
+    ///     payload: ApprovalPayload(orderId: "abc-123", approved: true))
     /// ```
     public func emit<E: WorkflowEvent>(
         _ eventType: E.Type,

--- a/Sources/Strand/DB/BackfillQueries.swift
+++ b/Sources/Strand/DB/BackfillQueries.swift
@@ -186,12 +186,39 @@ package enum BackfillQueries {
         namespaceID: String,
         logger: Logger
     ) async throws {
+        // Atomically in one round-trip:
+        //   1. Mark the backfill HALTED (guard: only if currently RUNNING).
+        //   2. Cancel any PENDING tasks that were enqueued for this backfill
+        //      but have not yet been claimed by a worker. These slots will
+        //      never run, so leaving them PENDING would orphan them.
+        //   3. Cancel their PENDING/SLEEPING runs.
+        //
+        // RUNNING tasks are intentionally left alone — they have already
+        // started work and should be allowed to complete.
         try await client.query(
             """
-            UPDATE strand.backfills
-            SET status = \(BackfillStatus.halted)
-            WHERE id = \(backfillID) AND namespace_id = \(namespaceID)
-              AND status = \(BackfillStatus.running)
+            WITH halted AS (
+                UPDATE strand.backfills
+                SET status = \(BackfillStatus.halted)
+                WHERE id            = \(backfillID)
+                  AND namespace_id  = \(namespaceID)
+                  AND status        = \(BackfillStatus.running)
+                RETURNING id
+            ),
+            cancelled_tasks AS (
+                UPDATE strand.tasks
+                SET state        = \(TaskState.cancelled),
+                    cancelled_at = NOW()
+                WHERE backfill_id = (SELECT id FROM halted)
+                  AND namespace_id = \(namespaceID)
+                  AND state       = \(TaskState.pending)
+                RETURNING id
+            )
+            UPDATE strand.runs
+            SET state = \(TaskState.cancelled)
+            WHERE task_id      IN (SELECT id FROM cancelled_tasks)
+              AND namespace_id  = \(namespaceID)
+              AND state        IN (\(TaskState.pending), \(TaskState.sleeping))
             """,
             logger: logger
         )

--- a/Sources/Strand/DB/ManagementQueries.swift
+++ b/Sources/Strand/DB/ManagementQueries.swift
@@ -196,7 +196,7 @@ extension EventRow {
         var col = row.makeIterator()
         id = try col.next()!.decode(UUID.self, context: .default)
         name = try col.next()!.decode(String.self, context: .default)
-        payloadBuffer = try col.next()!.decode(ByteBuffer?.self, context: .default)
+        payloadBuffer = try col.next()!.decode(RawJSONB?.self, context: .default).map(\.buffer)
         createdAt = try col.next()!.decode(Date.self, context: .default)
         queue = try col.next()!.decode(String.self, context: .default)
         // triggered_tasks is a json_agg result; uniqueness enforced by the
@@ -948,6 +948,96 @@ package enum ManagementQueries {
         return h > 0 ? "\(days)d \(h)h" : "\(days)d"
     }
 
+    // MARK: - Retention helpers
+
+    /// Returns all namespace IDs from `strand.namespaces`, ordered alphabetically.
+    /// Used by the pruner when `namespaceID` is `nil` (prune all namespaces).
+    /// Connection overload — SQL lives here.
+    package static func allNamespaceIDs(
+        on conn: PostgresConnection,
+        logger: Logger
+    ) async throws -> [String] {
+        let stream = try await conn.query(
+            "SELECT id FROM strand.namespaces ORDER BY id",
+            logger: logger
+        )
+        var ids: [String] = []
+        for try await row in stream {
+            var col = row.makeIterator()
+            if let id = try? col.next()?.decode(String.self, context: .default) {
+                ids.append(id)
+            }
+        }
+        return ids
+    }
+
+    package static func allNamespaceIDs(
+        on client: PostgresClient,
+        logger: Logger
+    ) async throws -> [String] {
+        try await client.withConnection { conn in
+            try await allNamespaceIDs(on: conn, logger: logger)
+        }
+    }
+
+    /// Minimum `retention_days` across all namespaces, falling back to 30.
+    ///
+    /// Used for partition-drop cutoff calculations in multi-namespace mode:
+    /// partitions are shared across all namespaces, so the most conservative
+    /// (shortest) retention window must be respected — a partition cannot be
+    /// dropped if any namespace still needs data from it.
+    /// Connection overload — SQL lives here.
+    package static func minimumRetentionDays(
+        on conn: PostgresConnection,
+        logger: Logger
+    ) async throws -> Int {
+        let stream = try await conn.query(
+            "SELECT COALESCE(MIN(retention_days), 30) FROM strand.namespaces",
+            logger: logger
+        )
+        guard let row = try await stream.first(where: { _ in true }) else { return 30 }
+        var col = row.makeIterator()
+        return (try? col.next()?.decode(Int.self, context: .default)) ?? 30
+    }
+
+    package static func minimumRetentionDays(
+        on client: PostgresClient,
+        logger: Logger
+    ) async throws -> Int {
+        try await client.withConnection { conn in
+            try await minimumRetentionDays(on: conn, logger: logger)
+        }
+    }
+
+    /// Returns `retention_days` for a single namespace, falling back to 30
+    /// if the row is missing. Used per-namespace in `tryPrune` and in
+    /// `tryManagePartitions` when a specific namespace is configured.
+    /// Connection overload — SQL lives here.
+    package static func retentionDays(
+        namespaceID: String,
+        on conn: PostgresConnection,
+        logger: Logger
+    ) async throws -> Int {
+        let stream = try await conn.query(
+            "SELECT retention_days FROM strand.namespaces WHERE id = \(namespaceID)",
+            logger: logger
+        )
+        guard let row = try await stream.first(where: { _ in true }) else { return 30 }
+        var col = row.makeIterator()
+        return (try? col.next()?.decode(Int.self, context: .default)) ?? 30
+    }
+
+    /// Client overload — one-liner that delegates to the connection overload.
+    package static func retentionDays(
+        namespaceID: String,
+        on client: PostgresClient,
+        logger: Logger
+    ) async throws -> Int {
+        try await client.withConnection { conn in
+            try await retentionDays(namespaceID: namespaceID, on: conn, logger: logger)
+        }
+    }
+
     // MARK: - Cleanup
 
     /// Deletes terminal tasks older than `ageSeconds` and their associated
@@ -983,14 +1073,45 @@ package enum ManagementQueries {
             -- Each state clause uses its own terminal timestamp so the
             -- partial indexes (strand_tasks_completed_at_idx, etc.) can be
             -- used instead of scanning the full table.
+            --
+            -- IMPORTANT — parent-task guard:
+            -- Never prune a child task (parent_task_id IS NOT NULL) while its
+            -- parent workflow is still alive. Doing so would delete the child's
+            -- task_completions row, which is the durable result store used by
+            -- crash-recovery (_activate → loadCompletedChildActivities). Without
+            -- that row, a post-crash replay would re-execute already-completed
+            -- activities, causing duplicate side effects.
+            --
+            -- A child task is safe to prune when:
+            --   (a) it has no parent (root task), OR
+            --   (b) its parent no longer exists (was already pruned), OR
+            --   (c) its parent is itself terminal — i.e. the whole workflow tree
+            --       is done and the parent will be pruned in the same or a
+            --       subsequent cycle.
             WITH to_delete AS (
-                SELECT id FROM strand.tasks
+                SELECT id FROM strand.tasks t
                 WHERE namespace_id = \(namespaceID)
                   AND (\(queue)::text IS NULL OR queue = \(queue))
                   AND (
-                        (state = 'COMPLETED' AND completed_at < NOW() - \(effectiveAgeSeconds) * INTERVAL '1 second')
-                     OR (state = 'CANCELLED' AND cancelled_at < NOW() - \(effectiveAgeSeconds) * INTERVAL '1 second')
-                     OR (state = 'FAILED'    AND created_at   < NOW() - \(effectiveAgeSeconds) * INTERVAL '1 second')
+                        (state = 'COMPLETED'        AND completed_at < NOW() - \(effectiveAgeSeconds) * INTERVAL '1 second')
+                     OR (state = 'CONTINUED_AS_NEW'  AND completed_at < NOW() - \(effectiveAgeSeconds) * INTERVAL '1 second')
+                     OR (state = 'CANCELLED'         AND cancelled_at < NOW() - \(effectiveAgeSeconds) * INTERVAL '1 second')
+                     OR (state = 'FAILED'            AND created_at   < NOW() - \(effectiveAgeSeconds) * INTERVAL '1 second')
+                  )
+                  AND (
+                      -- Root task — safe to prune independently.
+                      t.parent_task_id IS NULL
+                      -- Parent no longer exists (was already pruned) — orphan cleanup.
+                      OR NOT EXISTS (
+                          SELECT 1 FROM strand.tasks parent
+                          WHERE parent.id = t.parent_task_id
+                      )
+                      -- Parent is itself terminal — whole tree is done.
+                      OR EXISTS (
+                          SELECT 1 FROM strand.tasks parent
+                          WHERE parent.id = t.parent_task_id
+                            AND parent.state IN ('COMPLETED', 'CONTINUED_AS_NEW', 'FAILED', 'CANCELLED')
+                      )
                   )
                 LIMIT \(limit)
                 FOR UPDATE SKIP LOCKED
@@ -1027,14 +1148,81 @@ package enum ManagementQueries {
         guard let row = try await stream.first(where: { _ in true }) else { return 0 }
         var col = row.makeIterator()
         let count = try col.next()!.decode(Int.self, context: .default)
-        logger.info(
-            "cleanup removed \(count) terminal tasks",
-            metadata: [
-                "strand.namespace": .string(namespaceID),
-                "strand.queue": .string(queue ?? "*"),
-                "strand.count": .stringConvertible(count),
-            ]
+        if count > 0 {
+            logger.debug(
+                "cleanup removed \(count) terminal tasks",
+                metadata: [
+                    "strand.namespace": .string(namespaceID),
+                    "strand.queue": .string(queue ?? "*"),
+                    "strand.count": .stringConvertible(count),
+                ]
+            )
+        }
+        return count
+    }
+
+    /// Deletes events from `strand.events` older than `ageSeconds`.
+    ///
+    /// Events are append-only and have no FK to tasks, so they are never
+    /// cascade-deleted by ``cleanupTasks``. Without explicit pruning they
+    /// accumulate indefinitely.
+    ///
+    /// Deleting an event sets `emission_id` to NULL on any `strand.event_triggers`
+    /// rows that reference it (via `ON DELETE SET NULL`). Those event_trigger
+    /// rows are eventually cleaned up by ``cleanupTasks`` when their tasks are
+    /// pruned.
+    ///
+    /// Returns the number of events deleted.
+    package static func cleanupEvents(
+        on client: PostgresClient,
+        namespaceID: String,
+        ageSeconds: Int?,
+        limit: Int,
+        logger: Logger
+    ) async throws -> Int {
+        let effectiveAgeSeconds: Int
+        if let explicit = ageSeconds {
+            effectiveAgeSeconds = explicit
+        } else {
+            let nsStream = try await client.query(
+                "SELECT retention_days FROM strand.namespaces WHERE id = \(namespaceID)",
+                logger: logger
+            )
+            var days = 30
+            if let nsRow = try await nsStream.first(where: { _ in true }) {
+                var col = nsRow.makeIterator()
+                days = (try? col.next()?.decode(Int.self, context: .default)) ?? 30
+            }
+            effectiveAgeSeconds = days * 24 * 3600
+        }
+
+        let stream = try await client.query(
+            """
+            WITH to_delete AS (
+                SELECT id FROM strand.events
+                WHERE namespace_id = \(namespaceID)
+                  AND created_at < NOW() - \(effectiveAgeSeconds) * INTERVAL '1 second'
+                ORDER BY created_at ASC
+                LIMIT \(limit)
+                FOR UPDATE SKIP LOCKED
+            )
+            DELETE FROM strand.events
+            WHERE id IN (SELECT id FROM to_delete)
+            RETURNING id
+            """,
+            logger: logger
         )
+        var count = 0
+        for try await _ in stream { count += 1 }
+        if count > 0 {
+            logger.debug(
+                "cleanup removed \(count) events",
+                metadata: [
+                    "strand.namespace": .string(namespaceID),
+                    "strand.count": .stringConvertible(count),
+                ]
+            )
+        }
         return count
     }
 }

--- a/Sources/Strand/DB/PartitionQueries.swift
+++ b/Sources/Strand/DB/PartitionQueries.swift
@@ -1,0 +1,325 @@
+import Logging
+import PostgresNIO
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+// MARK: - PartitionQueries
+
+/// DDL helpers for managing monthly range partitions on `strand.runs`,
+/// `strand.task_logs`, and `strand.workflow_history`. Called by ``StrandPruner``
+/// at startup and every 12 hours.
+///
+/// ## Why manual ANALYZE matters
+///
+/// Postgres autovacuum silently skips partitioned **parent** tables — it only
+/// processes child partitions. Without a periodic `ANALYZE strand.runs`, the
+/// query planner has zero statistics for the parent and produces catastrophically
+/// wrong row estimates (Hatchet observed 6 000 000× off in production), causing
+/// the claim path to fall back to sequential scans under load. Every function in
+/// this file that touches the schema also calls ``analyzeParentTables(on:logger:)``
+/// to keep planner statistics current.
+///
+/// ## DETACH PARTITION CONCURRENTLY
+///
+/// `DETACH PARTITION … CONCURRENTLY` takes a lighter lock than a plain
+/// `DETACH PARTITION` — it does not block concurrent reads or writes on the
+/// parent table while running. The trade-off is that it is **non-transactional**
+/// and must run on a raw connection (not inside `BEGIN`). If the process crashes
+/// mid-detach, an orphaned pending-detach partition is left behind; call
+/// ``finalizeOrphanedDetaches(on:logger:)`` to clean those up before retrying.
+package enum PartitionQueries {
+
+    /// The partitioned tables that ``StrandPruner`` manages.
+    ///
+    /// `strand.runs` and `strand.task_logs` are both partitioned by `created_at`
+    /// (monthly RANGE). `strand.workflow_history` is intentionally non-partitioned
+    /// because its `batchAppendHistory` query uses
+    /// `ON CONFLICT (task_id, seq) DO NOTHING` for idempotency — a unique constraint
+    /// that cannot exist without the partition key, which would break the ON CONFLICT
+    /// clause. Retention for history is handled by cascade DELETE from strand.tasks.
+    ///
+    /// `task_logs` has no FK to `strand.tasks` — partition DROP TABLE handles
+    /// cleanup automatically when StrandPruner drops expired months.
+    static let partitionedTables: [String] = ["runs", "task_logs"]
+
+    // MARK: - Ensure partitions exist
+
+    /// Creates monthly partitions for `runs` and `task_logs` covering the current
+    /// month plus the next `monthsAhead` months. Idempotent — already-existing
+    /// partitions are silently skipped.
+    ///
+    /// Called at startup and every 12 h by ``StrandPruner``.
+    static func ensurePartitions(
+        on client: PostgresClient,
+        monthsAhead: Int = 2,
+        logger: Logger
+    ) async throws {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let now = Date()
+
+        for table in partitionedTables {
+            for offset in 0...monthsAhead {
+                guard
+                    let monthDate = cal.date(
+                        byAdding: .month,
+                        value: offset,
+                        to: cal.startOfDay(for: now)
+                    )
+                else { continue }
+                // Snap to month start
+                let components = cal.dateComponents([.year, .month], from: monthDate)
+                guard let monthStart = cal.date(from: components) else { continue }
+
+                let stream = try await client.query(
+                    "SELECT strand.create_range_partition(\(table), \(monthStart)::DATE)",
+                    logger: logger
+                )
+                if let row = try await stream.first(where: { _ in true }) {
+                    var col = row.makeIterator()
+                    let created = try col.next()!.decode(Bool.self, context: .default)
+                    if created {
+                        logger.info(
+                            "partition created",
+                            metadata: [
+                                "strand.table": .string("strand.\(table)"),
+                                "strand.partition": .string("\(table)_\(partitionSuffix(monthStart))"),
+                            ]
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Drop expired partitions
+
+    /// Detaches and drops all monthly partitions whose month is strictly before
+    /// `cutoffDate`. Uses `DETACH PARTITION … CONCURRENTLY` (non-transactional,
+    /// raw connection) followed by `DROP TABLE`.
+    ///
+    /// Returns the number of partitions dropped.
+    @discardableResult
+    static func dropExpiredPartitions(
+        on client: PostgresClient,
+        olderThan cutoffDate: Date,
+        logger: Logger
+    ) async throws -> Int {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        // Snap cutoff to month start so we only drop whole months.
+        let comps = cal.dateComponents([.year, .month], from: cutoffDate)
+        guard let cutoffMonth = cal.date(from: comps) else { return 0 }
+
+        var dropped = 0
+
+        for table in partitionedTables {
+            let stream = try await client.query(
+                "SELECT partition_name FROM strand.list_partitions_before(\(table), \(cutoffMonth)::DATE)",
+                logger: logger
+            )
+            var names: [String] = []
+            for try await row in stream {
+                var col = row.makeIterator()
+                names.append(try col.next()!.decode(String.self, context: .default))
+            }
+
+            for partitionName in names {
+                do {
+                    try await client.withConnection { conn in
+                        try await detachAndDrop(
+                            on: conn,
+                            parentTable: table,
+                            partitionName: partitionName,
+                            logger: logger
+                        )
+                    }
+                    dropped += 1
+                    logger.info(
+                        "partition dropped",
+                        metadata: [
+                            "strand.table": .string("strand.\(table)"),
+                            "strand.partition": .string("strand.\(partitionName)"),
+                        ]
+                    )
+                } catch {
+                    // Log and continue — a failed drop is not fatal; it will be
+                    // retried on the next cycle. Call finalizeOrphanedDetaches
+                    // if CONCURRENTLY leaves a pending-detach orphan.
+                    logger.error(
+                        "failed to drop partition — will retry next cycle",
+                        metadata: [
+                            "strand.partition": .string(partitionName),
+                            "error": .string(strandErrorMessage(error)),
+                        ]
+                    )
+                }
+            }
+        }
+
+        return dropped
+    }
+
+    // MARK: - ANALYZE parent tables
+
+    /// Runs `ANALYZE` on the partitioned parent tables.
+    ///
+    /// **Must be called periodically** — Postgres autovacuum never analyzes
+    /// partitioned parent tables, only their child partitions. Without this call
+    /// the query planner uses stale (or zero) statistics for the parent, producing
+    /// wrong row estimates that can degrade the hot claim path to sequential scans.
+    ///
+    /// Called at startup and every 12 h by ``StrandPruner``.
+    static func analyzeParentTables(
+        on client: PostgresClient,
+        logger: Logger
+    ) async throws {
+        // ANALYZE cannot run inside a transaction on partitioned tables;
+        // client.query starts its own implicit transaction which is fine here.
+        // strand.runs and strand.task_logs are partitioned — autovacuum skips their
+        // parent tables. workflow_history is a plain table and autovacuum handles it.
+        for table in partitionedTables {
+            try await client.query(
+                "ANALYZE strand.\(unescaped: table)",
+                logger: logger
+            )
+            logger.debug(
+                "ANALYZE complete on parent table",
+                metadata: ["strand.table": .string("strand.\(table)")]
+            )
+        }
+    }
+
+    // MARK: - Orphan cleanup
+
+    /// Finalizes any partitions left in a pending-detach state by a prior
+    /// `DETACH PARTITION … CONCURRENTLY` that was interrupted (e.g. process crash).
+    ///
+    /// Safe to call on every startup — it is a no-op when there are no orphans.
+    static func finalizeOrphanedDetaches(
+        on client: PostgresClient,
+        logger: Logger
+    ) async throws {
+        // The pending-detach mechanism changed across major versions:
+        //   PG13 and earlier — DETACH PARTITION CONCURRENTLY doesn't exist; skip.
+        //   PG14–16          — pg_class.relisbeingdetached tracks pending detach.
+        //   PG17+            — pg_inherits.inhdetachpending replaced relisbeingdetached.
+        let verStream = try await client.query(
+            "SELECT current_setting('server_version_num')::int",
+            logger: logger
+        )
+        guard let verRow = try await verStream.first(where: { _ in true }) else { return }
+        var verCol = verRow.makeIterator()
+        let versionNum = (try? verCol.next()?.decode(Int.self, context: .default)) ?? 0
+
+        guard versionNum >= 140_000 else {
+            logger.debug("pruner: PostgreSQL < 14 — skipping orphaned-detach finalization")
+            return
+        }
+
+        // Build a version-appropriate WHERE predicate for pending-detach state.
+        let pendingFilter = versionNum >= 170_000
+            ? "i.inhdetachpending = TRUE"      // PG17+
+            : "child.relisbeingdetached = TRUE" // PG14–16
+
+        let stream = try await client.query(
+            """
+            SELECT n.nspname || '.' || parent.relname AS parent_name,
+                   n.nspname || '.' || child.relname  AS child_name
+            FROM   pg_inherits i
+            JOIN   pg_class parent ON parent.oid = i.inhparent
+            JOIN   pg_class child  ON child.oid  = i.inhrelid
+            JOIN   pg_namespace n  ON n.oid      = parent.relnamespace
+            WHERE  \(unescaped: pendingFilter)
+              AND  n.nspname = 'strand'
+            """,
+            logger: logger
+        )
+        var orphans: [(parent: String, child: String)] = []
+        for try await row in stream {
+            var col = row.makeIterator()
+            let parent = try col.next()!.decode(String.self, context: .default)
+            let child = try col.next()!.decode(String.self, context: .default)
+            orphans.append((parent: parent, child: child))
+        }
+
+        for orphan in orphans {
+            logger.warning(
+                "finalizing orphaned partition detach",
+                metadata: [
+                    "strand.parent": .string(orphan.parent),
+                    "strand.partition": .string(orphan.child),
+                ]
+            )
+            try await client.withConnection { conn in
+                // FINALIZE completes the interrupted CONCURRENTLY detach.
+                // values come from pg_class (system catalog), not user input.
+                try await conn.query(
+                    "ALTER TABLE \(unescaped: orphan.parent) DETACH PARTITION \(unescaped: orphan.child) FINALIZE",
+                    logger: logger
+                )
+                // Extract the unqualified partition name for the safe SQL function.
+                let childName = orphan.child.split(separator: ".").last.map(String.init) ?? orphan.child
+                let parentName = orphan.parent.split(separator: ".").last.map(String.init) ?? orphan.parent
+                try await conn.query(
+                    "SELECT strand.drop_partition(\(parentName), \(childName))",
+                    logger: logger
+                )
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    /// `DETACH PARTITION … CONCURRENTLY` + `DROP TABLE` on a raw connection.
+    ///
+    /// Must NOT be called inside a transaction — CONCURRENTLY is non-transactional.
+    ///
+    /// ## Why DETACH uses `\(unescaped:)`
+    ///
+    /// PostgreSQL's bind-parameter syntax (`$1`, `$2`) only works for **data
+    /// values**, never for identifiers (schema/table names). There is no
+    /// parameterized form for `ALTER TABLE … DETACH PARTITION`.
+    /// Additionally, `DETACH PARTITION CONCURRENTLY` is banned inside any
+    /// PL/pgSQL function (Postgres raises "ERROR: DETACH PARTITION CONCURRENTLY
+    /// cannot run inside a transaction block"), so we cannot route it through a
+    /// server-side SQL function either.
+    ///
+    /// PostgresNIO's `\(unescaped: value)` interpolation appends the string
+    /// directly to the SQL without creating a bind parameter — the right tool
+    /// for identifier injection. The values are safe because both `parentTable`
+    /// and `partitionName` come exclusively from `strand.list_partitions_before`,
+    /// which reads from the `pg_inherits` system catalog, not from user input.
+    /// The DROP TABLE step delegates to `strand.drop_partition()` which uses
+    /// `format('%I', …)` for proper server-side identifier quoting.
+    private static func detachAndDrop(
+        on conn: PostgresConnection,
+        parentTable: String,
+        partitionName: String,  // e.g. "runs_202601"
+        logger: Logger
+    ) async throws {
+        // Step 1: DETACH CONCURRENTLY — use \(unescaped:) for identifier injection.
+        // Values are from pg_inherits (system catalog), not user input.
+        try await conn.query(
+            "ALTER TABLE strand.\(unescaped: parentTable) DETACH PARTITION strand.\(unescaped: partitionName) CONCURRENTLY",
+            logger: logger
+        )
+        // Step 2: DROP via the server-side function which uses format('%I').
+        try await conn.query(
+            "SELECT strand.drop_partition(\(parentTable), \(partitionName))",
+            logger: logger
+        )
+    }
+
+    /// Returns the `YYYYMM` suffix for a month-start date.
+    private static func partitionSuffix(_ date: Date) -> String {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let comps = cal.dateComponents([.year, .month], from: date)
+        return String(format: "%04d%02d", comps.year ?? 0, comps.month ?? 0)
+    }
+}

--- a/Sources/Strand/DB/Queries.swift
+++ b/Sources/Strand/DB/Queries.swift
@@ -163,6 +163,7 @@ enum Queries {
         fairnessWeight: Double = 1.0,
         kind: TaskKind = .workflow,
         parentTaskID: UUID? = nil,
+        firstTaskID: UUID? = nil,
         backfillID: UUID? = nil,
         logger: Logger
     ) async throws -> EnqueueRow {
@@ -177,14 +178,14 @@ enum Queries {
                     (namespace_id, id, queue, name, params, headers, scheduling_metadata,
                      retry_strategy, max_attempts, timeout_seconds, heartbeat_timeout_seconds,
                      cancellation, idempotency_key, priority, fairness_key, fairness_weight,
-                     state, kind, parent_task_id, deadline_at, backfill_id)
+                     state, kind, parent_task_id, first_task_id, deadline_at, backfill_id)
                 VALUES (\(namespaceID), \(taskID), \(queue), \(taskName), \(paramsBuffer),
                         \(headersBuffer), \(schedulingMetadata),
                         \(retryStrategyBuffer), \(maxAttempts),
                         \(timeoutSeconds), \(heartbeatTimeoutSeconds),
                         \(cancellationBuffer), \(idempotencyKey), \(priority),
                         \(fairnessKey), \(fairnessWeight), \(TaskState.pending),
-                        \(kind), \(parentTaskID), \(deadlineAt), \(backfillID))
+                        \(kind), \(parentTaskID), \(firstTaskID), \(deadlineAt), \(backfillID))
                 ON CONFLICT (namespace_id, queue, idempotency_key) DO NOTHING
                 """,
                 logger: logger
@@ -626,7 +627,8 @@ enum Queries {
                    t.name, t.params, t.retry_strategy, t.max_attempts, t.headers,
                    c.wake_event, c.event_payload,
                    t.parent_task_id, t.kind, t.timeout_seconds, t.heartbeat_timeout_seconds,
-                   t.scheduling_metadata, c.available_at, c.heartbeat_details, t.deadline_at
+                   t.scheduling_metadata, c.available_at, c.heartbeat_details, t.deadline_at,
+                   t.first_task_id
             FROM claimed c JOIN strand.tasks t ON t.id = c.task_id
             ORDER BY c.id
             """,
@@ -1177,14 +1179,18 @@ enum Queries {
 
     // MARK: - Checkpoints
 
-    /// Bulk-loads all checkpoints for `taskID` written by `runID`.
+    /// Loads all checkpoint rows for a workflow task regardless of which run wrote them.
     ///
-    /// Keyed by `seq_num` (integer primary key) rather than name. Callers use the
-    /// returned `seqNum` to reconstruct the deterministic step counter cache.
+    /// The `run_id` filter was removed: `strand.checkpoints` has PRIMARY KEY
+    /// `(task_id, seq_num)`, so there is at most one row per seq_num per task.
+    /// The `setCheckpointState` upsert already uses an attempt-number guard so
+    /// only the highest-attempt run's value survives for each seq_num. Loading
+    /// all checkpoints for the task (not just the current run) means crash recovery
+    /// correctly reconstructs deterministic values (uuid(), random()) even when
+    /// `failRun` has created a new run_id for a workflow retry.
     static func getCheckpointStates(
         on client: PostgresClient,
         taskID: UUID,
-        runID: UUID,
         logger: Logger
     ) async throws -> [CheckpointRow] {
         let stream = try await client.query(
@@ -1192,8 +1198,7 @@ enum Queries {
             SELECT seq_num, name, state
             FROM strand.checkpoints
             WHERE task_id = \(taskID)
-              AND run_id  = \(runID)
-            ORDER BY created_at
+            ORDER BY seq_num
             """,
             logger: logger
         )
@@ -1353,8 +1358,9 @@ enum Queries {
             )
             if let row = try await evtStream.first(where: { _ in true }) {
                 var col = row.makeIterator()
-                if let payload = try col.next()!.decode(ByteBuffer?.self, context: .default) {
-                    return .payload(payload)
+                // RawJSONB decodes JSONB in text wire format — no 0x01 binary prefix.
+                if let raw = try col.next()!.decode(RawJSONB?.self, context: .default) {
+                    return .payload(raw.buffer)
                 }
             }
             let timeoutAt: Date? = timeoutSeconds.map { Date.now.addingTimeInterval(Double($0)) }
@@ -1499,13 +1505,20 @@ enum Queries {
             try await conn.query(
                 """
                 INSERT INTO strand.events (id, namespace_id, queue, name, payload)
-                VALUES (\(emissionID), \(namespaceID), \(queue), \(eventName), \(payloadBuffer))
+                VALUES (\(emissionID), \(namespaceID), \(queue), \(eventName), \(RawJSONB(payloadBuffer)))
                 """,
                 logger: logger
             )
-            // namespace_id filter is essential for tenant isolation.
+
+            // payload is JSONB; RawJSONB sends payloadBuffer with JSONB OID directly.
             let waitsStream = try await conn.query(
-                "SELECT task_id, run_id FROM strand.event_waits WHERE namespace_id = \(namespaceID) AND queue = \(queue) AND event_name = \(eventName)",
+                """
+                SELECT task_id, run_id FROM strand.event_waits
+                WHERE namespace_id = \(namespaceID)
+                  AND queue        = \(queue)
+                  AND event_name   = \(eventName)
+                  AND \(RawJSONB(payloadBuffer)) @> predicate
+                """,
                 logger: logger
             )
             var waits: [(taskID: UUID, runID: UUID)] = []
@@ -1543,8 +1556,16 @@ enum Queries {
                     logger: logger
                 )
             }
+            // Delete only the waiters that were actually woken (predicate matched).
+            // Non-matching waiters remain registered for a future event that satisfies them.
             try await conn.query(
-                "DELETE FROM strand.event_waits WHERE namespace_id = \(namespaceID) AND queue = \(queue) AND event_name = \(eventName)",
+                """
+                DELETE FROM strand.event_waits
+                WHERE namespace_id = \(namespaceID)
+                  AND queue        = \(queue)
+                  AND event_name   = \(eventName)
+                  AND \(RawJSONB(payloadBuffer)) @> predicate
+                """,
                 logger: logger
             )
             if !waits.isEmpty {

--- a/Sources/Strand/DB/RowDecoding.swift
+++ b/Sources/Strand/DB/RowDecoding.swift
@@ -67,6 +67,10 @@ struct ClaimedTask: Sendable {
     /// Used by activities to compute remaining budget: `deadlineAt.map { $0.timeIntervalSince(.now) }`.
     let deadlineAt: Date?
 
+    /// First task in the `continueAsNew` chain this task belongs to.
+    /// `nil` for the first task in a chain, for child tasks, and for activities.
+    let firstTaskID: UUID?
+
     /// `true` when this attempt is the last one allowed.
     ///
     /// Used to decide whether a thrown error should mark the OTel span `ERROR`.
@@ -80,10 +84,11 @@ struct ClaimedTask: Sendable {
 
 extension ClaimedTask {
     /// Decode from the column order returned by the claim CTE:
-    /// Columns: run_id, task_id, attempt, version, task_name, params,
+    /// run_id, task_id, attempt, version, task_name, params,
     /// retry_strategy, max_attempts, headers, wake_event, event_payload,
     /// parent_task_id, kind, timeout_seconds, heartbeat_timeout_seconds,
-    /// scheduling_metadata, available_at, heartbeat_details, deadline_at
+    /// scheduling_metadata, available_at, heartbeat_details, deadline_at,
+    /// first_task_id
     init(row: PostgresRow) throws {
         var col = row.makeIterator()
         runID = try col.next()!.decode(UUID.self, context: .default)
@@ -113,6 +118,7 @@ extension ClaimedTask {
         availableAt = try col.next()!.decode(Date.self, context: .default)
         heartbeatDetails = try col.next()!.decode(ByteBuffer?.self, context: .default)
         deadlineAt = try col.next()!.decode(Date?.self, context: .default)
+        firstTaskID = try col.next()!.decode(UUID?.self, context: .default)
     }
 }
 

--- a/Sources/Strand/DB/WorkflowStateQueries.swift
+++ b/Sources/Strand/DB/WorkflowStateQueries.swift
@@ -275,6 +275,8 @@ package enum WorkflowStateQueries {
         case workflowFailed = "WORKFLOW_FAILED"
         case signalReceived = "SIGNAL_RECEIVED"
         case activityScheduled = "ACTIVITY_SCHEDULED"
+        case activityCompleted = "ACTIVITY_COMPLETED"
+        case activityFailed = "ACTIVITY_FAILED"
         case timerStarted = "TIMER_STARTED"
         case timerFired = "TIMER_FIRED"
         case conditionWaiting = "CONDITION_WAITING"

--- a/Sources/Strand/Errors.swift
+++ b/Sources/Strand/Errors.swift
@@ -53,34 +53,7 @@ public enum StrandError: Error, LocalizedError, Sendable {
     }
 }
 
-// MARK: - EventWaitTimeoutError
 
-/// Thrown by ``WorkflowContext/waitForEvent(_:as:timeout:)`` when the timeout
-/// elapses before the named event arrives.
-///
-/// Catch this type specifically in your workflow handler — do **not** catch the
-/// broader ``StrandError`` enum, which contains framework-internal variants
-/// that must propagate to the runtime:
-///
-/// ```swift
-/// do {
-///     let payload = try await context.waitForEvent(
-///         "order.shipped", as: ShipmentInfo.self, timeout: .seconds(300)
-///     )
-///     return .success(payload)
-/// } catch is EventWaitTimeoutError {
-///     // No one shipped within 5 minutes — escalate
-///     return .timedOut
-/// }
-/// ```
-public struct EventWaitTimeoutError: Error, Sendable {
-    /// The name of the event that was being waited for.
-    public let eventName: String
-
-    public var localizedDescription: String {
-        "Timed out waiting for event \"\(eventName)\""
-    }
-}
 
 /// Internal sentinel errors used to signal clean lifecycle transitions.
 /// Never surfaced to user code.

--- a/Sources/Strand/Internal/JSONHelpers.swift
+++ b/Sources/Strand/Internal/JSONHelpers.swift
@@ -1,5 +1,6 @@
 package import NIOCore
 import NIOFoundationCompat
+import PostgresNIO
 
 #if canImport(FoundationEssentials)
 import FoundationEssentials
@@ -92,5 +93,55 @@ package enum JSON {
     ) throws(StrandError) -> T? {
         guard let buffer, buffer.readableBytes > 0 else { return nil }
         return try decode(type, from: buffer)
+    }
+}
+
+// MARK: - RawJSONB
+
+/// A `PostgresCodable` that binds and reads a JSONB column using the text
+/// wire format (OID 3802) rather than binary.
+///
+/// ```swift
+/// // Write — bind a ByteBuffer directly as JSONB:
+/// conn.query("INSERT INTO t (payload) VALUES (\(RawJSONB(payloadBuffer)))")
+/// conn.query("SELECT … WHERE payload @> \(RawJSONB(payloadBuffer))")
+///
+/// // Read — decode a JSONB column as a ByteBuffer, no SQL ::text cast:
+/// let raw = try col.next()!.decode(RawJSONB?.self, context: .default)
+/// let buf: ByteBuffer? = raw.map(\.buffer)
+/// ```
+struct RawJSONB: PostgresNonThrowingEncodable, PostgresDecodable, Sendable {
+    static var psqlType: PostgresDataType { .jsonb }
+    static var psqlFormat: PostgresFormat { .text }
+
+    private(set) var buffer: ByteBuffer
+
+    init(_ buffer: ByteBuffer) {
+        self.buffer = buffer
+    }
+
+    // MARK: Encode (write side)
+
+    func encode(
+        into byteBuffer: inout ByteBuffer,
+        context: PostgresEncodingContext<some PostgresJSONEncoder>
+    ) {
+        var buf = buffer
+        byteBuffer.writeBuffer(&buf)
+    }
+
+    // MARK: Decode (read side)
+    //
+    // PostgresNIO requests text format for this column because psqlFormat == .text.
+    // PostgreSQL sends the JSON string with no binary prefix, so we get clean bytes.
+
+    init(
+        from buffer: inout ByteBuffer,
+        type: PostgresDataType,
+        format: PostgresFormat,
+        context: PostgresDecodingContext<some PostgresJSONDecoder>
+    ) throws {
+        // readSlice shares the underlying storage (copy-on-write) — no copy.
+        self.buffer = buffer.readSlice(length: buffer.readableBytes) ?? ByteBuffer()
     }
 }

--- a/Sources/Strand/Internal/StrandMetrics.swift
+++ b/Sources/Strand/Internal/StrandMetrics.swift
@@ -46,6 +46,25 @@ public enum StrandMetrics {
     /// Workflow called `context.continueAsNew(input:)` — old run completed, new task enqueued.
     /// **Dimensions**: `task_name`, `queue`
     public static let tasksContinuedAsNew = "strand.tasks.continued_as_new"
+
+    // MARK: - Pruner
+
+    /// Number of terminal tasks deleted in a pruner cycle.
+    /// Includes COMPLETED, CONTINUED_AS_NEW, FAILED, and CANCELLED tasks
+    /// that have aged past the namespace retention window.
+    /// **Dimensions**: `namespace`
+    public static let prunerTasksDeleted = "strand.pruner.tasks_deleted"
+
+    /// Number of events deleted in a pruner cycle.
+    /// `strand.events` rows have no FK to tasks and are pruned independently.
+    /// **Dimensions**: `namespace`
+    public static let prunerEventsDeleted = "strand.pruner.events_deleted"
+
+    /// Number of monthly partitions dropped in a partition management cycle.
+    /// A non-zero value means at least one whole month of `strand.runs` or
+    /// `strand.task_logs` data was instantly reclaimed without a vacuum.
+    /// **Dimensions**: `namespace`
+    public static let prunerPartitionsDropped = "strand.pruner.partitions_dropped"
 }
 
 // MARK: - LISTEN/NOTIFY channel names

--- a/Sources/Strand/Internal/WorkflowExecutor.swift
+++ b/Sources/Strand/Internal/WorkflowExecutor.swift
@@ -33,7 +33,12 @@ enum WorkflowCommand: Sendable {
     case startTimer(wakeAt: Date, seqNum: Int)
 
     /// Register a named-event wait and suspend until the event arrives.
-    case awaitEvent(eventName: String, seqNum: Int, timeoutAt: Date?)
+    ///
+    /// `predicate` is a JSONB-serialized equality filter (e.g. `{"approvalId": "abc-123"}`).
+    /// `nil` means match any payload — used by the auto-scoped typed API.
+    /// Non-nil predicates are stored in `strand.event_waits.predicate` and evaluated
+    /// by Postgres at emission time via `incoming_payload @> predicate`.
+    case awaitEvent(eventName: String, seqNum: Int, timeoutAt: Date?, predicate: ByteBuffer?)
 
     /// Persist a computed value as a checkpoint (uuid/random result or activity fast-path).
     /// Non-suspending — the handler continues immediately after emitting this.
@@ -63,6 +68,13 @@ enum WorkflowCommand: Sendable {
     /// Always carries `seqNum` (the deadline checkpoint slot) so `applyScheduleCommands`
     /// can atomically write the `ConditionResultSentinel` and `CONDITION_TIMED_OUT`.
     case conditionTimedOut(seqNum: Int)
+
+    /// Records that an activity result (success or failure) was delivered to the handler.
+    /// Non-suspending — processed by the step-2 loop to write an `ACTIVITY_COMPLETED` or
+    /// `ACTIVITY_FAILED` history event. For successful completions the accompanying
+    /// `.writeCheckpoint` ensures replays return via fast-path-1 without re-emitting.
+    /// For failures, an `ActivityFailedSentinel` checkpoint guards the same invariant.
+    case activityCompleted(name: String, seqNum: Int, failed: Bool)
 
     /// Records that a child workflow result was delivered to the handler.
     /// Non-suspending — processed by the step-2 loop to write a `CHILD_WORKFLOW_COMPLETED`
@@ -107,8 +119,6 @@ enum WorkflowCommand: Sendable {
 /// parked on `CheckedContinuation`s here. On re-activation the worker calls the
 /// Resume API (`resumeActivity`, `resumeAllTimers`, etc.) to deliver real results,
 /// then calls `drain()` to continue the handler from where it paused.
-///
-/// **Why `@unchecked Sendable`**
 ///
 /// All access occurs on the drain loop caller's thread. Never share this object
 /// across concurrent tasks or call `drain()` from two threads at once.

--- a/Sources/Strand/Internal/WorkflowRegistration.swift
+++ b/Sources/Strand/Internal/WorkflowRegistration.swift
@@ -157,7 +157,6 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
         let checkpointRows = try await Queries.getCheckpointStates(
             on: exec.postgres,
             taskID: claimed.taskID,
-            runID: claimed.runID,
             logger: exec.logger
         )
         var checkpointCache: [Int: ByteBuffer] = [:]
@@ -356,7 +355,6 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
             let freshCheckpoints = try await Queries.getCheckpointStates(
                 on: exec.postgres,
                 taskID: claimed.taskID,
-                runID: claimed.runID,
                 logger: exec.logger
             )
             for row in freshCheckpoints where activation.cachedCheckpoint(for: row.seqNum) == nil {

--- a/Sources/Strand/Internal/WorkflowScheduling.swift
+++ b/Sources/Strand/Internal/WorkflowScheduling.swift
@@ -132,6 +132,15 @@ extension WorkflowRegistration {
                     logger: exec.logger
                 )
                 historySeq += 1
+            case .activityCompleted(let name, let seqNum, let failed):
+                // Record activity completion or failure. runActivity emits this command
+                // exactly once; for successes the accompanying .writeCheckpoint ensures
+                // replays return from fast-path-1 without re-emitting; for failures an
+                // ActivityFailedSentinel checkpoint guards the same invariant.
+                try await record(
+                    failed ? .activityFailed : .activityCompleted,
+                    try? JSON.encode(WorkflowStateQueries.ActivityScheduledData(activity: name, seqNum: seqNum))
+                )
             case .childWorkflowCompleted(let name, let seqNum):
                 // Record child workflow completion. runChildWorkflow emits this command
                 // exactly once; the accompanying checkpoint ensures replays return from
@@ -218,7 +227,7 @@ extension WorkflowRegistration {
             case .scheduleActivity, .startTimer, .awaitEvent, .scheduleChildWorkflow:
                 return true
             case .writeCheckpoint, .timerFired, .eventReceived, .eventWaitTimedOut,
-                .conditionMet, .conditionTimedOut, .emitEvent, .childWorkflowCompleted:
+                .conditionMet, .conditionTimedOut, .emitEvent, .activityCompleted, .childWorkflowCompleted:
                 return false
             }
         }
@@ -325,7 +334,7 @@ extension WorkflowRegistration {
                         logger: exec.logger
                     )
 
-                case .awaitEvent(let eventName, let seqNum, let timeoutAt):
+                case .awaitEvent(let eventName, let seqNum, let timeoutAt, let predicate):
                     // Atomic check-or-wait: prevents the lost-wakeup race where the
                     // event fires between drain() returning and this transaction committing.
                     //
@@ -340,6 +349,11 @@ extension WorkflowRegistration {
                     let taskID = claimed.taskID
                     let runID = claimed.runID
                     let queueName = exec.queue
+                    // Wrap predicate as RawJSONB — same approach as emitEvent.
+                    // nil predicate uses '{}' (matches any payload); non-nil uses the
+                    // serialized predicate bytes.
+                    let predicateRaw = RawJSONB(predicate ?? ByteBuffer(string: "{}"))
+
                     try await exec.postgres.withTransaction(logger: exec.logger) { conn in
                         // Always register the event_wait so emitEvent can find this run later.
                         // namespace_id is required for tenant isolation — never rely on the
@@ -347,10 +361,12 @@ extension WorkflowRegistration {
                         try await conn.query(
                             """
                             INSERT INTO strand.event_waits
-                                (namespace_id, task_id, run_id, queue, seq_num, event_name, timeout_at)
-                            VALUES (\(exec.namespace), \(taskID), \(runID), \(queueName), \(seqNum), \(eventName), \(timeoutAt))
+                                (namespace_id, task_id, run_id, queue, seq_num, event_name, timeout_at, predicate)
+                            VALUES (\(exec.namespace), \(taskID), \(runID), \(queueName), \(seqNum), \(eventName), \(timeoutAt), \(predicateRaw))
                             ON CONFLICT (run_id, seq_num) DO UPDATE
-                                SET event_name = EXCLUDED.event_name, timeout_at = EXCLUDED.timeout_at
+                                SET event_name = EXCLUDED.event_name,
+                                    timeout_at  = EXCLUDED.timeout_at,
+                                    predicate   = EXCLUDED.predicate
                             """,
                             logger: exec.logger
                         )
@@ -364,6 +380,7 @@ extension WorkflowRegistration {
                             WHERE namespace_id = \(exec.namespace)
                               AND queue = \(queueName)
                               AND name  = \(eventName)
+                              AND payload @> \(predicateRaw)
                             ORDER BY created_at DESC
                             LIMIT 1
                             """,
@@ -374,9 +391,9 @@ extension WorkflowRegistration {
                             var col = evtRow.makeIterator()
                             let emissionID = try col.next()!.decode(UUID.self, context: .default)
                             let existingPayload = try col.next()!.decode(
-                                ByteBuffer?.self,
+                                RawJSONB?.self,
                                 context: .default
-                            )
+                            ).map(\.buffer)
                             // Transition to PENDING with the event payload so the next
                             // activation's waitForEvent fast-path (wakeEvent == name) fires.
                             try await conn.query(
@@ -483,7 +500,7 @@ extension WorkflowRegistration {
                     )
 
                 case .writeCheckpoint, .timerFired, .eventReceived, .eventWaitTimedOut,
-                    .conditionMet, .conditionTimedOut, .childWorkflowCompleted:
+                    .conditionMet, .conditionTimedOut, .activityCompleted, .childWorkflowCompleted:
                     break  // processed in step-2 (non-suspending, not enqueued as child tasks)
                 }
             }

--- a/Sources/Strand/Schedule/BackfillTypes.swift
+++ b/Sources/Strand/Schedule/BackfillTypes.swift
@@ -52,7 +52,13 @@ public struct BackfillHandle: Sendable {
         self.logger = logger
     }
 
-    /// Stop enqueueing new slots. In-flight tasks continue to completion.
+    /// Stop enqueueing new slots and cancel any PENDING (not-yet-started)
+    /// slots that were already enqueued.
+    ///
+    /// Tasks that are currently RUNNING are left to complete — they have
+    /// already started work. Only slots that have not yet been claimed by a
+    /// worker (state = PENDING) are cancelled, preventing them from being
+    /// picked up after the halt.
     public func halt() async throws {
         try await BackfillQueries.halt(
             on: postgres,

--- a/Sources/Strand/StrandPruner.swift
+++ b/Sources/Strand/StrandPruner.swift
@@ -1,12 +1,19 @@
 import Logging
+import Metrics
 public import PostgresNIO
 public import ServiceLifecycle
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 // MARK: - Options
 
 /// Configuration for ``StrandPruner``.
 public struct StrandPrunerOptions: Sendable {
-    /// How often to run a prune cycle. Default: 30 s.
+    /// How often to run a fine-grained DELETE prune cycle. Default: 30 s.
     public var interval: Duration
     /// Maximum age of terminal tasks before they are deleted.
     /// Default: `nil` — ``ManagementQueries/cleanupTasks`` reads the namespace
@@ -17,24 +24,40 @@ public struct StrandPrunerOptions: Sendable {
     public var limit: Int
     /// Queue to prune. `nil` = all queues in the namespace. Default: `nil`.
     public var queue: String?
-    /// Postgres advisory lock key used for leader election.
-    /// Must be identical across every ``StrandPruner`` instance in the cluster
-    /// so only one instance runs cleanup per cycle.
+    /// Postgres advisory lock key used for leader election of the fine-grained
+    /// DELETE prune cycle. Must be identical across every ``StrandPruner``
+    /// instance in the cluster.
     /// Default: a stable constant derived from "StrandPN".
     public var advisoryLockKey: Int64
+    /// Postgres advisory lock key used for leader election of the partition
+    /// management cycle (DDL: create/drop partitions, ANALYZE).
+    /// Kept separate from ``advisoryLockKey`` so row-level cleanup and DDL
+    /// never compete for the same lock.
+    /// Default: derived from ``advisoryLockKey`` XOR `"PART"`.
+    public var partitionAdvisoryLockKey: Int64
+    /// How often to run partition management (create future partitions, drop
+    /// expired ones, ANALYZE parent tables). Default: 12 h.
+    ///
+    /// Partition creation is idempotent so running it more often is safe.
+    /// ANALYZE is cheap on empty-ish parent tables; the real work is on child
+    /// partitions which autovacuum handles automatically.
+    public var partitionManagementInterval: Duration
 
     public init(
         interval: Duration = .seconds(30),
         maxAge: Duration? = nil,
         limit: Int = 10_000,
         queue: String? = nil,
-        advisoryLockKey: Int64 = 0x5374_7261_6E64_504E  // "StrandPN"
+        advisoryLockKey: Int64 = 0x5374_7261_6E64_504E,  // "StrandPN"
+        partitionManagementInterval: Duration = .seconds(12 * 3600)
     ) {
         self.interval = interval
         self.maxAge = maxAge
         self.limit = limit
         self.queue = queue
         self.advisoryLockKey = advisoryLockKey
+        self.partitionAdvisoryLockKey = advisoryLockKey ^ 0x5041_5254  // XOR "PART"
+        self.partitionManagementInterval = partitionManagementInterval
     }
 }
 
@@ -47,25 +70,31 @@ public struct StrandPrunerOptions: Sendable {
 /// unboundedly without requiring manual cleanup calls.
 ///
 /// Only one instance in the cluster runs each cycle — leader election is via
-/// `pg_try_advisory_lock`. Non-leaders log a debug message and skip that cycle.
+/// `pg_try_advisory_lock`. Non-leaders skip the cycle silently.
 ///
 /// ```swift
+/// // Prune all namespaces (default) — retention read from strand.namespaces.retention_days
+/// let pruner = StrandPruner(postgres: postgres)
+///
+/// // Prune a single namespace with an explicit retention override:
 /// let pruner = StrandPruner(
 ///     postgres: postgres,
-///     namespaceID: "default",
-///     options: StrandPrunerOptions(maxAge: .seconds(7 * 24 * 3600)) // 7 days
+///     namespaceID: "production",
+///     options: StrandPrunerOptions(maxAge: .seconds(7 * 24 * 3_600))
 /// )
 /// let group = ServiceGroup(services: [postgres, worker, pruner])
 /// ```
 public struct StrandPruner: Service {
     private let postgres: PostgresClient
-    private let namespaceID: String
+    /// Namespace to prune. `nil` = prune every namespace in `strand.namespaces`
+    /// each cycle, each using its own `retention_days` setting.
+    private let namespaceID: String?
     private let options: StrandPrunerOptions
     private let logger: Logger
 
     public init(
         postgres: PostgresClient,
-        namespaceID: String = "default",
+        namespaceID: String? = nil,
         options: StrandPrunerOptions = .init(),
         logger: Logger = Logger(label: "dev.strand.pruner")
     ) {
@@ -78,34 +107,178 @@ public struct StrandPruner: Service {
     // MARK: - Service
 
     public func run() async throws {
-        logger.info(
+        logger.trace(
             "pruner starting",
             metadata: [
-                "strand.namespace": .string(namespaceID),
+                "strand.namespace": .string(namespaceID ?? "*"),
                 "strand.interval": .string("\(options.interval)"),
                 "strand.limit": .stringConvertible(options.limit),
+                "strand.partition_interval": .string("\(options.partitionManagementInterval)"),
             ]
         )
-        defer { logger.info("pruner stopped") }
+        defer { logger.trace("pruner stopped") }
 
-        while !Task.isShuttingDownGracefully && !Task.isCancelled {
-            try? await cancelWhenGracefulShutdown {
-                try await Task.sleep(for: self.options.interval)
+        // ── Startup: partition housekeeping before serving any traffic ────────
+        //
+        // 1. Finalize orphaned DETACH CONCURRENTLY operations (crash recovery).
+        // 2. Ensure current + next 2 months of partitions exist.
+        // 3. ANALYZE parent tables — autovacuum never touches them.
+        //    Without this the query planner has zero statistics and falls back
+        //    to sequential scans on the claim path.
+        do {
+            try await PartitionQueries.finalizeOrphanedDetaches(on: postgres, logger: logger)
+            try await PartitionQueries.ensurePartitions(on: postgres, logger: logger)
+            try await PartitionQueries.analyzeParentTables(on: postgres, logger: logger)
+        } catch {
+            logger.trace(
+                "pruner: startup partition management failed",
+                metadata: ["error": .string(strandErrorMessage(error))]
+            )
+            // Non-fatal: continue, the next cycle will retry.
+        }
+
+        // ── Two concurrent loops ──────────────────────────────────────────────
+        //
+        // • Short loop  (options.interval, default 30 s):
+        //     Leader-gated fine-grained DELETE of terminal rows within the
+        //     current partition. Handles rows that are within the retention window
+        //     but past their age — whole-partition drops can't help here.
+        //
+        // • Long loop   (options.partitionManagementInterval, default 12 h):
+        //     Leader-gated partition creation, DROP TABLE for expired months,
+        //     and ANALYZE on parent tables. Low frequency is fine because
+        //     partition creation is idempotent and DROP TABLE is instant.
+
+        await withTaskGroup(of: Void.self) { group in
+            // Short loop
+            group.addTask {
+                while !Task.isShuttingDownGracefully && !Task.isCancelled {
+                    try? await cancelWhenGracefulShutdown {
+                        try await Task.sleep(for: self.options.interval)
+                    }
+                    guard !Task.isShuttingDownGracefully && !Task.isCancelled else { break }
+                    do { try await self.tryPrune() } catch {
+                        self.logger.trace(
+                            "pruner cycle failed",
+                            metadata: ["error": .string(strandErrorMessage(error))]
+                        )
+                    }
+                }
             }
-            guard !Task.isShuttingDownGracefully && !Task.isCancelled else { break }
 
-            do {
-                try await tryPrune()
-            } catch {
-                logger.error(
-                    "pruner cycle failed",
-                    metadata: ["error": .string(String(reflecting: error))]
-                )
+            // Long loop
+            group.addTask {
+                while !Task.isShuttingDownGracefully && !Task.isCancelled {
+                    try? await cancelWhenGracefulShutdown {
+                        try await Task.sleep(for: self.options.partitionManagementInterval)
+                    }
+                    guard !Task.isShuttingDownGracefully && !Task.isCancelled else { break }
+                    do { try await self.tryManagePartitions() } catch {
+                        self.logger.trace(
+                            "pruner: partition management cycle failed",
+                            metadata: ["error": .string(strandErrorMessage(error))]
+                        )
+                    }
+                }
             }
         }
     }
 
     // MARK: - Private
+
+    /// Leader-gated partition management cycle (runs every 12 h):
+    ///   1. Create partitions for the current month + next 2 months.
+    ///   2. Drop expired whole-month partitions (DETACH CONCURRENTLY + DROP).
+    ///   3. ANALYZE parent tables (autovacuum skips them — critical!).
+    private func tryManagePartitions() async throws {
+        // Hold the advisory lock for the full duration of this function so that
+        // concurrent pruner instances cannot race on DDL (partition creation,
+        // DETACH PARTITION, DROP TABLE, ANALYZE).
+        //
+        // The lock is session-level (not transaction-level), so it stays held
+        // even when DDL sub-calls open their own connections from the pool —
+        // DETACH PARTITION CONCURRENTLY must run outside a transaction block,
+        // so those sub-calls use separate raw connections as required.
+        try await postgres.withConnection { conn in
+            let lockKey = self.options.partitionAdvisoryLockKey
+
+            let lockStream = try await conn.query(
+                "SELECT pg_try_advisory_lock(\(lockKey))",
+                logger: self.logger
+            )
+            guard let lockRow = try await lockStream.first(where: { _ in true }) else { return }
+            var lockCol = lockRow.makeIterator()
+            let acquired = try lockCol.next()!.decode(Bool.self, context: .default)
+            guard acquired else {
+                self.logger.debug("pruner: not leader — skipping partition management")
+                return
+            }
+
+            // Explicit unlock when this block exits (success or failure).
+            // Session-level locks are also released when the connection is
+            // returned to the pool, but explicit unlock is cleaner.
+            defer {
+                Task {
+                    _ = try? await conn.query(
+                        "SELECT pg_advisory_unlock(\(lockKey))",
+                        logger: self.logger
+                    )
+                }
+            }
+
+            // All DDL runs while the advisory lock is held.
+            // ensurePartitions and dropExpiredPartitions open their own
+            // connections from the pool (DETACH CONCURRENTLY requirement);
+            // that is safe — the advisory lock on `conn` prevents other
+            // pruner instances from starting concurrently.
+            try await PartitionQueries.ensurePartitions(on: self.postgres, logger: self.logger)
+
+            // Cutoff: options.maxAge takes precedence; otherwise read retention_days.
+            // Partition drops affect ALL namespaces simultaneously, so in multi-namespace
+            // mode we use the minimum retention_days across all namespaces — a partition
+            // cannot be dropped if any namespace still needs data from it.
+            let cutoff: Date
+            if let maxAge = self.options.maxAge {
+                cutoff = Date().addingTimeInterval(-maxAge.timeInterval)
+            } else {
+                let days: Int
+                if let ns = self.namespaceID {
+                    days = try await ManagementQueries.retentionDays(
+                        namespaceID: ns,
+                        on: conn,
+                        logger: self.logger
+                    )
+                } else {
+                    days = try await ManagementQueries.minimumRetentionDays(
+                        on: conn,
+                        logger: self.logger
+                    )
+                }
+                cutoff = Date().addingTimeInterval(-Double(days) * 86_400)
+            }
+            let dropped = try await PartitionQueries.dropExpiredPartitions(
+                on: self.postgres,
+                olderThan: cutoff,
+                logger: self.logger
+            )
+            if dropped > 0 {
+                self.logger.info(
+                    "partition management: dropped expired partitions",
+                    metadata: [
+                        "strand.namespace": .string(self.namespaceID ?? "*"),
+                        "strand.dropped": .stringConvertible(dropped),
+                    ]
+                )
+                Counter(
+                    label: StrandMetrics.prunerPartitionsDropped,
+                    dimensions: [("namespace", self.namespaceID ?? "*")]
+                ).increment(by: dropped)
+            }
+
+            // ANALYZE parent tables — autovacuum never touches them.
+            try await PartitionQueries.analyzeParentTables(on: self.postgres, logger: self.logger)
+        }
+    }
 
     private func tryPrune() async throws {
         // Hold a dedicated connection for the duration of the advisory lock so
@@ -124,7 +297,7 @@ public struct StrandPruner: Service {
             guard acquired else {
                 logger.debug(
                     "pruner: not leader — skipping this cycle",
-                    metadata: ["strand.namespace": .string(namespaceID)]
+                    metadata: ["strand.namespace": .string(namespaceID ?? "*")]
                 )
                 return
             }
@@ -133,21 +306,64 @@ public struct StrandPruner: Service {
             // (it will use a separate connection from the pool; that's fine — the
             // advisory lock is held here just to prevent other instances from
             // starting a concurrent cleanup).
-            let ageSeconds: Int?
-            if let maxAge = options.maxAge {
-                ageSeconds = Int(maxAge.components.seconds)
+            //
+            // Determine which namespaces to prune this cycle. When namespaceID
+            // is nil, query the full namespace list and prune each in turn,
+            // using each namespace's own retention_days.
+            let namespacesToPrune: [String]
+            if let ns = namespaceID {
+                namespacesToPrune = [ns]
             } else {
-                ageSeconds = nil  // ManagementQueries.cleanupTasks reads namespace retention_days
+                namespacesToPrune = try await ManagementQueries.allNamespaceIDs(
+                    on: conn,
+                    logger: logger
+                )
             }
 
-            _ = try await ManagementQueries.cleanupTasks(
-                on: postgres,
-                namespaceID: namespaceID,
-                queue: options.queue,
-                ageSeconds: ageSeconds,
-                limit: options.limit,
-                logger: logger
-            )
+            for ns in namespacesToPrune {
+                let ageSeconds: Int
+                if let maxAge = options.maxAge {
+                    ageSeconds = Int(maxAge.components.seconds)
+                } else {
+                    let days = try await ManagementQueries.retentionDays(
+                        namespaceID: ns,
+                        on: conn,
+                        logger: logger
+                    )
+                    ageSeconds = days * 24 * 3600
+                }
+
+                let deletedTasks = try await ManagementQueries.cleanupTasks(
+                    on: postgres,
+                    namespaceID: ns,
+                    queue: options.queue,
+                    ageSeconds: ageSeconds,
+                    limit: options.limit,
+                    logger: logger
+                )
+                if deletedTasks > 0 {
+                    Counter(
+                        label: StrandMetrics.prunerTasksDeleted,
+                        dimensions: [("namespace", ns)]
+                    ).increment(by: deletedTasks)
+                }
+
+                // Events are not tied to tasks (no FK), so they are not cascade-
+                // deleted when tasks are pruned. Prune them separately.
+                let deletedEvents = try await ManagementQueries.cleanupEvents(
+                    on: postgres,
+                    namespaceID: ns,
+                    ageSeconds: ageSeconds,
+                    limit: options.limit,
+                    logger: logger
+                )
+                if deletedEvents > 0 {
+                    Counter(
+                        label: StrandMetrics.prunerEventsDeleted,
+                        dimensions: [("namespace", ns)]
+                    ).increment(by: deletedEvents)
+                }
+            }
 
             // Explicitly release the advisory lock so other instances can
             // become leader on the next cycle (rather than waiting for the

--- a/Sources/Strand/StrandService.swift
+++ b/Sources/Strand/StrandService.swift
@@ -40,9 +40,17 @@ public struct StrandService: Service {
     public struct Options: Sendable {
         /// One entry per logical worker. At least one queue is required.
         public var queues: [QueueConfig]
-        /// Automatic task pruning. `nil` disables the pruner.
-        /// Use `StrandPrunerOptions()` for defaults; all five fields are
-        /// available (`interval`, `maxAge`, `limit`, `queue`, `advisoryLockKey`).
+        /// Automatic task pruning. Enabled by default with ``StrandPrunerOptions``
+        /// defaults: 30-second DELETE cycle (same as River's `JobCleanerIntervalDefault`),
+        /// 12-hour partition management, row limit of 10,000 per cycle, and
+        /// retention read per-namespace from `strand.namespaces.retention_days`
+        /// (default: 30 days). All registered namespaces are pruned each cycle.
+        ///
+        /// Only one instance in the cluster runs each cycle — leader election
+        /// is via `pg_try_advisory_lock`, so running a pruner on every node is safe.
+        ///
+        /// Set to `nil` to disable pruning entirely (useful in test environments
+        /// or when running a dedicated pruner process).
         public var pruner: StrandPrunerOptions?
         /// Scheduler options. `nil` disables the scheduler.
         /// Add schedules with ``StrandService/addSchedule(_:)``.
@@ -52,7 +60,7 @@ public struct StrandService: Service {
 
         public init(
             queues: [QueueConfig],
-            pruner: StrandPrunerOptions? = nil,
+            pruner: StrandPrunerOptions? = .init(),
             scheduler: SchedulerConfig? = nil,
             logger: Logger = Logger(label: "dev.strand")
         ) {
@@ -277,11 +285,12 @@ public struct StrandService: Service {
             )
         }
 
-        // ── 4. Pruner (optional) ────────────────────────────────────────────────
+        // ── 4. Pruner (optional) ────────────────────────────────────────────
+        // namespaceID: nil — prune every namespace in strand.namespaces each
+        // cycle, respecting each namespace's own retention_days setting.
         let pruner: StrandPruner? = options.pruner.map { opts in
             StrandPruner(
                 postgres: postgres,
-                namespaceID: firstQueue.namespace,
                 options: opts,
                 logger: logger
             )

--- a/Sources/Strand/Worker.swift
+++ b/Sources/Strand/Worker.swift
@@ -958,6 +958,10 @@ public struct StrandWorker: Service {
                 } else {
                     // ── Root workflow ─────────────────────────────────────────────────
                     // No parent is tracking this task_id, so a fresh task is fine.
+                    // Propagate first_task_id so the full continueAsNew chain is
+                    // navigable: if this task was itself a continuation, carry the
+                    // original chain root forward; otherwise this task IS the root.
+                    let firstTaskID = claimed.firstTaskID ?? claimed.taskID
                     _ = try await Queries.enqueueTask(
                         on: postgres,
                         namespaceID: signal.namespaceID,
@@ -975,8 +979,12 @@ public struct StrandWorker: Service {
                         fairnessWeight: 1.0,
                         kind: .workflow,
                         parentTaskID: nil,
+                        firstTaskID: firstTaskID,
                         logger: logger
                     )
+                    // completeRun transitions strand.tasks.state → COMPLETED and sets
+                    // completed_at. We immediately overwrite to CONTINUED_AS_NEW so the
+                    // old task is distinguishable from a naturally-completed workflow.
                     try await Queries.completeRun(
                         on: postgres,
                         namespaceID: signal.namespaceID,
@@ -984,6 +992,19 @@ public struct StrandWorker: Service {
                         version: claimed.version,
                         resultBuffer: nil,
                         logger: logger
+                    )
+                    // Override the task state set by completeRun.
+                    // This is a separate statement — there is no race: the old run is
+                    // COMPLETED after completeRun and can never be claimed again, so
+                    // no worker can concurrently transition it to a different state.
+                    try await postgres.query(
+                        """
+                        UPDATE strand.tasks
+                        SET state = \(TaskState.continuedAsNew)
+                        WHERE id           = \(claimed.taskID)
+                          AND namespace_id = \(signal.namespaceID)
+                        """,
+                        logger: taskLogger
                     )
                 }
             } catch {

--- a/Sources/Strand/Workflow.swift
+++ b/Sources/Strand/Workflow.swift
@@ -152,28 +152,39 @@ extension Workflow {
 
 /// A named, typed event that a workflow can wait for and a client can emit.
 ///
-/// Define an event as a concrete type so the compiler enforces that both sides
-/// agree on the name and payload type. A typo or payload mismatch becomes a
-/// compile error instead of a silent runtime failure.
+/// ## Instance-scoped delivery
+///
+/// The typed `waitForEvent` and `emit(to:)` APIs are **instance-scoped**: the
+/// event name is automatically suffixed with the target workflow's task UUID,
+/// so a single `OrderApprovedEvent` emission reaches exactly one waiting
+/// workflow instance rather than broadcasting to all.
 ///
 /// ```swift
 /// // 1. Define the event once:
-/// struct OrderShippedEvent: WorkflowEvent {
-///     typealias Payload = TrackingInfo
-///     static let name   = "order.shipped"
+/// struct OrderApprovedEvent: WorkflowEvent {
+///     typealias Payload = ApprovalPayload
+///     static let name   = "order.approved"  // human-readable, no ID needed
 /// }
 ///
-/// // 2. Wait for it in the workflow:
-/// let tracking = try await context.waitForEvent(OrderShippedEvent.self)
+/// ```swift
+/// // 2. Wait in the workflow, filtering by a payload field:
+/// let approval = try await context.waitForEvent(
+///     OrderApprovedEvent.self,
+///     matching: \.orderId == input.orderId   // only wake when orderId matches
+/// )
 ///
-/// // 3. Emit it from the client:
-/// try await client.emit(OrderShippedEvent.self,
-///     payload: TrackingInfo(number: "1Z999"),
-///     to: orderHandle)
+/// // 3. Emit from an HTTP handler — routing is done by the waiter's predicate:
+/// try await client.emit(OrderApprovedEvent.self,
+///     payload: ApprovalPayload(orderId: "abc-123", approved: true))
 /// ```
 ///
-/// For dynamic event names (e.g. per-order topics) the string API remains:
-/// `context.waitForEvent("order.shipped:\(orderID)", as: TrackingInfo.self)`
+/// ## Broadcast (no predicate)
+///
+/// Omit `matching:` to wake every workflow waiting for this event type:
+/// ```swift
+/// let signal = try await context.waitForEvent(SystemShutdownEvent.self)
+/// try await client.emit(SystemShutdownEvent.self, payload: ShutdownPayload())
+/// ```
 public protocol WorkflowEvent: Sendable {
     /// The event payload. Must be `Codable` and `Sendable`.
     associatedtype Payload: Codable & Sendable
@@ -185,6 +196,113 @@ public protocol WorkflowEvent: Sendable {
 
 extension WorkflowEvent {
     public static var name: String { String(describing: Self.self) }
+}
+
+// MARK: - EventPredicate
+
+/// A serializable equality predicate for payload-based event routing.
+///
+/// Created via the `==` operator on a `KeyPath` of the event's `Payload` type.
+/// The predicate is stored as JSONB in `strand.event_waits` and evaluated by
+/// Postgres at emission time using the `@>` containment operator — only the
+/// workflows whose predicate is a subset of the incoming event payload are woken.
+/// Filtering happens **before** any workflow is resumed.
+///
+/// ```swift
+/// // Flat field:
+/// \.approvalId == input.approvalId     // stores {"approvalId": "abc-123"}
+///
+/// // Nested field:
+/// \.order.id == input.orderID          // stores {"order": {"id": "abc-123"}}
+/// ```
+///
+/// - Note: The property name is extracted from Swift's KeyPath description string
+///   (`String(describing:)`). This is reliable for stored properties in current
+///   Swift (5.9+). Computed properties or very deep nesting may require using
+///   ``EventPredicate/init(path:equals:)`` with an explicit dot-path string.
+public struct EventPredicate<Target>: Sendable {
+    /// Dot-separated path components, e.g. `["order", "id"]`.
+    let pathComponents: [String]
+    /// JSON-encoded bytes of the expected value (e.g. `"\"abc-123\""` for a String).
+    let valueBytes: [UInt8]
+
+    /// Creates a predicate with an explicit dot-path string.
+    ///
+    /// Use this when `String(describing: keyPath)` doesn't produce the expected
+    /// field name, for example with computed properties or protocol requirements.
+    ///
+    /// ```swift
+    /// EventPredicate<MyPayload>(path: "order.merchantID", equals: input.merchantID)
+    /// ```
+    public init<V: Codable & Sendable>(path: String, equals value: V) {
+        self.pathComponents = path.components(separatedBy: ".")
+            .filter { !$0.isEmpty }
+        self.valueBytes = (try? JSON.encode(value))
+            .map { Array($0.readableBytesView) } ?? []
+    }
+
+    internal init(pathComponents: [String], valueBytes: [UInt8]) {
+        self.pathComponents = pathComponents
+        self.valueBytes = valueBytes
+    }
+
+    /// Serializes the predicate to a JSONB-compatible nested JSON byte array.
+    ///
+    /// `["order", "id"]` + value `"abc-123"` → `{"order": {"id": "abc-123"}}`
+    func toJSONBytes() throws -> [UInt8] {
+        // Wrap value bytes in `[…]` so JSONSerialization can parse any scalar
+        // JSON type (string, number, bool) not just objects/arrays.
+        let wrapped = [UInt8(ascii: "[")] + valueBytes + [UInt8(ascii: "]")]
+        guard
+            let parsed = try? JSONSerialization.jsonObject(with: Data(wrapped)) as? [Any],
+            let valueAny = parsed.first
+        else {
+            throw EventPredicateError.invalidValue
+        }
+        let nested = Self.buildNested(pathComponents, value: valueAny)
+        let data = try JSONSerialization.data(withJSONObject: nested)
+        return Array(data)
+    }
+
+    private static func buildNested(_ path: [String], value: Any) -> [String: Any] {
+        guard !path.isEmpty else { return [:] }
+        if path.count == 1 { return [path[0]: value] }
+        return [path[0]: buildNested(Array(path.dropFirst()), value: value)]
+    }
+}
+
+/// Errors thrown during EventPredicate serialization.
+public enum EventPredicateError: Error {
+    case invalidValue
+}
+
+/// Creates a payload-equality predicate from a `KeyPath` and a concrete value.
+///
+/// The property path is extracted from Swift's KeyPath description string.
+/// Both flat (`\.approvalId`) and shallow-nested (`\.order.id`) paths work
+/// reliably in Swift 5.9+.
+///
+/// ```swift
+/// let approval = try await context.waitForEvent(
+///     "agent.approval.response",
+///     as: ApprovalPayload.self,
+///     matching: \.approvalId == input.approvalId
+/// )
+/// ```
+public func == <Root, Value: Codable & Sendable>(
+    lhs: KeyPath<Root, Value>,
+    rhs: Value
+) -> EventPredicate<Root> {
+    // String(describing: \Foo.bar.baz) → "\Foo.bar.baz" in Swift 5.9+
+    // Drop the first component ("\TypeName") to get the property path.
+    let raw = String(describing: lhs)
+    var parts = raw.components(separatedBy: ".")
+    if let first = parts.first, first.hasPrefix("\\") {
+        parts = Array(parts.dropFirst())
+    }
+    let components = parts.filter { !$0.isEmpty }
+    let bytes = (try? JSON.encode(rhs)).map { Array($0.readableBytesView) } ?? []
+    return EventPredicate(pathComponents: components, valueBytes: bytes)
 }
 
 // MARK: - WorkflowSignalDefinition

--- a/Sources/Strand/Workflow.swift
+++ b/Sources/Strand/Workflow.swift
@@ -248,26 +248,23 @@ public struct EventPredicate<Target>: Sendable {
 
     /// Serializes the predicate to a JSONB-compatible nested JSON byte array.
     ///
-    /// `["order", "id"]` + value `"abc-123"` → `{"order": {"id": "abc-123"}}`
+    /// `["order", "id"]` + value `"abc-123"` → `{"order":{"id":"abc-123"}}`
+    ///
+    /// Built from inside out using the already-encoded `valueBytes` — no
+    /// `JSONSerialization` round-trip needed, works with `FoundationEssentials`.
     func toJSONBytes() throws -> [UInt8] {
-        // Wrap value bytes in `[…]` so JSONSerialization can parse any scalar
-        // JSON type (string, number, bool) not just objects/arrays.
-        let wrapped = [UInt8(ascii: "[")] + valueBytes + [UInt8(ascii: "]")]
-        guard
-            let parsed = try? JSONSerialization.jsonObject(with: Data(wrapped)) as? [Any],
-            let valueAny = parsed.first
-        else {
-            throw EventPredicateError.invalidValue
+        guard !pathComponents.isEmpty else { throw EventPredicateError.invalidValue }
+        // JSON.encode(String) produces a quoted key, e.g. "order" → `"order"`.
+        // Wrap one level at a time from the innermost component outward.
+        var result = valueBytes
+        for component in pathComponents.reversed() {
+            guard let keyBuf = try? JSON.encode(component) else {
+                throw EventPredicateError.invalidValue
+            }
+            result = [UInt8(ascii: "{")] + Array(keyBuf.readableBytesView)
+                + [UInt8(ascii: ":")] + result + [UInt8(ascii: "}")]
         }
-        let nested = Self.buildNested(pathComponents, value: valueAny)
-        let data = try JSONSerialization.data(withJSONObject: nested)
-        return Array(data)
-    }
-
-    private static func buildNested(_ path: [String], value: Any) -> [String: Any] {
-        guard !path.isEmpty else { return [:] }
-        if path.count == 1 { return [path[0]: value] }
-        return [path[0]: buildNested(Array(path.dropFirst()), value: value)]
+        return result
     }
 }
 

--- a/Sources/Strand/WorkflowContext.swift
+++ b/Sources/Strand/WorkflowContext.swift
@@ -34,6 +34,20 @@ struct SleepCompletedSentinel: Codable {
     }
 }
 
+/// Checkpoint sentinel stored when an activity terminates with FAILED or CANCELLED.
+/// On fresh-path replay, detecting this sentinel in the checkpoint cache causes
+/// `runActivity` to re-throw the stored error without emitting `.activityCompleted`,
+/// ensuring the `ACTIVITY_FAILED` history event is written exactly once regardless of
+/// how many re-activations follow.
+struct ActivityFailedSentinel: Codable {
+    let failed: Bool
+    init() { self.failed = true }
+    private enum CodingKeys: String, CodingKey { case failed = "$activityFailed" }
+    static func detect(in buffer: ByteBuffer) -> Bool {
+        (try? JSON.decode(ActivityFailedSentinel.self, from: buffer))?.failed == true
+    }
+}
+
 /// Checkpoint sentinel written when a `condition(timeout:)` call resolves (either
 /// predicate satisfied or deadline elapsed). Overrides the deadline checkpoint so
 /// replay can return the result immediately without re-evaluating the predicate.
@@ -384,12 +398,37 @@ public struct WorkflowContext<W: Workflow>: Sendable {
 
         // ── Fast path 1: checkpoint cache (result persisted in a prior activation) ──────
         if let cached = _impl.checkpointCache[seqNum] {
+            // An ActivityFailedSentinel means the activity failed or was cancelled.
+            // Re-throw the stored error without emitting any command — exactly-once guard
+            // that prevents ACTIVITY_FAILED from being written more than once on replay.
+            if ActivityFailedSentinel.detect(in: cached) {
+                if let nonSuccess = _impl.executor.preloadedNonCompletion(for: seqNum) {
+                    if let buf = nonSuccess.failureReason,
+                        let af = ActivityFailure.decode(from: buf),
+                        let typedErr = af.decode(A.Failure.self)
+                    {
+                        throw typedErr
+                    }
+                    let cause = nonSuccess.failureReason.flatMap { ActivityFailure.decode(from: $0) }
+                    let retryState: ActivityRetryState =
+                        nonSuccess.state == .cancelled ? .cancelled : .maximumAttemptsReached
+                    throw ActivityError(activityName: A.name, retryState: retryState, cause: cause)
+                }
+                // Fallback: failure reason not available (edge case in crash recovery).
+                throw ActivityError(activityName: A.name, retryState: .maximumAttemptsReached, cause: nil)
+            }
             return try JSON.decode(A.Output.self, from: cached)
         }
 
         // ── Fast path 2a: activity terminated with FAILED or CANCELLED in a prior activation ───
         if let nonSuccess = _impl.executor.preloadedNonCompletion(for: seqNum) {
             _impl.lastCallSite = (fileID, line)
+            // Write a failure sentinel so the next fresh-path replay hits fast path 1 and
+            // does not re-emit .activityCompleted — exactly-once ACTIVITY_FAILED history write.
+            if let sentinel = try? JSON.encode(ActivityFailedSentinel()) {
+                _impl.executor.emit(.writeCheckpoint(seqNum: seqNum, name: A.name, value: sentinel))
+            }
+            _impl.executor.emit(.activityCompleted(name: A.name, seqNum: seqNum, failed: true))
             // Attempt to decode the original typed Failure value from the stored payload.
             // Falls back to ActivityError when Failure = Never or payload is absent.
             if let buf = nonSuccess.failureReason,
@@ -412,6 +451,7 @@ public struct WorkflowContext<W: Workflow>: Sendable {
             _impl.checkpointCache[seqNum] = preloaded
             // Emit a checkpoint write so the worker persists this result after drain.
             _impl.executor.emit(.writeCheckpoint(seqNum: seqNum, name: A.name, value: preloaded))
+            _impl.executor.emit(.activityCompleted(name: A.name, seqNum: seqNum, failed: false))
             return try JSON.decode(A.Output.self, from: preloaded)
         }
 
@@ -437,9 +477,21 @@ public struct WorkflowContext<W: Workflow>: Sendable {
                 (cont: CheckedContinuation<ByteBuffer, Error>) in
                 _impl.executor.suspendActivity(seqNum: seqNum, continuation: cont)
             }
+            // Continuation resumed — activity completed in this activation.
+            // Write a checkpoint so fresh-path replays use fast path 1 without needing
+            // task_completions. Emit .activityCompleted for the ACTIVITY_COMPLETED history event.
+            _impl.checkpointCache[seqNum] = resultBuffer
+            _impl.executor.emit(.writeCheckpoint(seqNum: seqNum, name: A.name, value: resultBuffer))
+            _impl.executor.emit(.activityCompleted(name: A.name, seqNum: seqNum, failed: false))
             return try JSON.decode(A.Output.self, from: resultBuffer)
         } catch let signal as _ActivityFailureSignal {
-            // Re-activation delivered a typed failure signal — try to decode A.Failure.
+            // Re-activation delivered a typed failure signal.
+            // Write a failure sentinel so fresh-path replays hit fast path 1 (exactly-once guard).
+            if let sentinel = try? JSON.encode(ActivityFailedSentinel()) {
+                _impl.executor.emit(.writeCheckpoint(seqNum: seqNum, name: A.name, value: sentinel))
+            }
+            _impl.executor.emit(.activityCompleted(name: A.name, seqNum: seqNum, failed: true))
+            // Try to decode A.Failure from the stored payload.
             if let buf = signal.failureReason,
                 let af = ActivityFailure.decode(from: buf),
                 let typedErr = af.decode(A.Failure.self)
@@ -636,20 +688,80 @@ public struct WorkflowContext<W: Workflow>: Sendable {
     /// Suspends the workflow until an event named `name` is emitted, then returns its payload.
     ///
     /// On replay, the payload is returned instantly from the checkpoint cache.
-    /// If `timeout` is set and elapses before the event arrives, throws `StrandError.timeout`.
+    ///
+    /// ## Filtering by payload content
+    ///
+    /// Supply `matching:` to only wake on events whose payload contains specific fields.
+    /// Filtering happens **before** any workflow is resumed (Postgres evaluates
+    /// `incoming_payload @> predicate` at emission time via a GIN index). Non-matching
+    /// emissions leave the wait registered for the next event.
+    ///
+    /// ```swift
+    /// // Wake only when an event arrives with the right approvalId:
+    /// let approval = try await context.waitForEvent(
+    ///     "agent.approval.response",
+    ///     as: ApprovalPayload.self,
+    ///     matching: \.approvalId == input.approvalId
+    /// )
+    ///
+    /// // With a timeout — returns nil when the deadline elapses:
+    /// if let approval = try await context.waitForEvent(
+    ///     "order.approved",
+    ///     as: ApprovalPayload.self,
+    ///     timeout: .seconds(300)
+    /// ) {
+    ///     // received
+    /// } else {
+    ///     // timed out — normal control flow, not an error
+    /// }
+    /// ```
     ///
     /// - Parameters:
-    ///   - name: The event name to wait for (matched against `emitEvent` calls or
-    ///     `client.emitEvent` calls from outside the workflow).
+    ///   - name: The event name to wait for.
     ///   - type: Expected payload type. Must match what the emitter encodes.
-    ///   - timeout: Optional maximum wait duration. `nil` = wait forever.
+    ///   - matching: Optional equality predicate on the payload. `nil` = match any payload.
     public func waitForEvent<T: Codable & Sendable>(
         _ name: String,
         as type: T.Type,
-        timeout: Duration? = nil,
+        matching predicate: EventPredicate<T>? = nil,
         fileID: String = #fileID,
         line: Int = #line
     ) async throws -> T {
+        // No timeout — nil is structurally impossible; force-unwrap is safe.
+        try await _waitForEvent(name, as: type, matching: predicate, timeout: nil, fileID: fileID, line: line)!
+    }
+
+    /// Suspends the workflow until an event named `name` is emitted, or until
+    /// `timeout` elapses — whichever comes first.
+    ///
+    /// Returns the decoded payload when the event arrives, or `nil` when the
+    /// deadline elapses. A timeout is normal control flow, not an error.
+    ///
+    /// - Parameters:
+    ///   - name: The event name to wait for.
+    ///   - type: Expected payload type. Must match what the emitter encodes.
+    ///   - matching: Optional equality predicate on the payload. `nil` = match any payload.
+    ///   - timeout: Maximum duration to wait. When elapsed, returns `nil`.
+    public func waitForEvent<T: Codable & Sendable>(
+        _ name: String,
+        as type: T.Type,
+        matching predicate: EventPredicate<T>? = nil,
+        timeout: Duration,
+        fileID: String = #fileID,
+        line: Int = #line
+    ) async throws -> T? {
+        try await _waitForEvent(name, as: type, matching: predicate, timeout: timeout, fileID: fileID, line: line)
+    }
+
+    // Shared implementation — public overloads above provide the right return type.
+    private func _waitForEvent<T: Codable & Sendable>(
+        _ name: String,
+        as type: T.Type,
+        matching predicate: EventPredicate<T>?,
+        timeout: Duration?,
+        fileID: String,
+        line: Int
+    ) async throws -> T? {
         _impl.lastCallSite = (fileID, line)
         let seqNum = _impl.nextSeqNum()
 
@@ -658,7 +770,7 @@ public struct WorkflowContext<W: Workflow>: Sendable {
         // Checkpoint cache — either the payload or a timeout sentinel from a prior activation.
         if let cached = _impl.checkpointCache[seqNum] {
             if TimeoutSentinel.detect(in: cached) {
-                throw EventWaitTimeoutError(eventName: name)
+                return nil
             }
             return try JSON.decode(T.self, from: cached)
         }
@@ -676,18 +788,22 @@ public struct WorkflowContext<W: Workflow>: Sendable {
                 // Woken by timeout — applyScheduleCommands writes the sentinel checkpoint
                 // and EVENT_WAIT_TIMED_OUT history row atomically via writeEventWaitTimedOut.
                 _impl.executor.emit(.eventWaitTimedOut(eventName: name, seqNum: seqNum))
-                throw EventWaitTimeoutError(eventName: name)
+                return nil
             }
         }
 
-        // ── Slow path: event not yet received — emit command and suspend ─────────────────
+        // ── Slow path: event not yet received — emit command and suspend ──────────
+        let predicateBuf: ByteBuffer? = try predicate.flatMap { p in
+            ByteBuffer(bytes: try p.toJSONBytes())
+        }
         let timeoutAt: Date? = timeout.map { Date.now.addingDuration($0) }
 
         _impl.executor.emit(
             .awaitEvent(
-                eventName: name,  // raw name — no prefix
+                eventName: name,
                 seqNum: seqNum,
-                timeoutAt: timeoutAt
+                timeoutAt: timeoutAt,
+                predicate: predicateBuf   // nil → DB stores '{}', matches any payload
             )
         )
 
@@ -703,7 +819,7 @@ public struct WorkflowContext<W: Workflow>: Sendable {
         } catch let err as StrandError {
             if case .timeout = err {
                 _impl.executor.emit(.eventWaitTimedOut(eventName: name, seqNum: seqNum))
-                throw EventWaitTimeoutError(eventName: name)
+                return nil
             }
             throw err
         }
@@ -711,15 +827,11 @@ public struct WorkflowContext<W: Workflow>: Sendable {
         // Write a checkpoint and record EVENT_RECEIVED so that:
         // (a) crash-recovery fresh activations fast-path through this seqNum, and
         // (b) the trace view shows a complete WAIT span duration.
-        // This mirrors what the re-activation fast-path does when wakeEvent == name;
-        // the slow path (cached-Task continuation resume) must do the same so both
-        // paths leave identical marks in strand.checkpoints and workflow_history.
         _impl.checkpointCache[seqNum] = resultBuffer
         _impl.executor.emit(
             .writeCheckpoint(seqNum: seqNum, name: "waitForEvent:\(name)", value: resultBuffer)
         )
         _impl.executor.emit(.eventReceived(eventName: name))
-
         return try JSON.decode(T.self, from: resultBuffer)
     }
 
@@ -731,31 +843,37 @@ public struct WorkflowContext<W: Workflow>: Sendable {
     /// the queue, this call is a no-op.
     ///
     /// - Parameters:
-    /// Typed `WorkflowEvent` overload — the compiler enforces that the event
-    /// name and payload type match between emitter and waiter.
+    /// Typed `WorkflowEvent` overload.
+    ///
+    /// Waits for an event named `E.name` and optionally filters by payload content.
+    /// Use `matching:` to ensure only events with specific field values wake this
+    /// workflow instance — filtering happens before any workflow is resumed.
     ///
     /// ```swift
-    /// try await context.waitForEvent(OrderShippedEvent.self)
+    /// // Broadcast — any emission of this event type wakes the workflow:
+    /// let signal = try await context.waitForEvent(SystemShutdownEvent.self)
+    ///
+    /// // Instance-scoped via predicate — only matching payloads wake this workflow:
+    /// let approval = try await context.waitForEvent(
+    ///     OrderApprovedEvent.self,
+    ///     matching: \.orderId == input.orderId
+    /// )
     /// ```
+    /// Typed overload — no timeout. Waits forever until the event arrives.
     public func waitForEvent<E: WorkflowEvent>(
         _ eventType: E.Type,
-        timeout: Duration? = nil
+        matching predicate: EventPredicate<E.Payload>? = nil
     ) async throws -> E.Payload {
-        try await waitForEvent(E.name, as: E.Payload.self, timeout: timeout)
+        try await waitForEvent(E.name, as: E.Payload.self, matching: predicate)
     }
 
-    /// Typed `WorkflowEvent` overload for emitting — derives the event name from
-    /// the event type so the compiler catches mismatches at the call site.
-    ///
-    /// ```swift
-    /// try await context.emitEvent(OrderShippedEvent.self,
-    ///     payload: TrackingInfo(number: "1Z999"))
-    /// ```
-    public func emitEvent<E: WorkflowEvent>(
+    /// Typed overload — with timeout. Returns `nil` when the deadline elapses.
+    public func waitForEvent<E: WorkflowEvent>(
         _ eventType: E.Type,
-        payload: E.Payload
-    ) throws {
-        try emitEvent(E.name, payload: payload)
+        matching predicate: EventPredicate<E.Payload>? = nil,
+        timeout: Duration
+    ) async throws -> E.Payload? {
+        try await waitForEvent(E.name, as: E.Payload.self, matching: predicate, timeout: timeout)
     }
 
     /// Emits a named event on this workflow's queue.

--- a/Sources/StrandServer/Models.swift
+++ b/Sources/StrandServer/Models.swift
@@ -201,7 +201,18 @@ struct EventResponse: Codable, Sendable {
     init(from row: EventRow) {
         id = row.id.uuidString.lowercased()
         name = row.name
-        payload = row.payloadBuffer.map { String(buffer: $0) }
+        // Strip the JSONB binary wire-format version byte (0x01) if present.
+        // PostgreSQL prepends this byte in binary protocol mode; reading with
+        // RawJSONB (text format) prevents it entirely, but we strip here too
+        // as a server-layer guarantee — callers never see the prefix.
+        payload = row.payloadBuffer.map { buf in
+            var b = buf
+            if b.readableBytes > 0,
+               b.getBytes(at: b.readerIndex, length: 1) == [0x01] {
+                b.moveReaderIndex(forwardBy: 1)
+            }
+            return String(buffer: b)
+        }
         createdAt = row.createdAt
         queue = row.queue
         triggeredTasks = row.triggeredTasks.map {

--- a/Tests/StrandTests/IntegrationTests.swift
+++ b/Tests/StrandTests/IntegrationTests.swift
@@ -137,13 +137,13 @@ private struct TimeoutEventWorkflow: Workflow {
         context: WorkflowContext<Self>,
         input: TimeoutEventInput
     ) async throws -> String {
-        do {
-            return try await context.waitForEvent(
-                input.eventName,
-                as: String.self,
-                timeout: .seconds(1)
-            )
-        } catch is EventWaitTimeoutError {
+        if let result = try await context.waitForEvent(
+            input.eventName,
+            as: String.self,
+            timeout: .seconds(1)
+        ) {
+            return result
+        } else {
             return "timed-out"
         }
     }

--- a/Tests/StrandTests/IntegrationTests.swift
+++ b/Tests/StrandTests/IntegrationTests.swift
@@ -149,7 +149,43 @@ private struct TimeoutEventWorkflow: Workflow {
     }
 }
 
-// ── 7. Signalled ────────────────────────────────────────────────────────────
+// ── 7. Nested-predicate event ──────────────────────────────────────────────
+// Exercises waitForEvent(matching:) with a 3-level keypath predicate.
+// Two concurrent workflows share the same event name but different city values;
+// each must only wake when the emitted payload matches its own predicate.
+// Used by: nestedPredicateRouting test.
+
+private struct CityPayload: Codable, Sendable, Equatable {
+    struct Order: Codable, Sendable, Equatable {
+        struct Address: Codable, Sendable, Equatable {
+            let city: String
+        }
+        let address: Address
+    }
+    let order: Order
+}
+
+private struct CityEvent: WorkflowEvent {
+    typealias Payload = CityPayload
+}
+
+private struct NestedPredicateWorkflow: Workflow {
+    typealias Input = String   // city this instance is waiting for
+    typealias Output = String  // city that actually arrived in the payload
+
+    mutating func run(
+        context: WorkflowContext<Self>,
+        input: String
+    ) async throws -> String {
+        let payload = try await context.waitForEvent(
+            CityEvent.self,
+            matching: \.order.address.city == input
+        )
+        return payload.order.address.city
+    }
+}
+
+// ── 8. Signalled ────────────────────────────────────────────────────────────
 // Stores signal receipt as optional workflow state so it survives between
 // activations. The `Bool?` (rather than `Bool`) decodes cleanly from the
 // initial empty-object `{}` that the worker synthesises on the first
@@ -452,6 +488,57 @@ struct EventTests {
 
             let result = try await handle.result(timeout: .seconds(10))
             #expect(result == EventPayload(msg: "from-test"))
+        }
+    }
+
+    @Test("waitForEvent matching: routes by nested payload predicate — 3-level keypath")
+    func nestedPredicateRouting() async throws {
+        try await withTestEnvironment { client in
+            let workerTask = startWorker(
+                postgres: client.postgres,
+                queueName: client.queueName,
+                logger: client.logger,
+                workflows: [NestedPredicateWorkflow.self]
+            )
+            defer { workerTask.cancel() }
+
+            // Two concurrent instances each waiting for a different city.
+            let handleNYC = try await client.startWorkflow(
+                NestedPredicateWorkflow.self, options: .init(), input: "NYC"
+            )
+            let handleLDN = try await client.startWorkflow(
+                NestedPredicateWorkflow.self, options: .init(), input: "London"
+            )
+
+            // Wait until both have registered their event_wait (state = WAITING).
+            let deadline = ContinuousClock.now + .seconds(5)
+            while ContinuousClock.now < deadline {
+                let s1 = try await handleNYC.snapshot()
+                let s2 = try await handleLDN.snapshot()
+                if s1?.state == .waiting && s2?.state == .waiting { break }
+                try await Task.sleep(for: .milliseconds(50))
+            }
+
+            // Emit London — the NYC workflow must NOT wake (predicate mismatch).
+            try await client.emit(
+                CityEvent.self,
+                payload: .init(order: .init(address: .init(city: "London")))
+            )
+            try await Task.sleep(for: .milliseconds(400))
+
+            let snapNYC = try await handleNYC.snapshot()
+            #expect(snapNYC?.state == .waiting, "NYC workflow should not wake on London event")
+
+            // Emit NYC — only the NYC workflow should wake.
+            try await client.emit(
+                CityEvent.self,
+                payload: .init(order: .init(address: .init(city: "NYC")))
+            )
+
+            let resultLDN = try await handleLDN.result(timeout: .seconds(10))
+            let resultNYC = try await handleNYC.result(timeout: .seconds(10))
+            #expect(resultLDN == "London")
+            #expect(resultNYC == "NYC")
         }
     }
 

--- a/loom/src/components/JsonView.tsx
+++ b/loom/src/components/JsonView.tsx
@@ -83,7 +83,8 @@ export function JsonView({ value, label, className }: Props) {
 
     function handleCopy() {
         if (!value) return;
-        navigator.clipboard.writeText(value).then(() => {
+        const toCopy = value.charCodeAt(0) === 1 ? value.slice(1) : value;
+        navigator.clipboard.writeText(toCopy).then(() => {
             setCopied(true);
             setTimeout(() => setCopied(false), 2000);
         });
@@ -97,9 +98,11 @@ export function JsonView({ value, label, className }: Props) {
         );
     }
 
-    let pretty = value;
+    // Strip JSONB binary wire-format version byte (0x01) defensively.
+    const sanitized = value.charCodeAt(0) === 1 ? value.slice(1) : value;
+    let pretty = sanitized;
     try {
-        pretty = JSON.stringify(JSON.parse(value), null, 2);
+        pretty = JSON.stringify(JSON.parse(sanitized), null, 2);
     } catch {
         /* not JSON — display as-is */
     }

--- a/loom/src/routes/events.tsx
+++ b/loom/src/routes/events.tsx
@@ -22,11 +22,15 @@ import type { StrandEvent } from "@/api/types";
 /** Returns the first ~60 visible characters of a JSON string, without newlines. */
 function payloadPreview(raw: string | null): string | null {
     if (!raw) return null;
+    // Strip JSONB binary wire-format version byte (0x01) defensively.
+    // The backend now uses RawJSONB (text format) so this byte should never
+    // appear, but guard against version skew or cached responses.
+    const clean = raw.charCodeAt(0) === 1 ? raw.slice(1) : raw;
     try {
-        const pretty = JSON.stringify(JSON.parse(raw));
+        const pretty = JSON.stringify(JSON.parse(clean));
         return pretty.length > 72 ? pretty.slice(0, 69) + "…" : pretty;
     } catch {
-        return raw.length > 72 ? raw.slice(0, 69) + "…" : raw;
+        return clean.length > 72 ? clean.slice(0, 69) + "…" : clean;
     }
 }
 

--- a/loom/src/routes/tasks_/$taskId.tsx
+++ b/loom/src/routes/tasks_/$taskId.tsx
@@ -190,6 +190,8 @@ function taskDurationMs(
 
 function eventColour(type: string): string {
     if (type.startsWith("WORKFLOW_")) return "bg-blue-400";
+    if (type === "ACTIVITY_COMPLETED") return "bg-green-400";
+    if (type === "ACTIVITY_FAILED") return "bg-red-400";
     if (type.startsWith("ACTIVITY_")) return "bg-yellow-400";
     if (type.startsWith("SIGNAL_")) return "bg-purple-400";
     if (type.startsWith("CHILD_")) return "bg-cyan-400";

--- a/strand.sql
+++ b/strand.sql
@@ -58,6 +58,132 @@ END;
 $$;
 
 -- ─────────────────────────────────────────────────────────────────────────────
+-- Monthly partition helpers
+--
+-- strand.runs and strand.workflow_history are partitioned by created_at
+-- (PARTITION BY RANGE). StrandPruner manages the lifecycle:
+--   • create_range_partition — idempotent; called at startup and every 12 h.
+--   • list_partitions_before — finds old partitions to detach and drop.
+--
+-- Naming convention: strand.<table>_<YYYYMM>  e.g. strand.runs_202601
+--
+-- IMPORTANT (Hatchet production lesson): Postgres autovacuum does NOT run
+-- ANALYZE on partitioned parent tables — only on their child partitions. Without
+-- periodic manual ANALYZE on strand.runs and strand.workflow_history the query
+-- planner uses wrong row estimates (up to 6 000 000× off in production), causing
+-- sequential scans on the claim path. StrandPruner.analyzeParentTables() calls
+-- ANALYZE on both parents every 12 h.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- create_range_partition(base_table, month_start, fill_factor)
+-- Creates a child table strand.<base_table>_<YYYYMM> covering one calendar month.
+-- Returns TRUE if the partition was newly created, FALSE if it already existed.
+CREATE OR REPLACE FUNCTION strand.create_range_partition(
+    base_table  TEXT,
+    month_start DATE,
+    fill_factor INTEGER DEFAULT 80
+) RETURNS BOOLEAN
+LANGUAGE plpgsql AS $$
+DECLARE
+    suffix  TEXT := to_char(date_trunc('month', month_start), 'YYYYMM');
+    p_name  TEXT := base_table || '_' || suffix;   -- e.g. 'runs_202601'
+    p_from  TEXT := to_char(date_trunc('month', month_start), 'YYYY-MM-DD');
+    p_to    TEXT := to_char(date_trunc('month', month_start)
+                            + INTERVAL '1 month', 'YYYY-MM-DD');
+BEGIN
+    -- Idempotent: exit immediately if the partition already exists.
+    IF EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'strand' AND c.relname = p_name
+    ) THEN
+        RETURN FALSE;
+    END IF;
+
+    -- Create the child table attached to the parent's partition set.
+    EXECUTE format(
+        'CREATE TABLE strand.%I PARTITION OF strand.%I
+         FOR VALUES FROM (%L::TIMESTAMPTZ) TO (%L::TIMESTAMPTZ)',
+        p_name, base_table, p_from, p_to
+    );
+
+    -- Mirror the storage/vacuum settings of the parent table.
+    EXECUTE format(
+        $fmt$ALTER TABLE strand.%I SET (
+            fillfactor                      = %s,
+            autovacuum_vacuum_scale_factor  = 0.05,
+            autovacuum_vacuum_threshold     = 50,
+            autovacuum_analyze_scale_factor = 0.02,
+            autovacuum_analyze_threshold    = 50,
+            autovacuum_vacuum_cost_delay    = 2,
+            autovacuum_vacuum_cost_limit    = 2000
+        )$fmt$,
+        p_name, fill_factor
+    );
+
+    RETURN TRUE;
+END;
+$$;
+
+-- drop_partition(base_table, partition_name)
+-- Drops a partition that has already been detached (or drops it with plain
+-- DETACH when CONCURRENTLY is not required).
+-- Using format('%I') guarantees safe identifier quoting on the SQL side so
+-- Swift callers do not need to build raw DDL strings.
+--
+-- NOTE: DETACH PARTITION CONCURRENTLY cannot run inside any PL/pgSQL block
+-- (Postgres bans it in transaction contexts). Swift therefore calls DETACH via
+-- a raw connection using PostgresQuery(unsafeSQL:) where the identifier values
+-- are sourced exclusively from strand.list_partitions_before — a pg_inherits
+-- system-catalog query, not from user input — so the raw-string approach is safe.
+CREATE OR REPLACE FUNCTION strand.drop_partition(
+    base_table     TEXT,
+    partition_name TEXT
+) RETURNS VOID
+LANGUAGE plpgsql AS $$
+BEGIN
+    -- Plain DETACH (no CONCURRENTLY) — safe inside a function / transaction.
+    -- Use this in dev environments or when lock contention is not a concern.
+    -- Production callers should DETACH CONCURRENTLY first (from app code),
+    -- then call this function to DROP the now-detached table.
+    EXECUTE format('DROP TABLE IF EXISTS strand.%I', partition_name);
+END;
+$$;
+
+-- list_partitions_before(base_table, cutoff_date)
+-- Returns the names (without schema) of partitions for base_table whose
+-- calendar month is strictly before cutoff_date.
+-- Uses the naming convention <table>_<YYYYMM> inside the strand schema.
+CREATE OR REPLACE FUNCTION strand.list_partitions_before(
+    base_table  TEXT,
+    cutoff_date DATE
+) RETURNS TABLE (partition_name TEXT)
+LANGUAGE plpgsql AS $$
+DECLARE
+    parent_oid OID;
+BEGIN
+    SELECT c.oid INTO parent_oid
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'strand' AND c.relname = base_table;
+
+    IF parent_oid IS NULL THEN RETURN; END IF;
+
+    RETURN QUERY
+    SELECT c.relname::TEXT
+    FROM   pg_inherits i
+    JOIN   pg_class c     ON c.oid = i.inhrelid
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  i.inhparent = parent_oid
+      AND  n.nspname   = 'strand'
+      -- Match naming convention: <base_table>_<YYYYMM>
+      AND  c.relname ~ ('^' || base_table || '_\d{6}$')
+      -- The YYYYMM suffix encodes the month; compare to cutoff
+      AND  to_date(substring(c.relname FROM '\d{6}$'), 'YYYYMM') < cutoff_date;
+END;
+$$;
+
+-- ─────────────────────────────────────────────────────────────────────────────
 -- Namespaces — top-level isolation boundary.
 --
 -- Provides hard data isolation between tenants. Every execution table carries
@@ -123,6 +249,9 @@ CREATE TABLE IF NOT EXISTS strand.tasks (
     --   'WORKFLOW'  — top-level orchestrator, enqueued directly by the client
     --   'ACTIVITY'  — leaf unit of work, spawned by a workflow via runActivity
     parent_task_id  UUID,  -- NULL for root; set when spawned by runActivity / runChildWorkflow
+    -- First task in a continueAsNew chain. NULL for the chain's first task and for all
+    -- child tasks. Set only on root workflows spawned by context.continueAsNew().
+    first_task_id   UUID,
 
     -- Lifecycle
     state        TEXT        NOT NULL DEFAULT 'PENDING',
@@ -148,7 +277,8 @@ CREATE TABLE IF NOT EXISTS strand.tasks (
     CONSTRAINT strand_tasks_idempotency_key UNIQUE (namespace_id, queue, idempotency_key),
     CONSTRAINT strand_tasks_kind            CHECK (kind IN ('WORKFLOW', 'ACTIVITY')),
     CONSTRAINT strand_tasks_state           CHECK (state IN (
-        'PENDING', 'RUNNING', 'SLEEPING', 'WAITING', 'COMPLETED', 'FAILED', 'CANCELLED'
+        'PENDING', 'RUNNING', 'SLEEPING', 'WAITING', 'COMPLETED', 'FAILED', 'CANCELLED',
+        'CONTINUED_AS_NEW'
     ))
 );
 
@@ -163,7 +293,7 @@ CREATE INDEX IF NOT EXISTS strand_tasks_ns_kind_idx
 -- Most-recent-first task list (new API sort order)
 CREATE INDEX IF NOT EXISTS strand_tasks_ns_id_desc_idx
     ON strand.tasks (namespace_id, queue, id DESC)
-    WHERE state NOT IN ('COMPLETED', 'FAILED', 'CANCELLED');
+    WHERE state NOT IN ('COMPLETED', 'FAILED', 'CANCELLED', 'CONTINUED_AS_NEW');
 
 -- Parent-child lineage: "show all activities spawned by this workflow"
 CREATE INDEX IF NOT EXISTS strand_tasks_parent_idx
@@ -187,6 +317,14 @@ CREATE INDEX IF NOT EXISTS strand_tasks_deadline_idx
 CREATE INDEX IF NOT EXISTS strand_tasks_completed_at_idx
     ON strand.tasks (namespace_id, queue, completed_at DESC)
     WHERE state = 'COMPLETED' AND completed_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS strand_tasks_continued_as_new_idx
+    ON strand.tasks (namespace_id, queue, completed_at DESC)
+    WHERE state = 'CONTINUED_AS_NEW' AND completed_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS strand_tasks_first_task_idx
+    ON strand.tasks (first_task_id)
+    WHERE first_task_id IS NOT NULL;
 
 CREATE INDEX IF NOT EXISTS strand_tasks_cancelled_at_idx
     ON strand.tasks (namespace_id, queue, cancelled_at DESC)
@@ -221,10 +359,21 @@ ALTER TABLE strand.tasks SET (
 -- High churn: rows transition through states frequently.
 -- ─────────────────────────────────────────────────────────────────────────────
 
+-- strand.runs is partitioned RANGE by created_at (monthly buckets).
+--
+-- The PRIMARY KEY is (id, created_at) — Postgres requires the partition key
+-- to be part of every unique constraint on a partitioned table.
+-- A separate non-unique index on id alone (strand_runs_id_idx) keeps
+-- point-lookups fast when only the UUID is known (completeRun, failRun, etc.).
+--
+-- FK note: strand.event_waits formerly had run_id REFERENCES strand.runs(id)
+-- ON DELETE CASCADE. That FK cannot reference a non-PK column on a partitioned
+-- table, so it is declared as a plain column (no FK). Application code and the
+-- cascade-drop via partition DROP TABLE maintain the invariant in practice.
 CREATE TABLE IF NOT EXISTS strand.runs (
     id           UUID    NOT NULL,
     namespace_id TEXT    NOT NULL DEFAULT 'default' REFERENCES strand.namespaces(id),
-    task_id      UUID    NOT NULL REFERENCES strand.tasks(id) ON DELETE CASCADE,
+    task_id      UUID    NOT NULL,   -- logical FK to strand.tasks(id); no DB constraint (see above)
     queue        TEXT    NOT NULL,   -- denormalised for fast claim query
     attempt      INTEGER NOT NULL,
 
@@ -260,12 +409,19 @@ CREATE TABLE IF NOT EXISTS strand.runs (
     finished_at TIMESTAMPTZ,
     created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
-    CONSTRAINT strand_runs_pkey  PRIMARY KEY (id),
+    -- Composite PK includes created_at (the partition key).
+    CONSTRAINT strand_runs_pkey  PRIMARY KEY (id, created_at),
     CONSTRAINT strand_runs_kind  CHECK (kind IN ('WORKFLOW', 'ACTIVITY')),
     CONSTRAINT strand_runs_state CHECK (state IN (
         'PENDING', 'RUNNING', 'SLEEPING', 'WAITING', 'COMPLETED', 'FAILED', 'CANCELLED'
     ))
-);
+) PARTITION BY RANGE (created_at);
+
+-- Fast UUID point-lookup when created_at is not known.
+-- Queries like completeRun / failRun use WHERE id = $runID; Postgres scans
+-- the active partition indexes (typically 2-3 monthly partitions).
+CREATE INDEX IF NOT EXISTS strand_runs_id_idx
+    ON strand.runs (id);
 
 -- strand.runs is the highest-churn table: attempt, state, lease_expires_at,
 -- started_at and finished_at all change on every execution. fillfactor = 80
@@ -308,7 +464,7 @@ CREATE INDEX IF NOT EXISTS strand_runs_lease_idx
 -- ─────────────────────────────────────────────────────────────────────────────
 
 CREATE TABLE IF NOT EXISTS strand.checkpoints (
-    namespace_id TEXT        NOT NULL DEFAULT 'default',
+    namespace_id TEXT        NOT NULL DEFAULT 'default' REFERENCES strand.namespaces(id) ON DELETE CASCADE,
     task_id      UUID        NOT NULL REFERENCES strand.tasks(id) ON DELETE CASCADE,
     seq_num      INTEGER     NOT NULL,                  -- global activation counter;
     name         TEXT,                                  -- optional human-readable label for debugging only
@@ -330,10 +486,14 @@ CREATE INDEX IF NOT EXISTS strand_checkpoints_ns_idx
 -- ─────────────────────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS strand.events (
     id           UUID        NOT NULL,  -- UUIDv7, always generated by Swift via UUID.v7()
-    namespace_id TEXT        NOT NULL DEFAULT 'default',
+    namespace_id TEXT        NOT NULL DEFAULT 'default' REFERENCES strand.namespaces(id) ON DELETE CASCADE,
     queue        TEXT        NOT NULL,
     name         TEXT        NOT NULL,
-    payload      BYTEA,
+    -- JSONB: the only table in Strand that stores payload as JSONB rather than BYTEA.
+    -- Justified exception: strand.events is content-routable (waitForEvent predicates
+    -- use `payload @> predicate` at emission time), making JSONB the honest type.
+    -- All other payload columns remain BYTEA per the project convention.
+    payload      JSONB,
     created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT strand_events_pkey PRIMARY KEY (id)
 );
@@ -342,13 +502,19 @@ CREATE TABLE IF NOT EXISTS strand.events (
 -- and the events page list (ordered newest first per name).
 CREATE INDEX IF NOT EXISTS strand_events_name_idx
     ON strand.events (namespace_id, queue, name, created_at DESC);
+-- GIN index enabling efficient `payload @> predicate` containment checks at
+-- event emission time. Sparse: only non-trivial payloads (not empty object)
+-- are indexed — most events have real content.
+CREATE INDEX IF NOT EXISTS strand_events_payload_gin
+    ON strand.events USING GIN (payload)
+    WHERE payload IS NOT NULL AND payload <> '{}';
 
 -- One row per (event emission → task woken) pair.
 -- emission_id links back to the specific strand.events row that caused this wake.
 -- Pruned automatically via ON DELETE CASCADE when the task is deleted by StrandPruner.
 CREATE TABLE IF NOT EXISTS strand.event_triggers (
     id           UUID        NOT NULL,  -- UUIDv7, always generated by Swift via UUID.v7()
-    namespace_id TEXT        NOT NULL DEFAULT 'default',
+    namespace_id TEXT        NOT NULL DEFAULT 'default' REFERENCES strand.namespaces(id) ON DELETE CASCADE,
     queue        TEXT        NOT NULL,
     event_name   TEXT        NOT NULL,
     emission_id  UUID        REFERENCES strand.events(id) ON DELETE SET NULL,
@@ -404,9 +570,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS strand_event_triggers_emission_task_idx
 -- ─────────────────────────────────────────────────────────────────────────────
 
 CREATE TABLE IF NOT EXISTS strand.event_waits (
-    namespace_id  TEXT        NOT NULL DEFAULT 'default',
+    namespace_id  TEXT        NOT NULL DEFAULT 'default' REFERENCES strand.namespaces(id),
     task_id       UUID        NOT NULL REFERENCES strand.tasks(id) ON DELETE CASCADE,
-    run_id        UUID        NOT NULL REFERENCES strand.runs(id) ON DELETE CASCADE,
+    run_id        UUID        NOT NULL,   -- logical FK to strand.runs(id); no DB constraint (partitioned table)
     queue         TEXT        NOT NULL,
     seq_num       INTEGER     NOT NULL,
     -- Named-event waits (context.waitForEvent): event_name is non-null, child_task_id is null.
@@ -415,6 +581,12 @@ CREATE TABLE IF NOT EXISTS strand.event_waits (
     event_name    TEXT,
     child_task_id UUID        REFERENCES strand.tasks(id) ON DELETE CASCADE,
     timeout_at    TIMESTAMPTZ,
+    -- Equality filter stored as JSONB. At emission, Postgres evaluates
+    -- `incoming_payload @> predicate` via GIN index — only matching waiters are woken.
+    -- '{}' (empty object) matches any payload and is the default for un-predicated waits
+    -- (auto-scoped typed events, string-based waitForEvent). A non-trivial predicate
+    -- like {"approvalId": "abc-123"} filters to matching payloads only.
+    predicate     JSONB NOT NULL DEFAULT '{}',
     created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT strand_event_waits_pkey PRIMARY KEY (run_id, seq_num)
 );
@@ -422,6 +594,13 @@ CREATE TABLE IF NOT EXISTS strand.event_waits (
 -- Wake-up lookup by named event (waitForEvent path).
 CREATE INDEX IF NOT EXISTS strand_event_waits_event_idx
     ON strand.event_waits (namespace_id, queue, event_name);
+
+-- GIN index on predicate for efficient @> containment lookups at emission time.
+-- Sparse: only non-trivial predicates ({} excluded) benefit from GIN. Rows with
+-- the default '{}' are matched unconditionally by exact event_name lookup.
+CREATE INDEX IF NOT EXISTS strand_event_waits_predicate_gin
+    ON strand.event_waits USING GIN (predicate)
+    WHERE predicate <> '{}';
 
 -- Wake-up lookup by child task ID (runActivity / runChildWorkflow completion path).
 CREATE INDEX IF NOT EXISTS strand_event_waits_child_task_idx
@@ -436,7 +615,7 @@ CREATE INDEX IF NOT EXISTS strand_event_waits_child_task_idx
 -- ─────────────────────────────────────────────────────────────────────────────
 
 CREATE TABLE IF NOT EXISTS strand.task_completions (
-    namespace_id TEXT        NOT NULL DEFAULT 'default',
+    namespace_id TEXT        NOT NULL DEFAULT 'default' REFERENCES strand.namespaces(id) ON DELETE CASCADE,
     task_id      UUID        NOT NULL REFERENCES strand.tasks(id) ON DELETE CASCADE,
     state        TEXT        NOT NULL,   -- 'COMPLETED' | 'FAILED' | 'CANCELLED'
     result       BYTEA,
@@ -456,7 +635,7 @@ CREATE INDEX IF NOT EXISTS strand_task_completions_ns_idx
 -- ─────────────────────────────────────────────────────────────────────────────
 
 CREATE TABLE IF NOT EXISTS strand.workflow_state (
-    namespace_id TEXT        NOT NULL DEFAULT 'default',
+    namespace_id TEXT        NOT NULL DEFAULT 'default' REFERENCES strand.namespaces(id) ON DELETE CASCADE,
     task_id      UUID        NOT NULL REFERENCES strand.tasks(id) ON DELETE CASCADE,
     state        BYTEA       NOT NULL,  -- JSON-encoded @Workflow struct
     state_seq    BIGINT      NOT NULL DEFAULT 0,  -- monotonic; updated each activation
@@ -475,7 +654,7 @@ CREATE TABLE IF NOT EXISTS strand.workflow_state (
 CREATE TABLE IF NOT EXISTS strand.workflow_signals (
     id           UUID        NOT NULL DEFAULT strand.gen_uuid_v7(),
     seq          BIGSERIAL   NOT NULL,   -- monotonic total order, unaffected by transaction commit ordering
-    namespace_id TEXT        NOT NULL DEFAULT 'default',
+    namespace_id TEXT        NOT NULL DEFAULT 'default' REFERENCES strand.namespaces(id) ON DELETE CASCADE,
     task_id      UUID        NOT NULL REFERENCES strand.tasks(id) ON DELETE CASCADE,
     signal_name  TEXT        NOT NULL,
     payload      BYTEA,
@@ -490,6 +669,32 @@ CREATE INDEX IF NOT EXISTS strand_workflow_signals_inbox_idx
     ON strand.workflow_signals (namespace_id, task_id, seq ASC);
 
 -- ─────────────────────────────────────────────────────────────────────────────
+-- Task logs — structured per-task log lines emitted by context.log(…).
+--
+-- Partitioned RANGE by created_at (monthly). No ON CONFLICT — log writes are
+-- fire-and-forget. No FK to strand.tasks — partition DROP TABLE handles cleanup
+-- automatically when StrandPruner drops expired months.
+--
+-- Powers the Loom "Logs" tab on the task detail page.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS strand.task_logs (
+    id           UUID        NOT NULL DEFAULT strand.gen_uuid_v7(),
+    namespace_id TEXT        NOT NULL DEFAULT 'default' REFERENCES strand.namespaces(id),
+    task_id      UUID        NOT NULL,   -- logical FK to strand.tasks(id); no DB constraint (partitioned)
+    run_id       UUID        NOT NULL,   -- which run/attempt produced this entry
+    level        TEXT        NOT NULL DEFAULT 'INFO',
+    message      TEXT        NOT NULL,
+    metadata     BYTEA,                  -- optional JSON key-value pairs
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT strand_task_logs_pkey  PRIMARY KEY (id, created_at),
+    CONSTRAINT strand_task_logs_level CHECK (level IN ('DEBUG', 'INFO', 'WARN', 'ERROR'))
+) PARTITION BY RANGE (created_at);
+
+-- Task-scoped log scan (Loom Logs tab, newest-first).
+CREATE INDEX IF NOT EXISTS strand_task_logs_task_idx
+    ON strand.task_logs (namespace_id, task_id, created_at DESC);
+
+-- ─────────────────────────────────────────────────────────────────────────────
 -- Workflow history — append-only event log per workflow execution.
 --
 -- Every significant decision (activity scheduled, activity completed, signal
@@ -497,8 +702,18 @@ CREATE INDEX IF NOT EXISTS strand_workflow_signals_inbox_idx
 -- Used by the UI timeline and future workflow-reset functionality.
 -- ─────────────────────────────────────────────────────────────────────────────
 
+-- strand.workflow_history is append-only and intentionally NOT partitioned.
+--
+-- Reason: batchAppendHistory uses ON CONFLICT (task_id, seq) DO NOTHING for
+-- idempotency. Postgres requires that the ON CONFLICT target be a unique
+-- constraint, and unique constraints on partitioned tables must include the
+-- partition key. Adding created_at to the PK would break the ON CONFLICT
+-- clause and allow duplicate (task_id, seq) rows in different partitions.
+-- The table is append-only (no UPDATEs), so bloat accumulation is much lower
+-- than strand.runs. Retention is handled by StrandPruner via DELETE cascaded
+-- from strand.tasks (ON DELETE CASCADE FK is preserved).
 CREATE TABLE IF NOT EXISTS strand.workflow_history (
-    namespace_id TEXT        NOT NULL DEFAULT 'default',
+    namespace_id TEXT        NOT NULL DEFAULT 'default' REFERENCES strand.namespaces(id) ON DELETE CASCADE,
     task_id      UUID        NOT NULL REFERENCES strand.tasks(id) ON DELETE CASCADE,
     seq          BIGINT      NOT NULL,  -- 1-based monotonic per workflow
     event_type   TEXT        NOT NULL,  -- 'WORKFLOW_STARTED' | 'ACTIVITY_SCHEDULED' |
@@ -514,7 +729,24 @@ CREATE TABLE IF NOT EXISTS strand.workflow_history (
 CREATE INDEX IF NOT EXISTS strand_workflow_history_ns_idx
     ON strand.workflow_history (namespace_id, task_id, seq ASC);
 
-
+-- Storage / autovacuum tuning for workflow_history.
+--
+-- No fillfactor: this table is append-only (no UPDATEs). HOT update savings
+-- only apply when the same row is updated in-place; reserving free space on
+-- heap pages would just waste storage without reducing index churn.
+--
+-- Autovacuum is tuned aggressively because dead tuples arrive in bursts:
+-- when StrandPruner CASCADE-DELETEs an old task, all its history rows die at
+-- once. The default scale_factor=0.2 would let those dead tuples sit until
+-- 20% of the table is dead; 0.05 triggers cleanup after each meaningful prune
+-- cycle instead.
+ALTER TABLE strand.workflow_history SET (
+    autovacuum_vacuum_scale_factor  = 0.05,
+    autovacuum_analyze_scale_factor = 0.05,
+    autovacuum_vacuum_threshold     = 50,
+    autovacuum_analyze_threshold    = 50,
+    autovacuum_vacuum_cost_delay    = 2
+);
 
 -- ────────────────────────────────────────────────────────────────────────────────────
 -- Schedules — cron/interval/one-shot task triggers.
@@ -630,7 +862,7 @@ CREATE INDEX IF NOT EXISTS strand_tasks_backfill_idx
 
 CREATE UNLOGGED TABLE IF NOT EXISTS strand.workers (
     id           TEXT        NOT NULL,    -- "<hostname>:<pid>"
-    namespace_id TEXT        NOT NULL DEFAULT 'default',
+    namespace_id TEXT        NOT NULL DEFAULT 'default' REFERENCES strand.namespaces(id) ON DELETE CASCADE,
     queue        TEXT        NOT NULL,
     concurrency  INTEGER     NOT NULL,    -- configured workflowConcurrency + activityConcurrency
     running      INTEGER     NOT NULL DEFAULT 0,   -- currently executing tasks
@@ -677,3 +909,33 @@ BEGIN
     RETURN (plan -> 0 -> 'Plan' ->> 'Plan Rows')::BIGINT;
 END;
 $$ LANGUAGE plpgsql;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Initial monthly partitions (fresh install)
+--
+-- Create partitions for the current month and the next two months so the
+-- schema is immediately usable. StrandPruner.ensurePartitions() maintains
+-- this lead time at runtime (called at startup and every 12 h).
+-- ─────────────────────────────────────────────────────────────────────────────
+DO $$
+DECLARE
+    i INTEGER;
+BEGIN
+    FOR i IN 0..2 LOOP
+        PERFORM strand.create_range_partition(
+            'runs',
+            date_trunc('month', NOW() + (i || ' months')::INTERVAL)::DATE
+        );
+        PERFORM strand.create_range_partition(
+            'task_logs',
+            date_trunc('month', NOW() + (i || ' months')::INTERVAL)::DATE
+        );
+    END LOOP;
+END;
+$$;
+
+-- Seed parent-table statistics for the query planner.
+-- Autovacuum never ANALYZEs partitioned parents — must be run manually
+-- (and by StrandPruner.analyzeParentTables every 12 h).
+ANALYZE strand.runs;
+ANALYZE strand.task_logs;


### PR DESCRIPTION
## Summary

Finalized Pruner and clean up public apis

## Changes

- StrandPruner
- Public APIs clean up

## Testing

<!-- How did you verify this works? Did you run `swift test`? -->

- [x] `swift test` passes locally

## AI Disclosure

<!--
  REQUIRED if any AI assistance was used — see CONTRIBUTING.md.
  Delete this section entirely if no AI was involved.
-->

- [ ] I used AI assistance while working on this PR

**Tool(s) used:** <!-- e.g. Claude, Copilot, ChatGPT -->

**Extent of use:**
<!-- Describe honestly. Examples:
  - Generated first draft of WorkflowDag.tsx, reviewed and edited manually.
  - Used for commit message suggestions only.
  - Pair-programmed the entire feature; all output was reviewed.
-->

**Was the PR description itself AI-generated?** No
