### PR TITLE
Add ProcessOrder example; support request-cancel

### DIFF
--- a/Examples/Sources/DevServer/DevServer.swift
+++ b/Examples/Sources/DevServer/DevServer.swift
@@ -14,18 +14,6 @@ import Foundation
 
 // MARK: - Types
 
-struct OrderInput: Codable, Sendable {
-    let orderId: String
-    let amount: Double
-    let items: [String]
-}
-
-struct OrderResult: Codable, Sendable {
-    let orderId: String
-    let status: String
-    let trackingNumber: String
-}
-
 struct ReportInput: Codable, Sendable {
     let reportId: String
     let dataset: String
@@ -47,26 +35,6 @@ struct GreetResult: Codable, Sendable {
 }
 
 // MARK: - Workflows
-
-/// Multi-step order pipeline — shows checkpoints in the run timeline.
-struct ProcessOrderWorkflow: Workflow {
-    typealias Input = OrderInput
-    typealias Output = OrderResult
-
-    mutating func run(
-        context: WorkflowContext<Self>,
-        input: OrderInput
-    ) async throws -> OrderResult {
-        // Values derived purely from input — deterministic, no checkpoint needed.
-        let paymentId = "pay_\(input.orderId.prefix(8).lowercased())"
-        let tracking = "TRK-\(paymentId.suffix(6).uppercased())"
-        return OrderResult(
-            orderId: input.orderId,
-            status: "completed",
-            trackingNumber: tracking
-        )
-    }
-}
 
 /// Sleeps before processing — lets you see SLEEPING state in the UI.
 struct GenerateReportWorkflow: Workflow {
@@ -207,19 +175,50 @@ private func seedBatch(
     reports: StrandClient,
     logger: Logger
 ) async {
-    let initialOrders: [(String, Double, [String])] = [
-        ("ORD-1001", 49.99, ["widget-a", "widget-b"]),
-        ("ORD-1002", 129.00, ["gadget-x"]),
-        ("ORD-1003", 19.95, ["sticker-pack", "mug"]),
-        ("ORD-1004", 299.00, ["pro-kit"]),
+    // Seed initial orders — mix of 1–3 items to exercise both the linear path
+    // and the parallel ReserveInventory fan-out
+    let initialOrders: [(String, String, String, [OrderLineItem], String)] = [
+        (
+            "ORD-1001", "cust-101", "alice@example.com",
+            [
+                OrderLineItem(sku: "SKU-WIDGET", name: "Widget Pro", quantity: 2, unitPriceCents: 2999),
+                OrderLineItem(sku: "SKU-MODULE", name: "Module X", quantity: 1, unitPriceCents: 1499),
+            ],
+            "42 Pine St, Seattle, WA 98101"
+        ),
+        (
+            "ORD-1002", "cust-207", "bob@example.com",
+            [OrderLineItem(sku: "SKU-GADGET", name: "Gadget Plus", quantity: 1, unitPriceCents: 4999)],
+            "7 Oak Ave, Portland, OR 97201"
+        ),
+        (
+            "ORD-1003", "cust-318", "carol@example.com",
+            [
+                OrderLineItem(sku: "SKU-KIT", name: "Starter Kit", quantity: 1, unitPriceCents: 7999),
+                OrderLineItem(sku: "SKU-WIDGET", name: "Widget Pro", quantity: 3, unitPriceCents: 2999),
+                OrderLineItem(sku: "SKU-MODULE", name: "Module X", quantity: 2, unitPriceCents: 1499),
+            ],
+            "88 Elm Rd, San Francisco, CA 94102"
+        ),
+        (
+            "ORD-1004", "cust-429", "dave@example.com",
+            [OrderLineItem(sku: "SKU-GADGET", name: "Gadget Plus", quantity: 2, unitPriceCents: 4999)],
+            "5 Maple Blvd, Austin, TX 78701"
+        ),
     ]
-    for (id, amount, items) in initialOrders {
+    for (id, custId, email, items, address) in initialOrders {
         do {
             _ = try await orders.startWorkflow(
                 ProcessOrderWorkflow.self,
-                input: OrderInput(orderId: id, amount: amount, items: items)
+                input: OrderInput(
+                    orderId: id,
+                    customerId: custId,
+                    customerEmail: email,
+                    items: items,
+                    shippingAddress: address
+                )
             )
-            logger.info("[seeder] order \(id) enqueued")
+            logger.info("[seeder] order \(id) enqueued (\(items.count) item(s))")
         } catch {
             logger.warning("[seeder] order \(id): \(error)")
         }
@@ -263,14 +262,39 @@ private func seedBatch(
 
 private func seedOne(orders: StrandClient, logger: Logger) async {
     let id = "ORD-\(Int.random(in: 2000...9999))"
-    let catalog = ["widget", "gadget", "module", "adapter", "kit"]
-    let items = ["\(catalog.randomElement()!)-\(Int.random(in: 1...9))"]
+    // Fully random customer — no hardcoded list
+    let custId = "cust-\(Int.random(in: 1000...9999))"
+    let firstName = ["alice", "bob", "carol", "dave", "eve", "frank", "grace", "hank"].randomElement()!
+    let domain = ["example.com", "test.org", "demo.net", "sample.io"].randomElement()!
+    let email = "\(firstName)\(Int.random(in: 1...99))@\(domain)"
+    let streets = ["Main St", "Oak Ave", "Elm Rd", "Pine Blvd", "Maple Dr", "Cedar Ln"]
+    let cities = [
+        ("Seattle", "WA", "981"), ("Portland", "OR", "972"), ("Austin", "TX", "787"),
+        ("Denver", "CO", "802"), ("Chicago", "IL", "606"), ("Boston", "MA", "021"),
+    ]
+    let (city, state, zip) = cities.randomElement()!
+    let address = "\(Int.random(in: 1...999)) \(streets.randomElement()!), \(city), \(state) \(zip)\(Int.random(in: 10...99))"
+    let skus = [
+        ("SKU-WIDGET", "Widget Pro", 2999), ("SKU-GADGET", "Gadget Plus", 4999),
+        ("SKU-MODULE", "Module X", 1499), ("SKU-KIT", "Starter Kit", 7999),
+    ]
+    // 1–3 items: exercises single-item path and fan-out inventory reservation
+    let items = (0..<Int.random(in: 1...3)).map { _ -> OrderLineItem in
+        let (sku, name, price) = skus.randomElement()!
+        return OrderLineItem(sku: sku, name: name, quantity: Int.random(in: 1...3), unitPriceCents: price)
+    }
     do {
         _ = try await orders.startWorkflow(
             ProcessOrderWorkflow.self,
-            input: OrderInput(orderId: id, amount: Double.random(in: 9.99...299.99), items: items)
+            input: OrderInput(
+                orderId: id,
+                customerId: custId,
+                customerEmail: email,
+                items: items,
+                shippingAddress: address
+            )
         )
-        logger.info("[seeder] periodic order \(id)")
+        logger.info("[seeder] periodic order \(id) (\(items.count) item(s)) for \(email)")
     } catch {
         logger.warning("[seeder] periodic order: \(error)")
     }
@@ -478,6 +502,10 @@ private func seedOnePodcast(client: StrandClient, logger: Logger) async {
                 TrainVoiceAssistantWorkflow.self,
                 TrainCountryModelWorkflow.self,
                 PodcastTranscriptionWorkflow.self,
+            ],
+            activityContainers: [
+                // @ActivityContainer groups related activities — no manual list
+                ProcessOrderActivities()
             ],
             activities: [
                 CalculateInvoiceActivity(),

--- a/Examples/Sources/DevServer/ProcessOrder/ProcessOrderActivities.swift
+++ b/Examples/Sources/DevServer/ProcessOrder/ProcessOrderActivities.swift
@@ -1,0 +1,148 @@
+import Strand
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// All five order-processing activities grouped into one container.
+///
+/// `@ActivityContainer` synthesises `ActivityContainerProtocol` conformance and
+/// generates a nested `Activity`-conforming struct for every `@Activity` method —
+/// named after the method with the first letter capitalised.
+///
+/// In a real service these methods would share injected clients:
+/// ```swift
+/// let inventory: InventoryServiceClient
+/// let payments:  PaymentGatewayClient
+/// let email:     EmailServiceClient
+/// ```
+/// Every `@Activity` below has access to those fields without any per-activity
+/// constructor boilerplate.  Registering the whole pipeline requires only:
+/// ```swift
+/// activityContainers: [ProcessOrderActivities()]
+/// ```
+@ActivityContainer
+struct ProcessOrderActivities {
+
+    // ── @Activity methods ─────────────────────────────────────────────────────
+    // The @ActivityContainer macro generates a nested `Activity`-conforming struct
+    // for each method:
+    //   validateOrder   → ProcessOrderActivities.ValidateOrder
+    //   reserveInventory → ProcessOrderActivities.ReserveInventory
+    //   chargePayment   → ProcessOrderActivities.ChargePayment
+    //   fulfillOrder    → ProcessOrderActivities.FulfillOrder
+    //   sendConfirmation → ProcessOrderActivities.SendConfirmation
+
+    /// Validates the order against the product catalog and confirms pricing.
+    /// 5 % transient failure rate — shows up as retries in the dashboard.
+    @Activity
+    func validateOrder(
+        input: ValidateOrderInput,
+        context: ActivityContext
+    ) async throws -> ValidateOrderOutput {
+        try await Task.sleep(for: .milliseconds(Int.random(in: 300...800)))
+        if Double.random(in: 0...1) < 0.05 {
+            struct Err: Error, CustomStringConvertible {
+                var description: String { "catalog service temporarily unavailable" }
+            }
+            throw Err()
+        }
+        let total = input.items.reduce(0) { $0 + $1.subtotalCents }
+        return ValidateOrderOutput(orderId: input.orderId, totalCents: total)
+    }
+
+    /// Reserves stock for a single SKU in the warehouse.
+    /// Called in parallel for each item — the Run Timeline shows
+    /// `ReserveInventory ×N` for clear fan-out visibility.
+    /// 10 % transient out-of-stock failure rate.
+    @Activity
+    func reserveInventory(
+        input: ReserveInventoryInput,
+        context: ActivityContext
+    ) async throws -> ReserveInventoryOutput {
+        try await Task.sleep(for: .milliseconds(Int.random(in: 200...600)))
+        if Double.random(in: 0...1) < 0.10 {
+            struct Err: Error, CustomStringConvertible {
+                let sku: String
+                var description: String { "SKU \(sku) temporarily out of stock" }
+            }
+            throw Err(sku: input.sku)
+        }
+        let warehouses = ["WH-SEA", "WH-LAX", "WH-ORD", "WH-JFK"]
+        return ReserveInventoryOutput(
+            sku: input.sku,
+            reservedQty: input.quantity,
+            warehouseId: warehouses.randomElement()!
+        )
+    }
+
+    /// Processes the payment via the gateway.
+    /// Highest failure rate (20 %) — makes retry/backoff clearly visible in
+    /// the dashboard run timeline.
+    @Activity
+    func chargePayment(
+        input: ChargePaymentInput,
+        context: ActivityContext
+    ) async throws -> ChargePaymentOutput {
+        try await Task.sleep(for: .milliseconds(Int.random(in: 500...1_500)))
+        if Double.random(in: 0...1) < 0.20 {
+            struct Err: Error, CustomStringConvertible {
+                let attempt: Int
+                var description: String { "payment gateway timeout (attempt \(attempt))" }
+            }
+            throw Err(attempt: context.attempt)
+        }
+        let chargeId = "ch_\(input.orderId.prefix(6))_\(Int.random(in: 10_000...99_999))"
+        return ChargePaymentOutput(chargeId: chargeId, amountCents: input.amountCents)
+    }
+
+    /// Creates a shipment and returns a tracking number.
+    /// Runs in parallel with `sendConfirmation` — the two-activity fan-out is
+    /// visible in the Run Timeline at the fulfilling stage.
+    @Activity
+    func fulfillOrder(
+        input: FulfillOrderInput,
+        context: ActivityContext
+    ) async throws -> FulfillOrderOutput {
+        try await Task.sleep(for: .milliseconds(Int.random(in: 800...2_000)))
+        if Double.random(in: 0...1) < 0.05 {
+            struct Err: Error, CustomStringConvertible {
+                var description: String { "fulfillment service unavailable" }
+            }
+            throw Err()
+        }
+        let carriers = ["UPS", "FedEx", "USPS", "DHL"]
+        let carrier = carriers.randomElement()!
+        let tracking = "\(carrier.prefix(3))-\(Int.random(in: 1_000_000...9_999_999))"
+        let days = Int.random(in: 2...5)
+        let eta = Calendar.current.date(byAdding: .day, value: days, to: Date())!
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return FulfillOrderOutput(
+            trackingNumber: tracking,
+            carrier: carrier,
+            estimatedDelivery: formatter.string(from: eta)
+        )
+    }
+
+    /// Sends an order-confirmation email to the customer.
+    /// Runs in parallel with `fulfillOrder`. 8 % transient failure rate.
+    @Activity
+    func sendConfirmation(
+        input: SendConfirmationInput,
+        context: ActivityContext
+    ) async throws -> StrandVoid {
+        try await Task.sleep(for: .milliseconds(Int.random(in: 300...700)))
+        if Double.random(in: 0...1) < 0.08 {
+            struct Err: Error, CustomStringConvertible {
+                let to: String
+                var description: String { "email delivery failed for \(to)" }
+            }
+            throw Err(to: input.customerEmail)
+        }
+        return StrandVoid()
+    }
+}

--- a/Examples/Sources/DevServer/ProcessOrder/ProcessOrderTypes.swift
+++ b/Examples/Sources/DevServer/ProcessOrder/ProcessOrderTypes.swift
@@ -1,0 +1,92 @@
+import Strand
+
+// MARK: - Workflow input / output
+
+/// Top-level order placed by a customer.
+struct OrderInput: Codable, Sendable {
+    let orderId: String
+    let customerId: String
+    let customerEmail: String
+    let items: [OrderLineItem]
+    let shippingAddress: String
+
+    var totalCents: Int { items.reduce(0) { $0 + $1.subtotalCents } }
+}
+
+struct OrderLineItem: Codable, Sendable {
+    let sku: String
+    let name: String
+    let quantity: Int
+    let unitPriceCents: Int
+
+    var subtotalCents: Int { unitPriceCents * quantity }
+}
+
+struct OrderResult: Codable, Sendable {
+    let orderId: String
+    let status: OrderStatus
+    let totalCents: Int
+    let trackingNumber: String
+}
+
+/// Mutable status tracked inside the workflow — readable via @WorkflowQuery.
+enum OrderStatus: String, Codable, Sendable {
+    case pending
+    case validating
+    case reservingInventory = "reserving_inventory"
+    case chargingPayment = "charging_payment"
+    case fulfilling
+    case completed
+    case cancelled
+}
+
+// MARK: - Activity I/O
+
+struct ValidateOrderInput: Codable, Sendable {
+    let orderId: String
+    let items: [OrderLineItem]
+}
+struct ValidateOrderOutput: Codable, Sendable {
+    let orderId: String
+    let totalCents: Int
+}
+
+struct ReserveInventoryInput: Codable, Sendable {
+    let orderId: String
+    let sku: String
+    let quantity: Int
+}
+struct ReserveInventoryOutput: Codable, Sendable {
+    let sku: String
+    let reservedQty: Int
+    let warehouseId: String
+}
+
+struct ChargePaymentInput: Codable, Sendable {
+    let orderId: String
+    let customerId: String
+    let amountCents: Int
+}
+struct ChargePaymentOutput: Codable, Sendable {
+    let chargeId: String
+    let amountCents: Int
+}
+
+struct FulfillOrderInput: Codable, Sendable {
+    let orderId: String
+    let items: [OrderLineItem]
+    let shippingAddress: String
+    let warehouseId: String
+}
+struct FulfillOrderOutput: Codable, Sendable {
+    let trackingNumber: String
+    let carrier: String
+    let estimatedDelivery: String
+}
+
+struct SendConfirmationInput: Codable, Sendable {
+    let orderId: String
+    let customerEmail: String
+    let amountCents: Int
+    let trackingNumber: String
+}

--- a/Examples/Sources/DevServer/ProcessOrder/ProcessOrderWorkflow.swift
+++ b/Examples/Sources/DevServer/ProcessOrder/ProcessOrderWorkflow.swift
@@ -1,0 +1,172 @@
+import Strand
+
+/// End-to-end order-processing pipeline demonstrating Strand's core patterns:
+///
+/// **Sequential steps** (each depends on the previous):
+///   1. `ProcessOrderActivities.ValidateOrder`    — catalog check, pricing
+///   2. `ProcessOrderActivities.ReserveInventory ×N` — fan-out: one per SKU
+///   3. `ProcessOrderActivities.ChargePayment`    — payment gateway
+///
+/// **Parallel fan-out** (both dispatched simultaneously):
+///   4a. `ProcessOrderActivities.FulfillOrder`      — shipment + tracking number
+///   4b. `ProcessOrderActivities.SendConfirmation`  — customer email
+///
+/// **Signals** — mutate workflow state while it is WAITING between activations:
+///   • `cancel()` — sets `isCancelled = true`; checked before each major step
+///
+/// **Queries** — zero-activation reads of persisted workflow state:
+///   • `currentStatus()` — returns the current `OrderStatus`
+///
+/// The `@Workflow` macro synthesises:
+///   • `handleSignal` dispatch to all `@WorkflowSignal` methods
+///   • `handleUpdate` dispatch to all `@WorkflowUpdate` methods
+///   • `init() {}` (required when stored properties have defaults)
+@Workflow
+struct ProcessOrderWorkflow {
+    typealias Input = OrderInput
+    typealias Output = OrderResult
+
+    // ── Persisted state — survives across activations ─────────────────────────
+    var status: OrderStatus = .pending
+    var isCancelled = false
+
+    // ── Signal ────────────────────────────────────────────────────────────────
+    /// Cancels the order gracefully.  The workflow exits early with `.cancelled`
+    /// before the next activity is dispatched.
+    @WorkflowSignal
+    mutating func cancel() {
+        isCancelled = true
+        status = .cancelled
+    }
+
+    // ── Query ─────────────────────────────────────────────────────────────────
+    /// Returns the current pipeline stage without activating the workflow.
+    /// Typed return — callers receive `OrderStatus` directly:
+    /// ```swift
+    /// let s: OrderStatus = try await handle.query(ProcessOrderWorkflow.CurrentStatus.self)
+    /// ```
+    @WorkflowQuery
+    func currentStatus() -> OrderStatus { status }
+
+    // ── Handler ───────────────────────────────────────────────────────────────
+    mutating func run(
+        context: WorkflowContext<Self>,
+        input: OrderInput
+    ) async throws -> OrderResult {
+
+        // ── 1. Validate order ─────────────────────────────────────────────────
+        status = .validating
+        let validation = try await context.runActivity(
+            ProcessOrderActivities.ValidateOrder.self,
+            input: .init(orderId: input.orderId, items: input.items),
+            options: .init(maxAttempts: 3)
+        )
+
+        if isCancelled { return .cancelled(input) }
+
+        // ── 2. Reserve inventory — fan-out, one activity per SKU ──────────────
+        // `ReserveInventory ×N` groups neatly in the Run Timeline.
+        status = .reservingInventory
+        var primaryWarehouse = "WH-SEA"
+        try await withThrowingTaskGroup(of: ReserveInventoryOutput.self) { group in
+            for item in input.items {
+                group.addTask {
+                    try await context.runActivity(
+                        ProcessOrderActivities.ReserveInventory.self,
+                        input: .init(
+                            orderId: input.orderId,
+                            sku: item.sku,
+                            quantity: item.quantity
+                        ),
+                        options: .init(
+                            maxAttempts: 4,
+                            retryStrategy: .backoff(
+                                initial: .milliseconds(400),
+                                multiplier: 1.5,
+                                cap: .seconds(5)
+                            )
+                        )
+                    )
+                }
+            }
+            for try await reservation in group {
+                primaryWarehouse = reservation.warehouseId
+            }
+        }
+
+        if isCancelled { return .cancelled(input) }
+
+        // ── 3. Charge payment ─────────────────────────────────────────────────
+        status = .chargingPayment
+        let warehouseId = primaryWarehouse  // let-bind before @Sendable capture
+        let charge = try await context.runActivity(
+            ProcessOrderActivities.ChargePayment.self,
+            input: .init(
+                orderId: input.orderId,
+                customerId: input.customerId,
+                amountCents: validation.totalCents
+            ),
+            options: .init(
+                maxAttempts: 5,
+                retryStrategy: .backoff(
+                    initial: .milliseconds(500),
+                    multiplier: 2.0,
+                    cap: .seconds(10)
+                )
+            )
+        )
+
+        // ── 4. Fulfill + notify in parallel ───────────────────────────────────
+        status = .fulfilling
+        var trackingNumber = ""
+        try await withThrowingTaskGroup(of: String?.self) { group in
+            // 4a: create shipment → returns tracking number
+            group.addTask {
+                let shipment = try await context.runActivity(
+                    ProcessOrderActivities.FulfillOrder.self,
+                    input: .init(
+                        orderId: input.orderId,
+                        items: input.items,
+                        shippingAddress: input.shippingAddress,
+                        warehouseId: warehouseId
+                    ),
+                    options: .init(maxAttempts: 3)
+                )
+                return shipment.trackingNumber
+            }
+            // 4b: email customer — no useful return value
+            group.addTask {
+                try await context.runActivity(
+                    ProcessOrderActivities.SendConfirmation.self,
+                    input: .init(
+                        orderId: input.orderId,
+                        customerEmail: input.customerEmail,
+                        amountCents: charge.amountCents,
+                        trackingNumber: "PENDING"
+                    ),
+                    options: .init(maxAttempts: 4)
+                )
+                return nil
+            }
+            for try await result in group {
+                if let tn = result { trackingNumber = tn }
+            }
+        }
+
+        status = .completed
+        return OrderResult(
+            orderId: input.orderId,
+            status: .completed,
+            totalCents: charge.amountCents,
+            trackingNumber: trackingNumber
+        )
+    }
+}
+
+// MARK: - Convenience
+
+extension OrderResult {
+    fileprivate static func cancelled(_ input: OrderInput) -> OrderResult {
+        OrderResult(orderId: input.orderId, status: .cancelled, totalCents: 0, trackingNumber: "")
+    }
+}

--- a/Sources/Strand/DB/Queries.swift
+++ b/Sources/Strand/DB/Queries.swift
@@ -695,7 +695,7 @@ enum Queries {
                    c.wake_event, c.event_payload,
                    t.parent_task_id, t.kind, t.timeout_seconds, t.heartbeat_timeout_seconds,
                    t.scheduling_metadata, c.available_at, c.heartbeat_details, t.deadline_at,
-                   t.first_task_id
+                   t.first_task_id, t.cancel_requested
             FROM claimed c JOIN strand.tasks t ON t.id = c.task_id
             ORDER BY c.id
             """,
@@ -793,30 +793,39 @@ enum Queries {
     private struct _ErrorType: Decodable { let name: String? }
     private struct _FailureMessage: Decodable { let message: String? }
 
-    /// Recursively cancel all non-terminal descendants of `parentTaskID` that have
-    /// `parent_close_policy = NULL` (default .terminate) or `= 'TERMINATE'`.
-    /// Descendants with `parent_close_policy = 'ABANDON'` or `= 'REQUEST_CANCEL'`
-    /// are left running. Called from every permanent-failure exit of `failRun`.
+    /// Recursively processes all non-terminal descendants of `parentTaskID` when the parent
+    /// workflow permanently fails.
+    ///
+    /// Three policies are enforced:
+    /// - **TERMINATE / nil**: full cancel — task CANCELLED, all non-RUNNING runs CANCELLED.
+    ///   RUNNING runs are left to expire via `sweepExpiredLeases` (transparent infrastructure event).
+    /// - **REQUEST_CANCEL (WORKFLOW kind)**: cooperative cancel — insert a
+    ///   `Signals.cancelRequested` signal and wake SLEEPING/WAITING runs to PENDING so the
+    ///   handler receives the signal at the next activation. The task is NOT marked CANCELLED;
+    ///   it completes naturally when the handler exits.
+    /// - **REQUEST_CANCEL (ACTIVITY kind)**: treated as ABANDON — activities have no signal
+    ///   handler so there is nothing to deliver.
+    /// - **ABANDON**: left entirely alone.
+    ///
+    /// Recursion stops at ABANDON and REQUEST_CANCEL nodes — their subtrees are unaffected.
+    ///
+    /// - Returns: Queue names of runs woken by REQUEST_CANCEL processing; callers should
+    ///   call `notifyWorkers` for each distinct queue so workers pick up the PENDING runs promptly.
+    @discardableResult
     private static func cancelDescendants(
         on conn: PostgresConnection,
         namespaceID: String,
         parentTaskID: UUID,
         logger: Logger
-    ) async throws {
-        // ── Identify which descendants to cancel ──────────────────────────────
-        // The recursive CTE stops at ABANDON and REQUEST_CANCEL nodes so their
-        // subtrees are not traversed — children of those nodes are unaffected.
-        // to_terminate: full cancel (task + all runs including RUNNING)
-        // to_request_cancel: soft cancel (task + non-RUNNING runs only, no cascade)
-        // ABANDON: skipped entirely
-        try await conn.query(
+    ) async throws -> [String] {
+        let stream = try await conn.query(
             """
             WITH RECURSIVE descendants AS (
-                SELECT id, parent_close_policy FROM strand.tasks
+                SELECT id, parent_close_policy, kind FROM strand.tasks
                 WHERE parent_task_id = \(parentTaskID)
                   AND namespace_id   = \(namespaceID)
                 UNION ALL
-                SELECT t.id, t.parent_close_policy FROM strand.tasks t
+                SELECT t.id, t.parent_close_policy, t.kind FROM strand.tasks t
                 JOIN descendants d ON t.parent_task_id = d.id
                 WHERE t.namespace_id = \(namespaceID)
                   AND (d.parent_close_policy IS NULL OR d.parent_close_policy = \(ParentClosePolicy.terminate))
@@ -826,12 +835,13 @@ enum Queries {
                 WHERE parent_close_policy IS NULL OR parent_close_policy = \(ParentClosePolicy.terminate)
             ),
             to_request_cancel AS (
-                SELECT id FROM descendants WHERE parent_close_policy = \(ParentClosePolicy.requestCancel)
+                SELECT id, kind FROM descendants WHERE parent_close_policy = \(ParentClosePolicy.requestCancel)
             ),
+            -- TERMINATE: cancel tasks + all non-RUNNING runs. RUNNING runs expire via leaseExpiryLoop.
             task_cancel AS (
                 UPDATE strand.tasks
                 SET state = \(TaskState.cancelled), cancelled_at = NOW()
-                WHERE id IN (SELECT id FROM to_terminate UNION ALL SELECT id FROM to_request_cancel)
+                WHERE id IN (SELECT id FROM to_terminate)
                   AND state NOT IN (
                       \(TaskState.completed), \(TaskState.failed), \(TaskState.cancelled)
                   )
@@ -845,15 +855,46 @@ enum Queries {
                       \(TaskState.running),
                       \(TaskState.completed), \(TaskState.failed), \(TaskState.cancelled)
                   )
+            ),
+            -- REQUEST_CANCEL (WORKFLOW only): wake suspended runs so the handler can see the signal.
+            -- Activities have no signal handler; treating REQUEST_CANCEL on activities as ABANDON.
+            request_cancel_wake AS (
+                UPDATE strand.runs
+                SET state            = \(TaskState.pending),
+                    available_at     = NOW(),
+                    lease_expires_at = NULL,
+                    wake_event       = NULL,
+                    event_payload    = NULL,
+                    worker_id        = NULL
+                WHERE task_id IN (SELECT id FROM to_request_cancel WHERE kind = \(TaskKind.workflow))
+                  AND namespace_id = \(namespaceID)
+                  AND state IN (\(TaskState.sleeping), \(TaskState.waiting))
+                RETURNING queue
+            ),
+            request_cancel_task_wake AS (
+                UPDATE strand.tasks
+                SET state = \(TaskState.pending)
+                WHERE id IN (SELECT id FROM to_request_cancel WHERE kind = \(TaskKind.workflow))
+                  AND namespace_id = \(namespaceID)
+                  AND state IN (\(TaskState.sleeping), \(TaskState.waiting))
+            ),
+            -- REQUEST_CANCEL: set cancel_requested = TRUE so the next activation delivers
+            -- Swift CancellationError natively to the handler via handlerTask.cancel().
+            cancel_requested_set AS (
+                UPDATE strand.tasks
+                SET cancel_requested = TRUE
+                WHERE id IN (SELECT id FROM to_request_cancel WHERE kind = \(TaskKind.workflow))
             )
-            UPDATE strand.runs
-            SET state = \(TaskState.cancelled), finished_at = NOW()
-            WHERE task_id IN (SELECT id FROM to_request_cancel)
-              AND namespace_id = \(namespaceID)
-              AND state IN (\(TaskState.pending), \(TaskState.sleeping), \(TaskState.waiting))
+            SELECT queue FROM request_cancel_wake
             """,
             logger: logger
         )
+        var queues: [String] = []
+        for try await row in stream {
+            var col = row.makeIterator()
+            queues.append(try col.next()!.decode(String.self, context: .default))
+        }
+        return queues
     }
 
     /// Marks a run as failed and schedules a retry if attempts remain.
@@ -1020,7 +1061,13 @@ enum Queries {
                 logger: logger
             )
             try await conn.query(
-                "UPDATE strand.tasks SET state = \(newState), attempt = \(nextAttempt) WHERE id = \(taskID)",
+                """
+                UPDATE strand.tasks
+                SET state            = \(newState),
+                    attempt          = \(nextAttempt),
+                    cancel_requested = FALSE
+                WHERE id = \(taskID)
+                """,
                 logger: logger
             )
             // Only notify when the retry is immediately runnable (no sleep delay).
@@ -1152,58 +1199,19 @@ enum Queries {
                 logger: logger
             )
 
-            // ── Step 3 + 4: Policy-aware cascade to descendants ────────────────────
-            // ABANDON: skip entirely (left running independently)
-            // REQUEST_CANCEL: mark task CANCELLED + cancel non-RUNNING runs, no cascade to its children
-            // TERMINATE / NULL: full cancel (all runs including RUNNING) + recurse
-            //
-            // The recursion stops at ABANDON and REQUEST_CANCEL nodes so their
-            // children are not traversed.
-            try await conn.query(
-                """
-                WITH RECURSIVE descendants AS (
-                    SELECT id, parent_close_policy FROM strand.tasks
-                        WHERE parent_task_id = \(taskID)
-                          AND namespace_id   = \(namespaceID)
-                        UNION ALL
-                        SELECT t.id, t.parent_close_policy FROM strand.tasks t
-                        JOIN descendants d ON t.parent_task_id = d.id
-                        WHERE t.namespace_id = \(namespaceID)
-                          AND (d.parent_close_policy IS NULL OR d.parent_close_policy = \(ParentClosePolicy.terminate))
-                    ),
-                    to_terminate AS (
-                        SELECT id FROM descendants
-                        WHERE parent_close_policy IS NULL OR parent_close_policy = \(ParentClosePolicy.terminate)
-                    ),
-                    to_request_cancel AS (
-                        SELECT id FROM descendants WHERE parent_close_policy = \(ParentClosePolicy.requestCancel)
-                    ),
-                task_cancel AS (
-                    UPDATE strand.tasks
-                    SET state = \(TaskState.cancelled), cancelled_at = NOW()
-                    WHERE id IN (SELECT id FROM to_terminate UNION ALL SELECT id FROM to_request_cancel)
-                      AND state NOT IN (
-                          \(TaskState.completed), \(TaskState.failed), \(TaskState.cancelled)
-                      )
-                ),
-                run_terminate AS (
-                    UPDATE strand.runs
-                    SET state = \(TaskState.cancelled)
-                    WHERE task_id IN (SELECT id FROM to_terminate)
-                      AND namespace_id = \(namespaceID)
-                      AND state IN (
-                          \(TaskState.pending), \(TaskState.sleeping),
-                          \(TaskState.waiting), \(TaskState.running)
-                      )
-                )
-                UPDATE strand.runs
-                SET state = \(TaskState.cancelled)
-                WHERE task_id IN (SELECT id FROM to_request_cancel)
-                  AND namespace_id = \(namespaceID)
-                  AND state IN (\(TaskState.pending), \(TaskState.sleeping), \(TaskState.waiting))
-                """,
+            // ── Step 3 + 4: Policy-aware cascade to descendants ─────────────────────
+            // cancelDescendants handles the three policies (TERMINATE / REQUEST_CANCEL /
+            // ABANDON) atomically. It returns queue names for any runs woken by
+            // REQUEST_CANCEL so we can notify workers immediately.
+            let cancelQueues = try await cancelDescendants(
+                on: conn,
+                namespaceID: namespaceID,
+                parentTaskID: taskID,
                 logger: logger
             )
+            for queue in Set(cancelQueues) {
+                try await conn.notifyWorkers(namespace: namespaceID, queue: queue, logger: logger)
+            }
 
             // ── Step 5: Wake any awaitTaskResult callers ───────────────────────────
             try await emitTaskCompletionSignal(
@@ -1279,15 +1287,18 @@ enum Queries {
                 logger: logger
             )
 
-            // ── Steps 3 + 4: Policy-aware cascade to descendants (bulk) ──────────
-            try await conn.query(
+            // ── Steps 3 + 4: Policy-aware cascade to descendants (bulk) ──────────────
+            // Mirror the single-task logic from cancelDescendants but for N parent IDs
+            // at once. REQUEST_CANCEL workflow descendants get a cooperative cancel signal;
+            // TERMINATE descendants are hard-cancelled; ABANDON descendants are untouched.
+            let wakeStream = try await conn.query(
                 """
                 WITH RECURSIVE descendants AS (
-                    SELECT id, parent_close_policy FROM strand.tasks
+                    SELECT id, parent_close_policy, kind FROM strand.tasks
                         WHERE parent_task_id = ANY(\(cancelledIDs))
                           AND namespace_id   = \(namespaceID)
                         UNION ALL
-                        SELECT t.id, t.parent_close_policy FROM strand.tasks t
+                        SELECT t.id, t.parent_close_policy, t.kind FROM strand.tasks t
                         JOIN descendants d ON t.parent_task_id = d.id
                         WHERE t.namespace_id = \(namespaceID)
                           AND (d.parent_close_policy IS NULL OR d.parent_close_policy = \(ParentClosePolicy.terminate))
@@ -1297,12 +1308,12 @@ enum Queries {
                         WHERE parent_close_policy IS NULL OR parent_close_policy = \(ParentClosePolicy.terminate)
                     ),
                     to_request_cancel AS (
-                        SELECT id FROM descendants WHERE parent_close_policy = \(ParentClosePolicy.requestCancel)
+                        SELECT id, kind FROM descendants WHERE parent_close_policy = \(ParentClosePolicy.requestCancel)
                     ),
                 task_cancel AS (
                     UPDATE strand.tasks
                     SET state = \(TaskState.cancelled), cancelled_at = NOW()
-                    WHERE id IN (SELECT id FROM to_terminate UNION ALL SELECT id FROM to_request_cancel)
+                    WHERE id IN (SELECT id FROM to_terminate)
                       AND state NOT IN (
                           \(TaskState.completed), \(TaskState.failed), \(TaskState.cancelled)
                       )
@@ -1316,15 +1327,44 @@ enum Queries {
                           \(TaskState.pending), \(TaskState.sleeping),
                           \(TaskState.waiting), \(TaskState.running)
                       )
+                ),
+                request_cancel_wake AS (
+                    UPDATE strand.runs
+                    SET state            = \(TaskState.pending),
+                        available_at     = NOW(),
+                        lease_expires_at = NULL,
+                        wake_event       = NULL,
+                        event_payload    = NULL,
+                        worker_id        = NULL
+                    WHERE task_id IN (SELECT id FROM to_request_cancel WHERE kind = \(TaskKind.workflow))
+                      AND namespace_id = \(namespaceID)
+                      AND state IN (\(TaskState.sleeping), \(TaskState.waiting))
+                    RETURNING queue
+                ),
+                request_cancel_task_wake AS (
+                    UPDATE strand.tasks
+                    SET state = \(TaskState.pending)
+                    WHERE id IN (SELECT id FROM to_request_cancel WHERE kind = \(TaskKind.workflow))
+                      AND namespace_id = \(namespaceID)
+                      AND state IN (\(TaskState.sleeping), \(TaskState.waiting))
+                ),
+                cancel_requested_set AS (
+                    UPDATE strand.tasks
+                    SET cancel_requested = TRUE
+                    WHERE id IN (SELECT id FROM to_request_cancel WHERE kind = \(TaskKind.workflow))
                 )
-                UPDATE strand.runs
-                SET state = \(TaskState.cancelled)
-                WHERE task_id IN (SELECT id FROM to_request_cancel)
-                  AND namespace_id = \(namespaceID)
-                  AND state IN (\(TaskState.pending), \(TaskState.sleeping), \(TaskState.waiting))
+                SELECT queue FROM request_cancel_wake
                 """,
                 logger: logger
             )
+            var cancelQueues: [String] = []
+            for try await row in wakeStream {
+                var col = row.makeIterator()
+                cancelQueues.append(try col.next()!.decode(String.self, context: .default))
+            }
+            for queue in Set(cancelQueues) {
+                try await conn.notifyWorkers(namespace: namespaceID, queue: queue, logger: logger)
+            }
 
             // ── Step 5: Wake any awaitTaskResult callers (one signal per root task) ─
             for taskID in cancelledIDs {
@@ -2551,7 +2591,10 @@ enum Queries {
             try await conn.query(
                 """
                 UPDATE strand.tasks
-                SET state = \(TaskState.pending), attempt = \(nextAttempt), max_attempts = \(newMaxAttempts)
+                SET state            = \(TaskState.pending),
+                    attempt          = \(nextAttempt),
+                    max_attempts     = \(newMaxAttempts),
+                    cancel_requested = FALSE
                 WHERE id = \(taskID)
                 """,
                 logger: logger
@@ -2667,14 +2710,19 @@ enum Queries {
 
     // MARK: - Task completion signals
 
-    /// Persists the completion and wakes every parent run waiting on this task.
+    /// Persists the child completion and signals any waiting parent workflow.
     ///
-    /// Single round trip: one CTE atomically inserts the completion record,
-    /// finds event_waits by child_task_id (FOR UPDATE SKIP LOCKED), wakes
-    /// WAITING/SLEEPING parent runs, conditionally removes event_waits (only
-    /// when the wake succeeded — RUNNING parents keep their event_wait so the
-    /// partial-completion re-wait CTE can detect the missed signal), and
-    /// transitions parent tasks to PENDING.
+    /// 1. **Insert** into `strand.task_completions` (idempotent via ON CONFLICT DO NOTHING).
+    /// 2. **Flag** RUNNING parents via `has_buffered_completion = TRUE`; step-7 detects
+    ///    this at the end of the parent's current activation and transitions to PENDING.
+    /// 3. **Notify** workers for WAITING/SLEEPING parents so the poll loop can call
+    ///    `wakeCompletedWaiting`.  RUNNING parents receive no notify here because
+    ///    step-7's own deferred `notifyWorkers` fires after its transaction commits.
+    ///
+    /// The parent run state is owned exclusively by:
+    ///   - step-7 `withTransaction`  (RUNNING → WAITING/PENDING)
+    ///   - `wakeCompletedWaiting`    (WAITING → PENDING, from poll loop)
+    ///   - External callers          (cancelTask, etc.)
     ///
     /// Must be called inside an existing transaction (`conn`).
     static func emitTaskCompletionSignal(
@@ -2685,7 +2733,6 @@ enum Queries {
         resultBuffer: ByteBuffer?,
         logger: Logger
     ) async throws {
-        let payloadBuf = try JSON.encode(["state": state.rawValue])
         try await conn.query(
             """
             WITH
@@ -2694,62 +2741,105 @@ enum Queries {
                 VALUES (\(namespaceID), \(taskID), \(state.rawValue), \(resultBuffer))
                 ON CONFLICT (task_id) DO NOTHING
             ),
-            waits AS (
-                SELECT task_id AS parent_task_id, run_id
-                FROM   strand.event_waits
-                WHERE  child_task_id = \(taskID)
-                FOR UPDATE SKIP LOCKED
-            ),
-            woken AS (
-                UPDATE strand.runs r
-                SET state            = \(TaskState.pending),
-                    available_at     = NOW(),
-                    event_payload    = \(payloadBuf),
-                    wake_event       = NULL,
-                    lease_expires_at = NULL
-                FROM   waits w
-                WHERE  r.id           = w.run_id
-                  AND  r.state        IN (\(TaskState.sleeping), \(TaskState.waiting))
-                  AND  r.namespace_id = \(namespaceID)
-                RETURNING r.id AS run_id
-            ),
-            flag_parent AS (
-                -- When the parent run is RUNNING (mid-activation), the woken CTE above
-                -- returned 0 rows for it. Set has_buffered_completion so that step 7's
-                -- UPDATE strand.runs (which acquires a row lock) sees the flag after
-                -- unblocking from any concurrent emitTaskCompletionSignal — eliminating
-                -- the READ COMMITTED race that previously left runs permanently stuck WAITING.
+            flag_running AS (
+                -- Parent is RUNNING (mid-activation): set has_buffered_completion so
+                -- the parent's step-7 withTransaction detects the child at the end of
+                -- its current activation and transitions to PENDING.
+                -- The parent's activation holds the runs row lock — do NOT try to
+                -- modify runs.state here to avoid lock-order conflicts.
                 UPDATE strand.runs r
                 SET    has_buffered_completion = TRUE
-                FROM   waits w
-                WHERE  r.id           = w.run_id
-                  AND  r.state        = \(TaskState.running)
-                  AND  r.namespace_id = \(namespaceID)
-            ),
-            del_waits AS (
-                -- Only delete the event_wait when the wake succeeded.
-                -- If the parent was RUNNING, woken is empty for that run
-                -- and the event_wait survives so the partial-completion
-                -- re-wait CTE can detect it on the next WAITING transition.
-                DELETE FROM strand.event_waits ew
-                USING  woken k
+                FROM   strand.event_waits ew
                 WHERE  ew.child_task_id = \(taskID)
-                  AND  ew.run_id        = k.run_id
+                  AND  r.id             = ew.run_id
+                  AND  r.state          = \(TaskState.running)
+                  AND  r.namespace_id   = \(namespaceID)
             ),
-            task_upd AS (
-                UPDATE strand.tasks t SET state = \(TaskState.pending)
-                FROM   woken k
-                JOIN   waits w ON w.run_id = k.run_id
-                WHERE  t.id           = w.parent_task_id
-                  AND  t.state        IN (\(TaskState.sleeping), \(TaskState.waiting))
-                  AND  t.namespace_id = \(namespaceID)
-                RETURNING t.namespace_id, t.queue
+            notif AS (
+                -- Collect the parent queue for WAITING/SLEEPING parents so workers
+                -- can run wakeCompletedWaiting and transition them to PENDING.
+                -- RUNNING parents are excluded: step-7's deferred notifyWorkers fires
+                -- after its own transaction commits.
+                SELECT r.queue, r.namespace_id
+                FROM   strand.event_waits ew
+                JOIN   strand.runs r ON r.id = ew.run_id
+                WHERE  ew.child_task_id = \(taskID)
+                  AND  r.state IN (\(TaskState.waiting), \(TaskState.sleeping))
+                  AND  r.namespace_id   = \(namespaceID)
+                LIMIT 1
             )
             SELECT pg_notify(\(StrandChannels.tasks), namespace_id || '/' || queue)
-            FROM task_upd
+            FROM notif
             """,
             logger: logger
         )
+    }
+
+    /// Transitions WAITING workflow runs to PENDING when their child activities have
+    /// completed.  Called from each worker's poll loop immediately before `claimTasks`.
+    ///
+    /// A WAITING run has no active activation, so there is no concurrent writer:
+    /// this is the only code path that makes WAITING → PENDING transitions.
+    /// `FOR UPDATE SKIP LOCKED` lets multiple workers process different runs in
+    /// parallel without contention.
+    static func wakeCompletedWaiting(
+        on client: PostgresClient,
+        namespaceID: String,
+        queue: String,
+        logger: Logger
+    ) async throws {
+        let stream = try await client.query(
+            """
+            WITH
+            to_wake AS (
+                -- WAITING runs that have at least one event_wait child already in
+                -- task_completions — the child completed but the parent was not
+                -- immediately transitioned (e.g. was RUNNING at completion time).
+                -- EXISTS is used instead of JOIN so that FOR UPDATE works without
+                -- a DISTINCT clause (Postgres forbids FOR UPDATE + DISTINCT).
+                SELECT r.id AS run_id, r.task_id
+                FROM   strand.runs r
+                WHERE  r.namespace_id = \(namespaceID)
+                  AND  r.queue        = \(queue)
+                  AND  r.state        = \(TaskState.waiting)
+                  AND  r.created_at  >= DATE_TRUNC('month', NOW()) - INTERVAL '1 month'
+                  AND  EXISTS (
+                      SELECT 1
+                      FROM   strand.event_waits ew
+                      JOIN   strand.task_completions tc ON tc.task_id = ew.child_task_id
+                      WHERE  ew.run_id        = r.id
+                        AND  ew.child_task_id IS NOT NULL
+                  )
+                ORDER BY r.id
+                LIMIT 50
+                FOR UPDATE SKIP LOCKED
+            ),
+            woken AS (
+                UPDATE strand.runs
+                SET state        = \(TaskState.pending),
+                    available_at = NOW(),
+                    lease_expires_at = NULL
+                FROM to_wake
+                WHERE strand.runs.id = to_wake.run_id
+                RETURNING to_wake.run_id, to_wake.task_id
+            )
+            UPDATE strand.tasks
+            SET state = \(TaskState.pending)
+            FROM woken
+            WHERE strand.tasks.id           = woken.task_id
+              AND strand.tasks.namespace_id = \(namespaceID)
+            RETURNING woken.run_id
+            """,
+            logger: logger
+        )
+        var count = 0
+        for try await _ in stream { count += 1 }
+        if count > 0 {
+            logger.debug(
+                "woke \(count) WAITING run(s) with completed children",
+                metadata: ["strand.queue": .string(queue)]
+            )
+        }
     }
 }
 

--- a/Sources/Strand/DB/RowDecoding.swift
+++ b/Sources/Strand/DB/RowDecoding.swift
@@ -71,6 +71,17 @@ struct ClaimedTask: Sendable {
     /// `nil` for the first task in a chain, for child tasks, and for activities.
     let firstTaskID: UUID?
 
+    /// `true` when this workflow's parent closed with `parentClosePolicy = .requestCancel`
+    /// and the framework should deliver a cooperative cancellation by calling
+    /// `handlerTask.cancel()` at the next activation.
+    ///
+    /// When `true`, the activation machinery calls `handlerTask.cancel()` before
+    /// the first `executor.drain()`. This causes `try Task.checkCancellation()` at
+    /// slow-path suspension points (runActivity / sleep / waitForEvent) to throw
+    /// `CancellationError`, which is then handled as cooperative cancellation in
+    /// `applyScheduleCommands`.
+    let cancelRequested: Bool
+
     /// `true` when this attempt is the last one allowed.
     ///
     /// Used to decide whether a thrown error should mark the OTel span `ERROR`.
@@ -88,7 +99,7 @@ extension ClaimedTask {
     /// retry_strategy, max_attempts, headers, wake_event, event_payload,
     /// parent_task_id, kind, timeout_seconds, heartbeat_timeout_seconds,
     /// scheduling_metadata, available_at, heartbeat_details, deadline_at,
-    /// first_task_id
+    /// first_task_id, cancel_requested
     init(row: PostgresRow) throws {
         var col = row.makeIterator()
         runID = try col.next()!.decode(UUID.self, context: .default)
@@ -119,6 +130,7 @@ extension ClaimedTask {
         heartbeatDetails = try col.next()!.decode(ByteBuffer?.self, context: .default)
         deadlineAt = try col.next()!.decode(Date?.self, context: .default)
         firstTaskID = try col.next()!.decode(UUID?.self, context: .default)
+        cancelRequested = try col.next()!.decode(Bool.self, context: .default)
     }
 }
 

--- a/Sources/Strand/DB/WorkflowStateQueries.swift
+++ b/Sources/Strand/DB/WorkflowStateQueries.swift
@@ -355,6 +355,9 @@ package enum WorkflowStateQueries {
         case childWorkflowStarted = "CHILD_WORKFLOW_STARTED"
         case childWorkflowCompleted = "CHILD_WORKFLOW_COMPLETED"
         case eventEmitted = "EVENT_EMITTED"  // ctx.emitEvent(...)
+        /// Workflow closed cooperatively after receiving a REQUEST_CANCEL from its parent.
+        /// Written in `applyScheduleCommands` when the handler exits via `CancellationError`.
+        case workflowCancelled = "WORKFLOW_CANCELLED"
     }
 
     // MARK: - History event data payloads

--- a/Sources/Strand/Internal/WorkflowRegistration.swift
+++ b/Sources/Strand/Internal/WorkflowRegistration.swift
@@ -290,6 +290,16 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
             }
         }
 
+        // Deliver cooperative cancel: if this workflow's parent closed with
+        // parentClosePolicy = .requestCancel, set the activation flag (readable
+        // from condition predicates in the worker-task context) AND cancel the
+        // handler Task (so slow-path try Task.checkCancellation() gates throw
+        // CancellationError natively inside the handler Task).
+        if claimed.cancelRequested {
+            activation.isCancelRequested = true
+            handlerTask.cancel()
+        }
+
         // Run the handler on the serial executor until it either completes or
         // every in-flight task has parked its continuation (pending activity,
         // timer, or event wait).
@@ -397,7 +407,7 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
             }
         }
 
-        // ── Signals ──────────────────────────────────────────────────────────
+        // ── Signals ────────────────────────────────────────────────────
         try await applyAndPersistSignals(to: &stateBox.value, exec: exec, claimed: claimed, historySeq: &historySeq)
 
         // ── Completed children ──────────────────────────────────────────────────
@@ -504,6 +514,15 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
         // If woken without an event name a sleep timer (or condition deadline) fired.
         if claimed.wakeEvent == nil { executor.resumeAllTimers() }
 
+        // Deliver cooperative cancel AFTER resuming real results so already-completed
+        // continuations are delivered first. Set both the activation flag (for condition
+        // predicates) and cancel the handler Task (for slow-path CancellationError gates).
+        // isCancelRequested is sticky — OR with existing value so it is never cleared.
+        if claimed.cancelRequested {
+            activation.isCancelRequested = true
+            cached.task.cancel()
+        }
+
         // ── Drain + conditions ────────────────────────────────────────────────
         executor.drain()
         while executor.resumeExpiredConditions() { executor.drain() }
@@ -542,6 +561,7 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
     /// applies regular signals through `handleSignal`, emits update results as
     /// named events, appends `SIGNAL_RECEIVED` history events, persists the updated
     /// state, and deletes the processed signal rows. No-op when no signals are pending.
+    ///
     private func applyAndPersistSignals(
         to state: inout W,
         exec: _WorkerExec,

--- a/Sources/Strand/Internal/WorkflowScheduling.swift
+++ b/Sources/Strand/Internal/WorkflowScheduling.swift
@@ -64,6 +64,10 @@ extension WorkflowRegistration {
         // Atomicity guarantee: if the transaction fails the next fresh-path activation
         // replays fully — fast-path-1 does not trigger because no checkpoint exists —
         // and both are written correctly on the retry.
+        //
+        // Clears pendingCheckpoints and pendingHistory after a successful commit so that
+        // flushWrites() can be called multiple times (once combined with a state transition
+        // in step 7, once at step 8 for any remaining items) without double-writing.
         func flushWrites() async throws {
             guard !pendingCheckpoints.isEmpty || !pendingHistory.isEmpty else { return }
             try await exec.postgres.withTransaction(logger: exec.logger) { conn in
@@ -105,6 +109,9 @@ extension WorkflowRegistration {
                     )
                 }
             }
+            // Clear after successful commit so double-calling is safe (no duplicate writes).
+            pendingCheckpoints.removeAll()
+            pendingHistory.removeAll()
         }
 
         // Non-suspending writes first — accumulated into pendingCheckpoints and written
@@ -278,6 +285,49 @@ extension WorkflowRegistration {
                 teardownHandler(cache: cache, taskID: claimed.taskID, handlerTask: handlerTask, executor: executor)
                 throw signal
             }
+            // CancellationError means the workflow received a cooperative cancel request
+            // (parentClosePolicy = .requestCancel from a closing parent). The handler
+            // Task was cancelled via handlerTask.cancel(); the first new suspension point
+            // threw CancellationError. Transition to CANCELLED — not FAILED — and
+            // unblock any awaitTaskResult callers.
+            //
+            // Distinct from worker-shutdown CancellationError (which propagates from
+            // applyScheduleCommands' own await points, never reaching this branch).
+            if error is CancellationError {
+                teardownHandler(cache: cache, taskID: claimed.taskID, handlerTask: handlerTask, executor: executor)
+                record(.workflowCancelled, nil)
+                try await flushWrites()
+                // Transition run + task to CANCELLED and wake awaitTaskResult callers.
+                try await exec.postgres.withTransaction(logger: exec.logger) { conn in
+                    try await conn.query(
+                        """
+                        WITH r AS (
+                            UPDATE strand.runs
+                            SET state = \(TaskState.cancelled), finished_at = NOW()
+                            WHERE id          = \(claimed.runID)
+                              AND state       = \(TaskState.running)
+                        )
+                        UPDATE strand.tasks
+                        SET state        = \(TaskState.cancelled),
+                            cancelled_at = NOW()
+                        WHERE id          = \(claimed.taskID)
+                          AND state NOT IN (
+                              \(TaskState.completed), \(TaskState.failed), \(TaskState.cancelled)
+                          )
+                        """,
+                        logger: exec.logger
+                    )
+                    try await Queries.emitTaskCompletionSignal(
+                        conn: conn,
+                        namespaceID: exec.namespace,
+                        taskID: claimed.taskID,
+                        state: .cancelled,
+                        resultBuffer: nil,
+                        logger: exec.logger
+                    )
+                }
+                return nil
+            }
             teardownHandler(cache: cache, taskID: claimed.taskID, handlerTask: handlerTask, executor: executor)
             let errData = try? JSON.encode(WorkflowStateQueries.WorkflowFailedData(error: String(describing: error)))
             record(.workflowFailed, errData)
@@ -375,19 +425,32 @@ extension WorkflowRegistration {
                     )
 
                 case .startTimer(let wakeAt, let timerSeqNum):
-                    // Transition run to SLEEPING. Both UPDATEs are one SQL statement
-                    // (data-modifying CTE) so PostgreSQL commits them atomically —
-                    // no explicit BEGIN/COMMIT wrapper needed.
+                    // Transition run to SLEEPING. If signals are already pending (e.g. a
+                    // REQUEST_CANCEL was inserted while this activation was running), go PENDING
+                    // instead so the signal is delivered at the next activation rather than
+                    // waiting until the timer fires.
                     try await exec.postgres.query(
                         """
-                        WITH r AS (
+                        WITH
+                        pending_sigs AS (
+                            SELECT COUNT(*) AS cnt FROM strand.workflow_signals
+                            WHERE task_id     = \(claimed.taskID)
+                              AND namespace_id = \(exec.namespace)
+                        ),
+                        r AS (
                             UPDATE strand.runs
-                            SET state = \(TaskState.sleeping), available_at = \(wakeAt),
+                            SET state        = CASE WHEN (SELECT cnt FROM pending_sigs) > 0
+                                                   THEN \(TaskState.pending)
+                                                   ELSE \(TaskState.sleeping) END,
+                                available_at = CASE WHEN (SELECT cnt FROM pending_sigs) > 0
+                                                   THEN NOW()
+                                                   ELSE \(wakeAt) END,
                                 lease_expires_at = NULL
                             WHERE id = \(claimed.runID)
-                            RETURNING id
+                            RETURNING state
                         )
-                        UPDATE strand.tasks SET state = \(TaskState.sleeping)
+                        UPDATE strand.tasks
+                        SET state = (SELECT state FROM r)
                         WHERE id = \(claimed.taskID)
                         """,
                         logger: exec.logger
@@ -504,21 +567,38 @@ extension WorkflowRegistration {
                             try await conn.notifyWorkers(namespace: exec.namespace, queue: queueName, logger: exec.logger)
                         } else {
                             // Event not yet emitted — set run to WAITING (or SLEEPING for timed waits).
+                            // If signals are already pending (e.g. a REQUEST_CANCEL arrived while
+                            // this activation was running), go PENDING instead so the signal is
+                            // delivered promptly rather than waiting for the event or timer.
                             let availableAt =
                                 timeoutAt ?? Date(timeIntervalSince1970: 32_503_680_000)
                             let runState: TaskState = timeoutAt != nil ? .sleeping : .waiting
                             try await conn.query(
                                 """
-                                WITH r AS (
+                                WITH
+                                pending_sigs AS (
+                                    SELECT COUNT(*) AS cnt FROM strand.workflow_signals
+                                    WHERE task_id     = \(taskID)
+                                      AND namespace_id = \(exec.namespace)
+                                ),
+                                r AS (
                                     UPDATE strand.runs
-                                    SET state        = \(runState),
-                                        available_at  = \(availableAt),
-                                        wake_event    = \(eventName),
+                                    SET state        = CASE WHEN (SELECT cnt FROM pending_sigs) > 0
+                                                           THEN \(TaskState.pending)
+                                                           ELSE \(runState) END,
+                                        available_at  = CASE WHEN (SELECT cnt FROM pending_sigs) > 0
+                                                           THEN NOW()
+                                                           ELSE \(availableAt) END,
+                                        wake_event    = CASE WHEN (SELECT cnt FROM pending_sigs) > 0
+                                                           THEN NULL
+                                                           ELSE \(eventName) END,
                                         event_payload = NULL,
                                         lease_expires_at = NULL
                                     WHERE id = \(runID)
+                                    RETURNING state
                                 )
-                                UPDATE strand.tasks SET state = \(runState)
+                                UPDATE strand.tasks
+                                SET state = (SELECT state FROM r)
                                 WHERE id = \(taskID)
                                 """,
                                 logger: exec.logger
@@ -609,6 +689,13 @@ extension WorkflowRegistration {
             }
         }
 
+        // ── 6–7. State transition + history atomicity invariant ──────────────────────
+        // The run MUST stay RUNNING in Postgres until both checkpoints and history
+        // are durable.  Steps 6 and 7 therefore merge their state-transition SQL
+        // inside the same withTransaction as the checkpoint/history writes, so no
+        // other worker can claim the run before the current activation's writes commit.
+        var needsNotifyAfterFlush = false
+
         // ── 6. Unsatisfied conditions ────────────────────────────────────────────────────
         // Any conditions not satisfied post-drain need a DB state transition so
         // the worker releases this run until a signal or timer wakes it.
@@ -620,91 +707,109 @@ extension WorkflowRegistration {
             let condTaskID = claimed.taskID
             let condRunID = claimed.runID
 
-            // Both branches use the same post-CTE logic: read the final state from
-            // RETURNING, then notify only if PENDING and write history only if
-            // the run actually parked (SLEEPING or WAITING).
-            //
-            // If a signal arrived while the run was RUNNING it couldn't flip the run
-            // directly (the signal UPDATE only matches SLEEPING/WAITING). The
-            // pending_sigs CTE catches that race: if workflow_signals already has rows
-            // for this task we go straight to PENDING rather than parking.
-            let condStateStream: PostgresRowSequence
-            if let wakeAt = executor.conditionMinWakeAt {
-                condStateStream = try await exec.postgres.query(
-                    """
-                    WITH
-                    pending_sigs AS (
-                        SELECT COUNT(*) AS cnt FROM strand.workflow_signals
-                        WHERE task_id = \(condTaskID) AND namespace_id = \(exec.namespace)
-                    ),
-                    run_upd AS (
-                        UPDATE strand.runs
-                        SET state        = CASE WHEN (SELECT cnt FROM pending_sigs) > 0
-                                               THEN \(TaskState.pending)
-                                               ELSE \(TaskState.sleeping) END,
-                            available_at = CASE WHEN (SELECT cnt FROM pending_sigs) > 0
-                                               THEN NOW()
-                                               ELSE \(wakeAt) END,
-                            lease_expires_at = NULL
-                        WHERE id = \(condRunID)
-                        RETURNING state
-                    )
-                    UPDATE strand.tasks
-                    SET state = (SELECT state FROM run_upd)
-                    WHERE id = \(condTaskID)
-                    RETURNING state
-                    """,
-                    logger: exec.logger
-                )
-            } else {
-                condStateStream = try await exec.postgres.query(
-                    """
-                    WITH
-                    pending_sigs AS (
-                        SELECT COUNT(*) AS cnt FROM strand.workflow_signals
-                        WHERE task_id = \(condTaskID) AND namespace_id = \(exec.namespace)
-                    ),
-                    run_upd AS (
-                        UPDATE strand.runs
-                        SET state        = CASE WHEN (SELECT cnt FROM pending_sigs) > 0
-                                               THEN \(TaskState.pending)
-                                               ELSE \(TaskState.waiting) END,
-                            available_at = CASE WHEN (SELECT cnt FROM pending_sigs) > 0
-                                               THEN NOW()
-                                               ELSE available_at END,
-                            lease_expires_at = NULL
-                        WHERE id = \(condRunID)
-                        RETURNING state
-                    )
-                    UPDATE strand.tasks
-                    SET state = (SELECT state FROM run_upd)
-                    WHERE id = \(condTaskID)
-                    RETURNING state
-                    """,
-                    logger: exec.logger
-                )
-            }
-
-            // Read the state the CTE actually wrote.
+            // Run the state transition INSIDE the same transaction as checkpoints+history
+            // (see the step 6–7 comment above for why this is necessary).
             var conditionState: TaskState = .waiting
-            for try await row in condStateStream {
-                var col = row.makeIterator()
-                conditionState = try col.next()!.decode(TaskState.self, context: .default)
+            try await exec.postgres.withTransaction(logger: exec.logger) { conn in
+                // Write checkpoints + history accumulated so far.
+                if !pendingCheckpoints.isEmpty {
+                    try await Queries.batchSetCheckpointsOnConn(
+                        on: conn,
+                        namespaceID: exec.namespace,
+                        taskID: claimed.taskID,
+                        runID: claimed.runID,
+                        checkpoints: pendingCheckpoints,
+                        logger: exec.logger
+                    )
+                    do {
+                        try await Queries.extendClaim(
+                            on: conn,
+                            namespaceID: exec.namespace,
+                            runID: claimed.runID,
+                            extendBySeconds: claimTimeoutSecs,
+                            logger: exec.logger
+                        )
+                    } catch InternalError.cancelled {}
+                }
+                if !pendingHistory.isEmpty {
+                    try await WorkflowStateQueries.batchAppendHistory(
+                        on: conn,
+                        namespaceID: exec.namespace,
+                        taskID: claimed.taskID,
+                        events: pendingHistory,
+                        logger: exec.logger
+                    )
+                }
+                // Condition state transition — runs AFTER history is written in the same txn.
+                // pending_sigs CTE: if a signal arrived while RUNNING, go PENDING immediately
+                // rather than parking (the signal couldn't flip RUNNING runs directly).
+                let condSQL: PostgresRowSequence
+                if let wakeAt = executor.conditionMinWakeAt {
+                    condSQL = try await conn.query(
+                        """
+                        WITH
+                        pending_sigs AS (
+                            SELECT COUNT(*) AS cnt FROM strand.workflow_signals
+                            WHERE task_id = \(condTaskID) AND namespace_id = \(exec.namespace)
+                        ),
+                        run_upd AS (
+                            UPDATE strand.runs
+                            SET state        = CASE WHEN (SELECT cnt FROM pending_sigs) > 0
+                                                   THEN \(TaskState.pending)
+                                                   ELSE \(TaskState.sleeping) END,
+                                available_at = CASE WHEN (SELECT cnt FROM pending_sigs) > 0
+                                                   THEN NOW()
+                                                   ELSE \(wakeAt) END,
+                                lease_expires_at = NULL
+                            WHERE id = \(condRunID)
+                            RETURNING state
+                        )
+                        UPDATE strand.tasks
+                        SET state = (SELECT state FROM run_upd)
+                        WHERE id = \(condTaskID)
+                        RETURNING state
+                        """,
+                        logger: exec.logger
+                    )
+                } else {
+                    condSQL = try await conn.query(
+                        """
+                        WITH
+                        pending_sigs AS (
+                            SELECT COUNT(*) AS cnt FROM strand.workflow_signals
+                            WHERE task_id = \(condTaskID) AND namespace_id = \(exec.namespace)
+                        ),
+                        run_upd AS (
+                            UPDATE strand.runs
+                            SET state        = CASE WHEN (SELECT cnt FROM pending_sigs) > 0
+                                                   THEN \(TaskState.pending)
+                                                   ELSE \(TaskState.waiting) END,
+                                available_at = CASE WHEN (SELECT cnt FROM pending_sigs) > 0
+                                                   THEN NOW()
+                                                   ELSE available_at END,
+                                lease_expires_at = NULL
+                            WHERE id = \(condRunID)
+                            RETURNING state
+                        )
+                        UPDATE strand.tasks
+                        SET state = (SELECT state FROM run_upd)
+                        WHERE id = \(condTaskID)
+                        RETURNING state
+                        """,
+                        logger: exec.logger
+                    )
+                }
+                for try await row in condSQL {
+                    var col = row.makeIterator()
+                    conditionState = try col.next()!.decode(TaskState.self, context: .default)
+                }
             }
+            pendingCheckpoints.removeAll()
+            pendingHistory.removeAll()
 
-            // Notify only when the run went PENDING (signals were waiting).
-            // SLEEPING/WAITING runs don't need a notify — they wake via timer or
-            // the next _sendSignal call.
-            if conditionState == .pending {
-                try await exec.postgres.notifyWorkers(namespace: exec.namespace, queue: exec.queue, logger: exec.logger)
-            }
-
+            if conditionState == .pending { needsNotifyAfterFlush = true }
             // Only record CONDITION_WAITING when the run actually parked.
-            // If pending signals sent us straight to PENDING the workflow never
-            // entered a wait — recording the event would mislead the history view.
-            if conditionState != .pending {
-                record(.conditionWaiting, nil)
-            }
+            if conditionState != .pending { record(.conditionWaiting, nil) }
         }
         // No else branch: if scheduleCommands is empty and no conditions remain,
         // suspension came from sleep/waitForEvent which already wrote its own DB update.
@@ -725,121 +830,143 @@ extension WorkflowRegistration {
             && scheduleCommands.isEmpty
             && !executor.hasUnsatisfiedConditions
         {
-            try await exec.postgres.query(
-                """
-                WITH
-                missed AS (
-                    -- event_waits whose children have already completed but whose
-                    -- wake signal was silently dropped (parent was RUNNING at the time).
-                    -- child_task_id is a typed UUID FK — direct join, no string parsing.
-                    SELECT ew.child_task_id
-                    FROM strand.event_waits ew
-                    JOIN strand.task_completions tc ON tc.task_id = ew.child_task_id
-                    WHERE ew.run_id        = \(claimed.runID)
-                      AND ew.child_task_id IS NOT NULL
-                ),
-                del_orphans AS (
-                    -- Delete the orphaned event_waits immediately so they do not
-                    -- re-trigger a PENDING transition on the NEXT re-activation
-                    -- (which would cause a spin loop: re-activate → no progress →
-                    -- PENDING again, ad infinitum, until the remaining children finish).
-                    DELETE FROM strand.event_waits ew
-                    USING missed m
-                    WHERE ew.run_id        = \(claimed.runID)
-                      AND ew.child_task_id = m.child_task_id
-                ),
-                run_upd AS (
-                    UPDATE strand.runs
-                    SET state            = CASE WHEN (SELECT COUNT(*) FROM missed) > 0 OR has_buffered_completion
-                                               THEN \(TaskState.pending)
-                                               ELSE \(TaskState.waiting) END,
-                        available_at     = CASE WHEN (SELECT COUNT(*) FROM missed) > 0 OR has_buffered_completion
-                                               THEN NOW()
-                                               ELSE available_at END,
-                        has_buffered_completion = FALSE,   -- reset regardless: either consumed (PENDING) or already caught by flag
-                        lease_expires_at = NULL
-                    WHERE id = \(claimed.runID)
-                    RETURNING state
+            // Steps 7+7B are merged with checkpoints+history into one transaction so
+            // the run stays RUNNING in Postgres until all writes are durable.
+            // In Postgres READ COMMITTED, each statement in a transaction gets a fresh
+            // snapshot, so step 7B below can see concurrent task_completions commits that
+            // step 7 missed — same correctness guarantee as the old two-statement approach.
+            try await exec.postgres.withTransaction(logger: exec.logger) { conn in
+                // ── flushWrites content ───────────────────────────────────────────────
+                if !pendingCheckpoints.isEmpty {
+                    try await Queries.batchSetCheckpointsOnConn(
+                        on: conn,
+                        namespaceID: exec.namespace,
+                        taskID: claimed.taskID,
+                        runID: claimed.runID,
+                        checkpoints: pendingCheckpoints,
+                        logger: exec.logger
+                    )
+                    do {
+                        try await Queries.extendClaim(
+                            on: conn,
+                            namespaceID: exec.namespace,
+                            runID: claimed.runID,
+                            extendBySeconds: claimTimeoutSecs,
+                            logger: exec.logger
+                        )
+                    } catch InternalError.cancelled {}
+                }
+                if !pendingHistory.isEmpty {
+                    try await WorkflowStateQueries.batchAppendHistory(
+                        on: conn,
+                        namespaceID: exec.namespace,
+                        taskID: claimed.taskID,
+                        events: pendingHistory,
+                        logger: exec.logger
+                    )
+                }
+                // ── Step 7: partial-completion re-wait ────────────────────────────────
+                try await conn.query(
+                    """
+                    WITH
+                    missed AS (
+                        SELECT ew.child_task_id
+                        FROM strand.event_waits ew
+                        JOIN strand.task_completions tc ON tc.task_id = ew.child_task_id
+                        WHERE ew.run_id        = \(claimed.runID)
+                          AND ew.child_task_id IS NOT NULL
+                    ),
+                    del_orphans AS (
+                        DELETE FROM strand.event_waits ew
+                        USING missed m
+                        WHERE ew.run_id        = \(claimed.runID)
+                          AND ew.child_task_id = m.child_task_id
+                    ),
+                    run_upd AS (
+                        UPDATE strand.runs
+                        SET state            = CASE WHEN (SELECT COUNT(*) FROM missed) > 0 OR has_buffered_completion
+                                                   THEN \(TaskState.pending)
+                                                   ELSE \(TaskState.waiting) END,
+                            available_at     = CASE WHEN (SELECT COUNT(*) FROM missed) > 0 OR has_buffered_completion
+                                                   THEN NOW()
+                                                   ELSE available_at END,
+                            has_buffered_completion = FALSE,
+                            lease_expires_at = NULL
+                        WHERE id = \(claimed.runID)
+                        RETURNING state
+                    )
+                    UPDATE strand.tasks
+                    SET state = (SELECT state FROM run_upd)
+                    WHERE id = \(claimed.taskID)
+                      AND namespace_id = \(exec.namespace)
+                    """,
+                    logger: exec.logger
                 )
-                UPDATE strand.tasks
-                SET state = (SELECT state FROM run_upd)
-                WHERE id = \(claimed.taskID)
-                  AND namespace_id = \(exec.namespace)
-                """,
-                logger: exec.logger
-            )
-            // Notify speculatively: if the run went PENDING (missed > 0) workers should
-            // claim it immediately. If it went WAITING the notification is a spurious
-            // wakeup that costs at most one empty poll — acceptable.
-            try await exec.postgres.notifyWorkers(namespace: exec.namespace, queue: exec.queue, logger: exec.logger)
-
-            // ── 7B. Post-wait snapshot-isolation recovery ───────────────────────────────
-            // Step 7's CTE runs under Postgres snapshot isolation: it cannot see
-            // task_completions rows that committed AFTER step 7's snapshot started.
-            // In the exact race window where a sibling worker commits a child
-            // completion concurrently with step 7, the run goes WAITING with no
-            // further signal to ever wake it — stuck forever.
-            //
-            // This follow-up query executes as a NEW statement (READ COMMITTED —
-            // fresh snapshot) and therefore sees all concurrent commits that step 7
-            // missed.  If any remaining event_wait children have now completed,
-            // flip WAITING → PENDING and notify.
-            //
-            // del_orphans here serves the same spin-loop prevention role as in step 7.
-            let recoveryStream = try await exec.postgres.query(
-                """
-                WITH
-                missed AS (
-                    SELECT ew.child_task_id
-                    FROM strand.event_waits ew
-                    JOIN strand.task_completions tc ON tc.task_id = ew.child_task_id
-                    WHERE ew.run_id        = \(claimed.runID)
-                      AND ew.child_task_id IS NOT NULL
-                ),
-                del_orphans AS (
-                    DELETE FROM strand.event_waits ew
-                    USING missed m
-                    WHERE ew.run_id        = \(claimed.runID)
-                      AND ew.child_task_id = m.child_task_id
-                ),
-                run_upd AS (
-                    UPDATE strand.runs
-                    SET state        = \(TaskState.pending),
-                        available_at = NOW(),
-                        lease_expires_at = NULL
-                    WHERE id    = \(claimed.runID)
-                      AND state = \(TaskState.waiting)
-                      AND (SELECT COUNT(*) FROM missed) > 0
-                    RETURNING id
+                // ── Step 7B: snapshot-isolation recovery ────────────────────────────
+                // Each statement in a READ COMMITTED transaction gets a fresh snapshot,
+                // so this sees task_completions rows committed concurrently with step 7.
+                let recoveryStream = try await conn.query(
+                    """
+                    WITH
+                    missed AS (
+                        SELECT ew.child_task_id
+                        FROM strand.event_waits ew
+                        JOIN strand.task_completions tc ON tc.task_id = ew.child_task_id
+                        WHERE ew.run_id        = \(claimed.runID)
+                          AND ew.child_task_id IS NOT NULL
+                    ),
+                    del_orphans AS (
+                        DELETE FROM strand.event_waits ew
+                        USING missed m
+                        WHERE ew.run_id        = \(claimed.runID)
+                          AND ew.child_task_id = m.child_task_id
+                    ),
+                    run_upd AS (
+                        UPDATE strand.runs
+                        SET state        = \(TaskState.pending),
+                            available_at = NOW(),
+                            lease_expires_at = NULL
+                        WHERE id    = \(claimed.runID)
+                          AND state = \(TaskState.waiting)
+                          AND (SELECT COUNT(*) FROM missed) > 0
+                        RETURNING id
+                    )
+                    UPDATE strand.tasks
+                    SET state = \(TaskState.pending)
+                    FROM run_upd
+                    WHERE strand.tasks.id           = \(claimed.taskID)
+                      AND strand.tasks.namespace_id = \(exec.namespace)
+                    RETURNING strand.tasks.id
+                    """,
+                    logger: exec.logger
                 )
-                UPDATE strand.tasks
-                SET state = \(TaskState.pending)
-                FROM run_upd
-                WHERE strand.tasks.id           = \(claimed.taskID)
-                  AND strand.tasks.namespace_id = \(exec.namespace)
-                RETURNING strand.tasks.id
-                """,
-                logger: exec.logger
-            )
-            if try await recoveryStream.first(where: { _ in true }) != nil {
-                exec.logger.debug(
-                    "partial-completion recovery: snapshot-isolation race detected — run set to PENDING",
-                    metadata: [
-                        "strand.task_id": .stringConvertible(claimed.taskID),
-                        "strand.run_id": .stringConvertible(claimed.runID),
-                    ]
-                )
-                try await exec.postgres.notifyWorkers(namespace: exec.namespace, queue: exec.queue, logger: exec.logger)
+                if try await recoveryStream.first(where: { _ in true }) != nil {
+                    exec.logger.debug(
+                        "partial-completion recovery: snapshot-isolation race detected — run set to PENDING",
+                        metadata: [
+                            "strand.task_id": .stringConvertible(claimed.taskID),
+                            "strand.run_id": .stringConvertible(claimed.runID),
+                        ]
+                    )
+                }
             }
+            pendingCheckpoints.removeAll()
+            pendingHistory.removeAll()
+            needsNotifyAfterFlush = true  // speculative: fires even if run went WAITING
         }
 
         // ── 8. Cache the live Task for the next activation ───────────────────────────
-        // The handler is parked on a continuation — do NOT call cancelPending().
-        // On the next activation, resumeActivation() delivers real results directly
-        // to those continuations and calls drain() to continue from where it paused.
+        // ── 8. Flush writes, then cache, then notify ─────────────────────────────────────────
+        // ORDER MATTERS:
+        //   1. flushWrites() commits checkpoints + history atomically.
+        //   2. cache.set() stores the live handler Task.
+        //   3. notifyWorkers() fires LAST — only after history is durable.
         //
-        // For the cached path: cache.set is idempotent — it simply refreshes the
-        // same references already stored from the previous activation.
+        // Sending pg_notify before flushWrites would let another worker claim
+        // the PENDING run, read the same nextHistorySeq(), and commit first.
+        // This activation's batchAppendHistory would then hit ON CONFLICT DO NOTHING,
+        // silently dropping history while the checkpoint UPSERT still succeeded —
+        // producing the checkpoint-without-history inconsistency.
         try await flushWrites()
         cache.set(
             claimed.taskID,
@@ -851,6 +978,17 @@ extension WorkflowRegistration {
                 activation: activation
             )
         )
+
+        // Fire deferred notifications now that history is committed.
+        // This is the last operation — another worker can safely claim
+        // the run and call nextHistorySeq() without racing this activation.
+        if needsNotifyAfterFlush {
+            try await exec.postgres.notifyWorkers(
+                namespace: exec.namespace,
+                queue: exec.queue,
+                logger: exec.logger
+            )
+        }
 
         return nil
     }

--- a/Sources/Strand/Worker.swift
+++ b/Sources/Strand/Worker.swift
@@ -504,7 +504,24 @@ public struct StrandWorker: Service {
                     continue
                 }
 
-                // ── Claim up to `free` tasks ───────────────────────────────────
+                // ── Claim up to `free` tasks ──────────────────────────────
+                // Transition WAITING runs whose children have completed to PENDING
+                // so they are immediately eligible for the claimTasks call below.
+                // Errors are non-fatal: a transient failure is retried on the next
+                // poll tick without affecting the claim path.
+                do {
+                    try await Queries.wakeCompletedWaiting(
+                        on: postgres,
+                        namespaceID: namespace,
+                        queue: queueName,
+                        logger: logger
+                    )
+                } catch {
+                    logger.warning(
+                        "wakeCompletedWaiting failed",
+                        metadata: .forError(error) + ["strand.queue": .string(queueName)]
+                    )
+                }
                 let claimed: [ClaimedTask]
                 do {
                     claimed = try await Queries.claimTasks(

--- a/Sources/Strand/WorkflowContext.swift
+++ b/Sources/Strand/WorkflowContext.swift
@@ -168,6 +168,16 @@ final class _WorkflowActivation<W: Workflow>: @unchecked Sendable {
     /// Updated by WorkflowContext public functions; read by activate() on handler failure.
     var lastCallSite: (fileID: String, line: Int)? = nil
 
+    /// Set to `true` when `claimed.cancelRequested` is set at activation start.
+    ///
+    /// Needed as a separate flag (not just `Task.isCancelled`) because condition
+    /// predicates are evaluated in the worker-task context after `drain()` returns,
+    /// not inside the handler Task. `Task.isCancelled` would always be `false` there.
+    /// The activation paths set this from `claimed.cancelRequested` and also call
+    /// `handlerTask.cancel()` so that slow-path `try Task.checkCancellation()` gates
+    /// in `runActivity`/`sleep`/`waitForEvent` throw natively inside the handler Task.
+    var isCancelRequested: Bool = false
+
     // MARK: - Init
 
     init(
@@ -382,6 +392,30 @@ public struct WorkflowContext<W: Workflow>: Sendable {
     /// ```
     public var historyEventCount: Int { _impl.historyEventCount }
 
+    /// Returns `true` when this workflow has received a cooperative cancellation request
+    /// from its parent workflow (i.e. the parent closed with
+    /// `ChildWorkflowOptions.parentClosePolicy = .requestCancel`).
+    ///
+    /// The flag is set at activation start when the claimed run has `cancel_requested = true`.
+    /// It is sticky — once set it is never cleared for the lifetime of this workflow.
+    ///
+    /// Two mechanisms work together:
+    /// - **`isCancelRequested` flag** (this property): readable from `condition` predicates,
+    ///   which run in the worker-task context outside the handler Task.
+    /// - **`handlerTask.cancel()`**: causes `try Task.checkCancellation()` gates at
+    ///   slow-path suspension points in `runActivity`, `sleep`, and `waitForEvent` to throw
+    ///   `CancellationError` natively inside the handler Task.
+    ///
+    /// Use in `condition` to detect and respond to the request gracefully:
+    /// ```swift
+    /// try await context.condition({ _ in context.isCancelRequested })
+    /// // perform cleanup, then return normally
+    /// ```
+    ///
+    /// Unlike hard `cancelTask()`, `requestCancel` is fully cooperative:
+    /// the workflow continues running until it returns or throws.
+    public var isCancelRequested: Bool { _impl.isCancelRequested }
+
     /// Scheduling metadata injected by ``StrandScheduler`` when this workflow was
     /// triggered by a schedule. `nil` when enqueued directly via ``StrandClient``.
     ///
@@ -524,6 +558,10 @@ public struct WorkflowContext<W: Workflow>: Sendable {
         }
 
         // ── Slow path: activity not yet complete — emit command and suspend ─────────────
+        // Guard: if this workflow has been cooperative-cancelled (requestCancel policy),
+        // throw CancellationError here rather than scheduling a new activity that would
+        // never be needed. Fast paths above are unaffected — already-completed work replays.
+        try Task.checkCancellation()
         let inputBuffer = try JSON.encode(input)
         // Use caller-supplied ID if set; otherwise derive a stable key from
         // the workflow task UUID and call-site sequence number.
@@ -743,6 +781,8 @@ public struct WorkflowContext<W: Workflow>: Sendable {
         }
 
         // Slow path: timer not yet elapsed — suspend via continuation.
+        // Guard: don't start new timers when cooperatively cancelled.
+        try Task.checkCancellation()
         _impl.executor.emit(.startTimer(wakeAt: resolvedWakeAt, seqNum: seqNum))
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
             _impl.executor.suspendTimer(seqNum: seqNum, continuation: cont)
@@ -864,6 +904,8 @@ public struct WorkflowContext<W: Workflow>: Sendable {
         }
 
         // ── Slow path: event not yet received — emit command and suspend ──────────
+        // Guard: don't register new event waits when cooperatively cancelled.
+        try Task.checkCancellation()
         let predicateBuf: ByteBuffer? = try predicate.flatMap { p in
             ByteBuffer(bytes: try p.toJSONBytes())
         }

--- a/Sources/Strand/WorkflowContext.swift
+++ b/Sources/Strand/WorkflowContext.swift
@@ -399,22 +399,57 @@ public struct WorkflowContext<W: Workflow>: Sendable {
     /// The flag is set at activation start when the claimed run has `cancel_requested = true`.
     /// It is sticky — once set it is never cleared for the lifetime of this workflow.
     ///
-    /// Two mechanisms work together:
-    /// - **`isCancelRequested` flag** (this property): readable from `condition` predicates,
-    ///   which run in the worker-task context outside the handler Task.
-    /// - **`handlerTask.cancel()`**: causes `try Task.checkCancellation()` gates at
-    ///   slow-path suspension points in `runActivity`, `sleep`, and `waitForEvent` to throw
-    ///   `CancellationError` natively inside the handler Task.
-    ///
-    /// Use in `condition` to detect and respond to the request gracefully:
+    /// Prefer ``waitForCancellation()`` over checking this property inline; reserve
+    /// `isCancelRequested` for mixing with other conditions:
     /// ```swift
-    /// try await context.condition({ _ in context.isCancelRequested })
-    /// // perform cleanup, then return normally
+    /// try await context.condition { $0.isPaused || context.isCancelRequested }
     /// ```
     ///
     /// Unlike hard `cancelTask()`, `requestCancel` is fully cooperative:
     /// the workflow continues running until it returns or throws.
     public var isCancelRequested: Bool { _impl.isCancelRequested }
+
+    /// Suspends the workflow until the parent requests cooperative cancellation
+    /// (`ChildWorkflowOptions.parentClosePolicy = .requestCancel`).
+    ///
+    /// **This call suspends the entire handler.** The workflow parks in `WAITING`
+    /// state and no activities can run until `isCancelRequested` is set.  Only
+    /// use it in one of two situations:
+    ///
+    /// **1. Pure waiting workflow** — the workflow's only job is to wait:
+    /// ```swift
+    /// try await context.waitForCancellation()
+    /// return .cleanedUp
+    /// ```
+    ///
+    /// **2. Racing inside a task group** — unblocks as soon as cancel arrives,
+    /// aborting concurrent activities:
+    /// ```swift
+    /// try await withThrowingTaskGroup(of: ...) { group in
+    ///     for item in items {
+    ///         group.addTask { try await context.runActivity(..., input: item) }
+    ///     }
+    ///     group.addTask {
+    ///         try await context.waitForCancellation()
+    ///         throw CancellationError()   // abort the group
+    ///     }
+    ///     for try await result in group { ... }
+    /// }
+    /// ```
+    ///
+    /// **For sequential activity pipelines, use an inline check instead** —
+    /// it is synchronous (no suspension) and lets you return a meaningful result:
+    /// ```swift
+    /// let charge = try await context.runActivity(ChargePayment.self, input: ...)
+    /// if context.isCancelRequested { return .cancelled }   // ← zero-cost check
+    /// let fulfillment = try await context.runActivity(FulfillOrder.self, input: ...)
+    /// ```
+    public func waitForCancellation() async throws {
+        // Capture `_impl` (the class reference) so the closure reads the live
+        // value of `isCancelRequested` on each evaluation, not a snapshot.
+        let impl = _impl
+        try await condition { _ in impl.isCancelRequested }
+    }
 
     /// Scheduling metadata injected by ``StrandScheduler`` when this workflow was
     /// triggered by a schedule. `nil` when enqueued directly via ``StrandClient``.

--- a/Tests/StrandTests/ChildWorkflowTests.swift
+++ b/Tests/StrandTests/ChildWorkflowTests.swift
@@ -80,10 +80,132 @@ private struct SameQueueParentWorkflow: Workflow {
     }
 }
 
+// ── 5. RequestCancelChild / RequestCancelParent ───────────────────────────
+// Child workflow: suspends in `context.condition` until `context.isCancelRequested`
+// is set by the framework (cooperative cancel from parent) or the timeout fires.
+// Returns "cancelled" when the cancel signal arrives, "timeout" otherwise.
+// Used by: parentClosePolicyRequestCancelDeliversSignal.
+
+private struct RequestCancelChildWorkflow: Workflow {
+    typealias Input = StrandVoid
+    typealias Output = String
+
+    mutating func run(
+        context: WorkflowContext<Self>,
+        input: StrandVoid
+    ) async throws -> String {
+        // Wait for the cooperative cancel signal (parent closed with .requestCancel).
+        // The predicate captures `context` whose _impl is the same _WorkflowActivation
+        // class instance across all activations — mutations to isCancelRequested are
+        // immediately visible when the condition is re-evaluated after signal delivery.
+        let met = try await context.condition(
+            { _ in context.isCancelRequested },
+            timeout: .seconds(10)
+        )
+        return met ? "cancelled" : "timeout"
+    }
+}
+
+// Parent: starts the child with .requestCancel policy and suspends waiting for it.
+// The test cancels the parent externally via `client.cancelTask`, which triggers
+// `cancelDescendants` and delivers the cooperative cancel signal to the child.
+private struct WaitForCancelableChildWorkflow: Workflow {
+    typealias Input = StrandVoid
+    typealias Output = String
+
+    mutating func run(
+        context: WorkflowContext<Self>,
+        input: StrandVoid
+    ) async throws -> String {
+        try await context.runChildWorkflow(
+            RequestCancelChildWorkflow.self,
+            options: .init(parentClosePolicy: .requestCancel),
+            input: StrandVoid()
+        )
+    }
+}
+
 // MARK: - Test suite
 
 @Suite("Integration — Child workflows", .tags(.integration), .serialized)
 struct ChildWorkflowTests {
+
+    // ── 0 ────────────────────────────────────────────────────────────────────────────
+    // `parentClosePolicy = .requestCancel` delivers the cooperative cancel signal when
+    // the parent is cancelled externally.
+    //
+    // Flow:
+    //   1. Start WaitForCancelableChildWorkflow (parent) which spawns RequestCancelChildWorkflow
+    //      (child) and suspends in WAITING state.
+    //   2. Child suspends in `context.condition({ _ in context.isCancelRequested })`.
+    //   3. Test cancels the parent via `cancelTask` which calls `cancelDescendants`:
+    //      - `cancelDescendants` sets `cancel_requested = TRUE` on the child's task row
+    //      - Wakes the child's WAITING run to PENDING
+    //   4. Worker claims child; `claimed.cancelRequested = true`:
+    //      - activation sets `activation.isCancelRequested = true` (for conditions)
+    //      - calls `handlerTask.cancel()` (for slow-path CancellationError gates)
+    //   5. `evaluateAndResumeFirstSatisfiedCondition` re-evaluates `{ _ in context.isCancelRequested }`
+    //      → returns `true` → condition satisfied → child returns "cancelled".
+    //   6. Test asserts the child's result is "cancelled".
+    @Test("parentClosePolicy .requestCancel delivers cooperative cancel signal and child returns gracefully")
+    func parentClosePolicyRequestCancelDeliversSignal() async throws {
+        try await withTestEnvironment { client in
+            let workerTask = startWorker(
+                postgres: client.postgres,
+                queueName: client.queueName,
+                logger: client.logger,
+                workflows: [
+                    WaitForCancelableChildWorkflow.self,
+                    RequestCancelChildWorkflow.self,
+                ]
+            )
+            defer { workerTask.cancel() }
+
+            // 1. Start the parent workflow.
+            let parentHandle = try await client.startWorkflow(
+                WaitForCancelableChildWorkflow.self,
+                options: .init(maxAttempts: 1),
+                input: StrandVoid()
+            )
+
+            // 2. Wait until the child task appears in the DB (parent has run at
+            //    least one activation and enqueued the child).
+            var childTaskID: UUID? = nil
+            for _ in 0..<50 {
+                let page = try await ManagementQueries.listChildTasks(
+                    on: client.postgres,
+                    namespaceID: "default",
+                    parentTaskID: parentHandle.taskID,
+                    cursor: nil,
+                    limit: 10,
+                    logger: client.logger
+                )
+                if let child = page.items.first {
+                    childTaskID = child.id
+                    break
+                }
+                try await Task.sleep(for: .milliseconds(200))
+            }
+            guard let childTaskID else {
+                Issue.record("child task never appeared in DB — parent did not start the child")
+                return
+            }
+
+            // 3. Cancel the parent. `cancelDescendants` runs atomically inside
+            //    `cancelTask`, delivering the cooperative cancel signal to the child
+            //    and waking its WAITING run to PENDING.
+            try await client.cancelTask(id: parentHandle.taskID)
+
+            // 4. Await the child's result. The child sees `isCancelRequested = true`,
+            //    its condition is satisfied, and it returns "cancelled" cooperatively.
+            let childResult = try await client.awaitTaskResult(
+                id: childTaskID,
+                as: String.self,
+                options: .init(timeout: .seconds(15))
+            )
+            #expect(childResult == "cancelled")
+        }
+    }
 
     // ── 1 ───────────────────────────────────────────────────────────────────
     // A single worker serves both the parent orchestrator and the child workflow

--- a/Tests/StrandTests/ChildWorkflowTests.swift
+++ b/Tests/StrandTests/ChildWorkflowTests.swift
@@ -94,15 +94,9 @@ private struct RequestCancelChildWorkflow: Workflow {
         context: WorkflowContext<Self>,
         input: StrandVoid
     ) async throws -> String {
-        // Wait for the cooperative cancel signal (parent closed with .requestCancel).
-        // The predicate captures `context` whose _impl is the same _WorkflowActivation
-        // class instance across all activations — mutations to isCancelRequested are
-        // immediately visible when the condition is re-evaluated after signal delivery.
-        let met = try await context.condition(
-            { _ in context.isCancelRequested },
-            timeout: .seconds(10)
-        )
-        return met ? "cancelled" : "timeout"
+        // Block until the parent requests cooperative cancellation.
+        try await context.waitForCancellation()
+        return "cancelled"
     }
 }
 

--- a/strand.sql
+++ b/strand.sql
@@ -238,6 +238,7 @@ CREATE TABLE IF NOT EXISTS strand.tasks (
     heartbeat_timeout_seconds INTEGER,        -- max seconds between heartbeats; NULL = claimTimeout
     schedule_to_start_timeout_seconds INTEGER, -- max seconds waiting in queue before failing; NULL = no cap
     parent_close_policy TEXT,                  -- TERMINATE|ABANDON|REQUEST_CANCEL; NULL = TERMINATE (default)
+    cancel_requested    BOOLEAN NOT NULL DEFAULT FALSE,  -- set by cancelDescendants when parent closes with REQUEST_CANCEL
     idempotency_key TEXT,
 
     -- Dispatch routing


### PR DESCRIPTION
## Summary

Added cooperative cancellation and fix and issue where span history could be missing data

## Changes

- Cooperative cancellation
- Fixed Span skip write
- Update ProcessWorkflow example

## Testing

<!-- How did you verify this works? Did you run `swift test`? -->

- [x] `swift test` passes locally

## AI Disclosure

<!--
  REQUIRED if any AI assistance was used — see CONTRIBUTING.md.
  Delete this section entirely if no AI was involved.
-->

- [ ] I used AI assistance while working on this PR

**Tool(s) used:** <!-- e.g. Claude, Copilot, ChatGPT -->

**Extent of use:**
<!-- Describe honestly. Examples:
  - Generated first draft of WorkflowDag.tsx, reviewed and edited manually.
  - Used for commit message suggestions only.
  - Pair-programmed the entire feature; all output was reviewed.
-->

**Was the PR description itself AI-generated?** No
