### PR TITLE
Add activity rate-limiting and slot allocator

### DIFF
--- a/Examples/Sources/GroundwaterPipeline/GroundwaterPipelineExample.swift
+++ b/Examples/Sources/GroundwaterPipeline/GroundwaterPipelineExample.swift
@@ -53,6 +53,11 @@ import Foundation
         let chunkSize = Int(env["CHUNK_SIZE"] ?? "50000") ?? 50_000
         let maxChunks = env["MAX_CHUNKS"].flatMap(Int.init)
         let runAI = (env["RUN_AI"] ?? "true").lowercased() != "false"
+        // CNRA.cnraDownloadRPS and CNRA.ollamaRPS are read lazily from env at first
+        // use; reference them here just to trigger eager initialisation so they
+        // appear in the startup banner below.
+        let downloadRPS = CNRA.cnraDownloadRPS
+        let ollamaRPS   = CNRA.ollamaRPS
         // RESUME_ONLY=true: start workers to continue existing in-flight
         // pipelines without spawning a new one. Use after a crash or Ctrl+C.
         let resumeOnly = (env["RESUME_ONLY"] ?? "false").lowercased() == "true"
@@ -167,6 +172,10 @@ import Foundation
                       Max chunks: \(maxChunks.map(String.init) ?? "all (~125)")
                       AI stage:   \(runAI ? "enabled (requires Ollama + qwen3)" : "disabled")
                       Job ID:     \(input.jobID)
+                    ─────────────────────────────────────────
+                      Rate limits (Strand slot scheduling):
+                        CNRA API: \(String(format: "%.1f", downloadRPS)) downloads/s  (CNRA_DOWNLOAD_RPS)
+                        Ollama:   \(String(format: "%.3g", ollamaRPS)) req/s           (OLLAMA_RPS)
                     ─────────────────────────────────────────
                     """
                 )

--- a/Examples/Sources/GroundwaterPipeline/Types.swift
+++ b/Examples/Sources/GroundwaterPipeline/Types.swift
@@ -14,6 +14,35 @@ enum CNRA {
     static let apiBase = "https://data.cnra.ca.gov/api/3/action/datastore_search"
     static let ollamaURL = "http://localhost:11434"
     static let ollamaModel = "qwen3"
+
+    // MARK: - Rate limits (tunable via environment variables)
+
+    /// Maximum chunk downloads started per second against the public CNRA CKAN API.
+    ///
+    /// CNRA doesn't publish a hard rate limit, but flooding a government data portal
+    /// with 125 simultaneous downloads is bad citizenship. Five per second spreads
+    /// the 125-chunk fan-out over ~25 s while still saturating the 20-worker pool.
+    ///
+    /// Override: `CNRA_DOWNLOAD_RPS=10 swift run GroundwaterPipeline`
+    static let cnraDownloadRPS: Double = {
+        let env = ProcessInfo.processInfo.environment
+        return env["CNRA_DOWNLOAD_RPS"].flatMap(Double.init) ?? 5.0
+    }()
+
+    /// Maximum Ollama requests released to the worker pool per second.
+    ///
+    /// Ollama runs on a single GPU thread — it processes requests sequentially.
+    /// With 58 counties all becoming claimable at once, the 5 gw-ai workers grab
+    /// them in bursts and Ollama's internal queue fills up with partially-processed
+    /// context windows, wasting VRAM. Releasing 1 request per 10 s paces the
+    /// pipeline to Ollama's actual throughput (~10–30 s per county on qwen3:8b),
+    /// keeping the queue short and memory pressure low.
+    ///
+    /// Override: `OLLAMA_RPS=0.5 swift run GroundwaterPipeline`
+    static let ollamaRPS: Double = {
+        let env = ProcessInfo.processInfo.environment
+        return env["OLLAMA_RPS"].flatMap(Double.init) ?? 0.1  // 1 request / 10 s
+    }()
 }
 
 // MARK: - Pipeline workflow I/O

--- a/Examples/Sources/GroundwaterPipeline/Workflows/AIAnalysisWorkflow.swift
+++ b/Examples/Sources/GroundwaterPipeline/Workflows/AIAnalysisWorkflow.swift
@@ -19,8 +19,11 @@ struct AIAnalysisOutput: Codable, Sendable {
 ///   - trend classification: DECLINING | STABLE | RECOVERING | UNKNOWN
 ///   - 2-sentence narrative for non-technical stakeholders
 ///
-/// Rate limiting: the `gw-ai` queue has lower concurrency (5 workflows)
-/// so Ollama isn't overwhelmed with 58 simultaneous requests.
+/// Rate limiting: `CNRA.ollamaRPS` (default 0.1 req/s = 1 per 10 s) controls
+/// how quickly county analyses enter the claimable pool.  This is qualitatively
+/// different from queue concurrency: even if 5 gw-ai workers are idle, analyses
+/// are released one-at-a-time at the Ollama-native pace rather than all 58 at
+/// once.  Adjust `OLLAMA_RPS` to match your hardware's throughput.
 struct AIAnalysisWorkflow: Workflow {
     typealias Input = AIAnalysisInput
     typealias Output = AIAnalysisOutput
@@ -59,7 +62,14 @@ struct AIAnalysisWorkflow: Workflow {
                             earliestMsmt: stats.earliestMsmt,
                             latestMsmt: stats.latestMsmt
                         ),
-                        options: ActivityOptions(maxAttempts: 2)
+                        options: ActivityOptions(
+                            maxAttempts: 2,
+                            // Pace Ollama calls to its single-threaded processing speed.
+                            // Each county uses the same global key so all 58 analyses
+                            // share one slot bucket — activities are released one-by-one
+                            // at `ollamaRPS` regardless of worker concurrency.
+                            rateLimit: .init(limit: CNRA.ollamaRPS, period: .seconds(1))
+                        )
                     )
                 }
             }

--- a/Examples/Sources/GroundwaterPipeline/Workflows/GroundwaterPipelineWorkflow.swift
+++ b/Examples/Sources/GroundwaterPipeline/Workflows/GroundwaterPipelineWorkflow.swift
@@ -21,7 +21,9 @@ import Foundation
 /// Stage 3 — AI  (gw-ai)
 ///   AIAnalysisWorkflow fans out Ollama (qwen3) to every county.
 ///   Classifies trend (DECLINING/STABLE/RECOVERING) + writes narrative.
-///   Rate-limited to 5 concurrent requests so Ollama isn't overwhelmed.
+///   Rate-limited via ActivityOptions.rateLimit (OLLAMA_RPS, default 0.1/s)
+///   so activities enter the claimable pool at Ollama’s native pace, not all
+///   at once.  Queue concurrency (5 workflows) caps simultaneous executions.
 ///
 /// Crash recovery:
 ///   Each stage is a child workflow. If the orchestrator process crashes

--- a/Examples/Sources/GroundwaterPipeline/Workflows/IngestChunkWorkflow.swift
+++ b/Examples/Sources/GroundwaterPipeline/Workflows/IngestChunkWorkflow.swift
@@ -11,6 +11,10 @@ import Strand
 ///   - Line-by-line CSV parsing
 ///   - Batched bulk insert (200 rows/transaction)
 ///   - heartbeat() every 1 000 rows to keep the lease alive
+///
+/// Rate limiting: `CNRA.cnraDownloadRPS` (default 5/s) controls how quickly
+/// the 125-chunk fan-out is released to the worker pool.  This prevents
+/// flooding the public CNRA API regardless of how many workers are running.
 struct IngestChunkWorkflow: Workflow {
     typealias Input = IngestChunkInput
     typealias Output = IngestChunkOutput
@@ -22,11 +26,15 @@ struct IngestChunkWorkflow: Workflow {
         try await context.runActivity(
             DownloadAndInsertActivity.self,
             input: input,
-            // 3 retries with exponential backoff — handles transient CNRA API hiccups.
-            // startToCloseTimeout mirrors the activity's own URLSession timeout (600s).
             options: ActivityOptions(
                 maxAttempts: 3,
-                retryStrategy: .backoff(initial: .seconds(10), multiplier: 2, cap: .seconds(120))
+                retryStrategy: .backoff(initial: .seconds(10), multiplier: 2, cap: .seconds(120)),
+                // Rate-limit CNRA API calls.  `available_at` is staggered by
+                // Strand's slot allocator so at most `cnraDownloadRPS` new
+                // downloads enter the claimable pool each second — even when
+                // 125 chunks are enqueued simultaneously.  The global key (nil)
+                // means ALL chunk downloads share one bucket across every worker.
+                rateLimit: .init(limit: CNRA.cnraDownloadRPS, period: .seconds(1))
             )
         )
     }

--- a/Sources/Strand/Activity.swift
+++ b/Sources/Strand/Activity.swift
@@ -75,6 +75,68 @@ extension ActivityCancellationType: PostgresCodable {
     }
 }
 
+// MARK: - RateLimit
+
+/// Leaky-bucket rate limit for an activity.  When set, each enqueue atomically
+/// claims a time slot; the run waits in PENDING until its slot arrives.
+///
+/// Only enforced when explicitly set — `nil` (the default) means no rate limit
+/// and the activity is enqueued at full speed, exactly as without this option.
+///
+/// - `limit` / `period`: together define the slot interval.
+///   `.init(limit: 10, period: .seconds(1))` → one slot every 100 ms.
+///   `.init(limit: 2, period: .minutes(1))` → one slot every 30 s.
+///
+/// - `key`: optional partition key that gives each entity its own independent
+///   bucket.  `nil` = one global bucket shared by all executions of this
+///   activity type on this queue.  Use the workflow's own computed value —
+///   there is no server-side expression language; Swift code is the expression.
+///
+/// ```swift
+/// // Global: 10 payment activities per second across all customers
+/// options: .init(rateLimit: .init(limit: 10, period: .seconds(1)))
+///
+/// // Per-customer: 2 enrichment calls per minute per customer ID
+/// options: .init(
+///     rateLimit: .init(limit: 2, period: .minutes(1), key: "customer:\(customerID)")
+/// )
+/// ```
+public struct RateLimit: Sendable {
+    /// Maximum executions allowed within `period`.
+    public var limit: Double
+    /// Time window over which `limit` applies. Default: `.seconds(1)`.
+    public var period: Duration
+    /// Optional partition key.  `nil` = one global bucket for this activity
+    /// type on this queue.  A non-nil value gives each entity its own bucket.
+    public var key: String?
+
+    /// Returns `nil` when `limit` is not positive; no crash.
+    public init?(limit: Double, period: Duration = .seconds(1), key: String? = nil) {
+        guard limit > 0 else { return nil }
+        self.limit = limit
+        self.period = period
+        self.key = key
+    }
+
+    // MARK: - Internal
+
+    /// Slot-allocation parameters for the `strand.rate_limit_slots` SQL.
+    ///
+    /// - Parameter activityName: the activity's registered name.
+    ///   Used as the bucket prefix when `key` is `nil` (global bucket),
+    ///   or as the prefix in `"ActivityName:entityKey"` (per-entity bucket).
+    /// - Returns: `slotKey` — the row key in `strand.rate_limit_slots`;
+    ///   `intervalMs` — milliseconds between consecutive slots,
+    ///   derived from `period / limit` and clamped to at least 1 ms.
+    internal func slotParams(for activityName: String) -> (slotKey: String, intervalMs: Int) {
+        let slotKey = key.map { "\(activityName):\($0)" } ?? activityName
+        let totalMs = period.components.seconds * 1_000
+                    + period.components.attoseconds / 1_000_000_000_000_000
+        let intervalMs = max(1, Int(Double(totalMs) / limit))
+        return (slotKey: slotKey, intervalMs: intervalMs)
+    }
+}
+
 // MARK: - ActivityOptions
 
 /// Per-activity execution configuration: timeout, retry, routing, priority, and fairness.
@@ -159,6 +221,14 @@ public struct ActivityOptions: Sendable {
     /// Automatic cancellation policy for this activity.
     public var cancellation: CancellationPolicy?
 
+    /// Rate limit for this activity execution.
+    ///
+    /// When non-nil, each enqueue atomically claims a time slot in
+    /// `strand.rate_limit_slots` and sets the run's `available_at` to that
+    /// slot time.  `nil` (the default) means no rate limiting — the activity
+    /// is enqueued immediately at full speed.
+    public var rateLimit: RateLimit?
+
     public init(
         timeout: Duration? = nil,
         heartbeatTimeout: Duration? = nil,
@@ -173,6 +243,7 @@ public struct ActivityOptions: Sendable {
         headers: [String: String] = [:],
         id: String? = nil,
         cancellation: CancellationPolicy? = nil,
+        rateLimit: RateLimit? = nil,
         scheduleToStartTimeout: Duration? = nil,
         cancellationType: ActivityCancellationType = .tryCancel
     ) {
@@ -189,6 +260,7 @@ public struct ActivityOptions: Sendable {
         self.headers = headers
         self.id = id
         self.cancellation = cancellation
+        self.rateLimit = rateLimit
         self.scheduleToStartTimeout = scheduleToStartTimeout
         self.cancellationType = cancellationType
     }

--- a/Sources/Strand/Client.swift
+++ b/Sources/Strand/Client.swift
@@ -59,7 +59,8 @@ public struct StrandClient: Sendable {
         params: P,
         options enqueueOpts: EnqueueOptions = .init()
     ) async throws -> EnqueueResult {
-        try await _enqueue(
+        let rlParams = enqueueOpts.rateLimit.map { $0.slotParams(for: taskName) }
+        return try await _enqueue(
             queue: enqueueOpts.queue ?? queueName,
             taskName: taskName,
             params: params,
@@ -72,7 +73,9 @@ public struct StrandClient: Sendable {
             delayUntil: enqueueOpts.delayUntil,
             maxDuration: enqueueOpts.maxDuration,
             fairnessKey: enqueueOpts.fairnessKey,
-            fairnessWeight: enqueueOpts.fairnessWeight
+            fairnessWeight: enqueueOpts.fairnessWeight,
+            rateLimitKey: rlParams?.slotKey,
+            rateLimitIntervalMs: rlParams?.intervalMs
         )
     }
 
@@ -99,7 +102,8 @@ public struct StrandClient: Sendable {
         input: A.Input,
         options: ActivityOptions = .init()
     ) async throws -> EnqueueResult {
-        try await _enqueue(
+        let rlParams = options.rateLimit.map { $0.slotParams(for: A.name) }
+        return try await _enqueue(
             queue: options.queue ?? queueName,
             taskName: A.name,
             params: input,
@@ -118,7 +122,9 @@ public struct StrandClient: Sendable {
             fairnessKey: options.fairnessKey,
             fairnessWeight: options.fairnessWeight,
             kind: .activity,
-            parentTaskID: nil
+            parentTaskID: nil,
+            rateLimitKey: rlParams?.slotKey,
+            rateLimitIntervalMs: rlParams?.intervalMs
         )
     }
 
@@ -317,7 +323,9 @@ public struct StrandClient: Sendable {
         fairnessKey: String? = nil,
         fairnessWeight: Double = 1.0,
         kind: TaskKind = .workflow,
-        parentTaskID: UUID? = nil
+        parentTaskID: UUID? = nil,
+        rateLimitKey: String? = nil,
+        rateLimitIntervalMs: Int? = nil
     ) async throws -> EnqueueResult {
         let deadlineAt: Date? = maxDuration.map { Date.now.addingDuration($0) }
         // Producer span: wraps the DB insert so that the context injected into
@@ -357,6 +365,8 @@ public struct StrandClient: Sendable {
                 kind: kind,
                 parentTaskID: parentTaskID,
                 parentClosePolicy: parentClosePolicy,
+                rateLimitKey: rateLimitKey,
+                rateLimitIntervalMs: rateLimitIntervalMs,
                 logger: logger
             )
             return EnqueueResult(

--- a/Sources/Strand/DB/Queries.swift
+++ b/Sources/Strand/DB/Queries.swift
@@ -167,6 +167,8 @@ enum Queries {
         firstTaskID: UUID? = nil,
         backfillID: UUID? = nil,
         parentClosePolicy: ParentClosePolicy? = nil,
+        rateLimitKey: String? = nil,
+        rateLimitIntervalMs: Int? = nil,
         logger: Logger
     ) async throws -> EnqueueRow {
         try await client.withTransaction(logger: logger) { conn in
@@ -217,6 +219,18 @@ enum Queries {
                         "strand.kind": .string(kind.rawValue),
                     ]
                 )
+                // Allocate a rate-limit slot when a RateLimit is set.
+                if let intervalMs = rateLimitIntervalMs {
+                    try await applyRateLimitSlots(
+                        on: conn,
+                        namespaceID: namespaceID,
+                        queues: [queue],
+                        slotKeys: [rateLimitKey ?? taskName],
+                        runIDs: [runID],
+                        intervalMses: [intervalMs],
+                        logger: logger
+                    )
+                }
                 // pg_notify is transactional — delivered only after this transaction commits.
                 try await conn.notifyWorkers(namespace: namespaceID, queue: queue, logger: logger)
                 // Write-through to trace_spans — atomic with the enqueue transaction.
@@ -260,6 +274,93 @@ enum Queries {
         }
     }
 
+    // MARK: - Rate-limit slot allocation
+
+    /// Allocates rate-limit slots for one or more runs in a single round-trip.
+    ///
+    /// Used by both `enqueueTask` (N=1) and `enqueueChildTasksBatch` (N≥1);
+    /// the same batch CTE handles both cases correctly.
+    ///
+    /// **Algorithm** (three CTE steps):
+    ///
+    /// 1. `ranked` — `UNNEST … WITH ORDINALITY` assigns each run its position
+    ///    (`rank 0…cnt-1`) within its `(queue, slot_key)` group.
+    ///
+    /// 2. `advanced` — one upsert per distinct `(queue, slot_key)` advances the
+    ///    cursor by `cnt × interval`.  The INSERT seeds new buckets at
+    ///    `NOW() + cnt × I` (task 0 is immediately available).  The
+    ///    `ON CONFLICT` arm applies `GREATEST(cursor, NOW())` before advancing,
+    ///    resetting a stale cursor on an idle queue to `NOW()`.
+    ///
+    /// 3. Final `UPDATE` sets each run's `available_at` using closed-form offsets:
+    ///    `cursor − (cnt − rank) × I = base + rank × I`
+    ///    where `base = GREATEST(old_cursor, NOW())`.
+    ///
+    /// - Parameters:
+    ///   - queues:       Queue name for each run (`text[]`).
+    ///   - slotKeys:     Rate-limit bucket key for each run (`text[]`).
+    ///   - runIDs:       `strand.runs.id` for each run (`uuid[]`).
+    ///   - intervalMses: Slot interval in milliseconds for each run (`int8[]`).
+    ///
+    /// All four arrays must be the same length and non-empty; the caller is
+    /// responsible for the guard (both call sites already check `!isEmpty`).
+    static func applyRateLimitSlots(
+        on conn: PostgresConnection,
+        namespaceID: String,
+        queues: [String],
+        slotKeys: [String],
+        runIDs: [UUID],
+        intervalMses: [Int],
+        logger: Logger
+    ) async throws {
+        try await conn.query(
+            """
+            WITH
+            ranked AS (
+                SELECT
+                    queue, slot_key, run_id, interval_ms,
+                    (ROW_NUMBER() OVER (PARTITION BY queue, slot_key ORDER BY ord)
+                     - 1)::int AS rank,
+                    COUNT(*) OVER (PARTITION BY queue, slot_key)::int AS cnt
+                FROM UNNEST(\(queues), \(slotKeys), \(runIDs), \(intervalMses))
+                     WITH ORDINALITY AS t(queue, slot_key, run_id, interval_ms, ord)
+            ),
+            advanced AS (
+                INSERT INTO strand.rate_limit_slots
+                    (namespace_id, queue, slot_key, next_slot_at)
+                SELECT DISTINCT ON (queue, slot_key)
+                    \(namespaceID), queue, slot_key,
+                    NOW() + cnt * interval_ms * INTERVAL '1 millisecond'
+                FROM ranked
+                ORDER BY queue, slot_key
+                ON CONFLICT (namespace_id, queue, slot_key) DO UPDATE
+                    SET next_slot_at = GREATEST(
+                            strand.rate_limit_slots.next_slot_at, NOW()
+                        ) + (
+                            SELECT r2.cnt * r2.interval_ms FROM ranked r2
+                            WHERE  r2.queue    = excluded.queue
+                              AND  r2.slot_key = excluded.slot_key
+                            LIMIT  1
+                        ) * INTERVAL '1 millisecond'
+                RETURNING queue, slot_key, next_slot_at AS cursor
+            )
+            UPDATE strand.runs
+            SET    available_at = GREATEST(
+                       available_at,
+                       a.cursor
+                           - (r.cnt - r.rank) * r.interval_ms
+                           * INTERVAL '1 millisecond'
+                   )
+            FROM   ranked r
+            JOIN   advanced a
+                   ON  a.queue    = r.queue
+                   AND a.slot_key = r.slot_key
+            WHERE  strand.runs.id = r.run_id
+            """,
+            logger: logger
+        )
+    }
+
     // MARK: - ChildEnqueueSpec
 
     /// One child task to enqueue as part of a batch spawned by a single workflow activation.
@@ -287,6 +388,12 @@ enum Queries {
         let fairnessKey: String?
         let fairnessWeight: Double
         let kind: TaskKind  // .activity or .workflow
+        /// Slot interval in milliseconds for the rate-limit bucket.
+        /// `nil` = no rate limiting; the run's `available_at` is unchanged.
+        let rateLimitIntervalMs: Int?
+        /// Rate-limit slot key.  `nil` falls back to `taskName` in the SQL.
+        /// Set to `"ActivityName:entityKey"` for per-entity buckets.
+        let rateLimitKey: String?
     }
 
     // MARK: - enqueueChildTasksBatch
@@ -455,6 +562,33 @@ enum Queries {
                         logger: logger
                     )
                 }
+            }
+
+            // ── 4b. Rate-limit slot allocation ──────────────────────────────────────────
+            // Collect rate-limited new children and forward to applyRateLimitSlots.
+            // Idempotency-hit tasks are excluded — their run already has the correct
+            // available_at from the original enqueue.  See applyRateLimitSlots for
+            // the full algorithm.
+            var rlQueues:       [String] = []
+            var rlSlotKeys:     [String] = []
+            var rlRunIDs:       [UUID]   = []
+            var rlIntervalMses: [Int]    = []
+            for child in newChildren where child.rateLimitIntervalMs != nil {
+                rlQueues.append(child.queue)
+                rlSlotKeys.append(child.rateLimitKey ?? child.taskName)
+                rlRunIDs.append(child.runID)
+                rlIntervalMses.append(child.rateLimitIntervalMs!)
+            }
+            if !rlRunIDs.isEmpty {
+                try await applyRateLimitSlots(
+                    on: conn,
+                    namespaceID: namespaceID,
+                    queues: rlQueues,
+                    slotKeys: rlSlotKeys,
+                    runIDs: rlRunIDs,
+                    intervalMses: rlIntervalMses,
+                    logger: logger
+                )
             }
 
             // ── 5. Notify workers — one pg_notify per distinct new child queue ────────

--- a/Sources/Strand/Enqueue.swift
+++ b/Sources/Strand/Enqueue.swift
@@ -78,6 +78,13 @@ public struct EnqueueOptions: Sendable {
     /// Only meaningful when multiple keys share the same queue and priority level.
     public var fairnessWeight: Double
 
+    /// Rate limit for this task.
+    ///
+    /// When non-nil, each enqueue atomically claims a time slot and sets the
+    /// run's `available_at` accordingly.  `nil` (the default) means no rate
+    /// limiting.  See ``RateLimit`` for full documentation.
+    public var rateLimit: RateLimit?
+
     public init(
         queue: String? = nil,
         maxAttempts: Int? = nil,
@@ -89,7 +96,8 @@ public struct EnqueueOptions: Sendable {
         delayUntil: Date? = nil,
         maxDuration: Duration? = nil,
         fairnessKey: String? = nil,
-        fairnessWeight: Double = 1.0
+        fairnessWeight: Double = 1.0,
+        rateLimit: RateLimit? = nil
     ) {
         self.queue = queue
         self.maxAttempts = maxAttempts
@@ -102,6 +110,7 @@ public struct EnqueueOptions: Sendable {
         self.maxDuration = maxDuration
         self.fairnessKey = fairnessKey
         self.fairnessWeight = max(fairnessWeight, 0.001)  // guard against divide-by-zero
+        self.rateLimit = rateLimit
     }
 }
 

--- a/Sources/Strand/Internal/WorkflowScheduling.swift
+++ b/Sources/Strand/Internal/WorkflowScheduling.swift
@@ -396,6 +396,7 @@ extension WorkflowRegistration {
                     let seqNum,
                     let idKey
                 ):
+                    let rlParams = options.rateLimit.map { $0.slotParams(for: name) }
                     pendingChildren.append(
                         Queries.ChildEnqueueSpec(
                             seqNum: seqNum,
@@ -418,7 +419,9 @@ extension WorkflowRegistration {
                             deadlineAt: options.maxDuration.map { activation.activationTime.addingDuration($0) },
                             fairnessKey: options.fairnessKey,
                             fairnessWeight: options.fairnessWeight,
-                            kind: .activity
+                            kind: .activity,
+                            rateLimitIntervalMs: rlParams?.intervalMs,
+                            rateLimitKey: rlParams?.slotKey
                         )
                     )
                     childHistoryItems.append(
@@ -681,7 +684,9 @@ extension WorkflowRegistration {
                             deadlineAt: childDeadlineAt,
                             fairnessKey: childFairnessKey,
                             fairnessWeight: childFairnessWeight,
-                            kind: .workflow
+                            kind: .workflow,
+                            rateLimitIntervalMs: nil,
+                            rateLimitKey: nil
                         )
                     )
                     childHistoryItems.append(

--- a/Tests/StrandTests/RateLimitTests.swift
+++ b/Tests/StrandTests/RateLimitTests.swift
@@ -1,0 +1,347 @@
+import Logging
+import NIOCore
+import PostgresNIO
+import Synchronization
+import Testing
+
+@testable import Strand
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+// MARK: - Fixtures
+
+private struct EchoInput: Codable, Sendable { let value: String }
+
+/// Minimal activity that returns its input — used to verify rate-limited
+/// activities still produce the correct result.
+private struct EchoActivity: Activity {
+    typealias Input  = EchoInput
+    typealias Output = String
+
+    func run(input: EchoInput, context: ActivityContext) async throws -> String {
+        input.value
+    }
+}
+
+/// Workflow that runs three EchoActivities sequentially, each under the same
+/// rate limit.  Returns the concatenated results so the test can confirm all
+/// three executed correctly.
+private struct ThreeEchoWorkflow: Workflow {
+    typealias Input  = StrandVoid
+    typealias Output = String
+
+    mutating func run(
+        context: WorkflowContext<Self>,
+        input: StrandVoid
+    ) async throws -> String {
+        // Very high rate (100/s = 10 ms gap) keeps tests fast while still
+        // exercising the slot-allocation path.
+        let rl = RateLimit(limit: 100, period: .seconds(1))
+        let a = try await context.runActivity(EchoActivity.self, input: .init(value: "A"), options: .init(rateLimit: rl))
+        let b = try await context.runActivity(EchoActivity.self, input: .init(value: "B"), options: .init(rateLimit: rl))
+        let c = try await context.runActivity(EchoActivity.self, input: .init(value: "C"), options: .init(rateLimit: rl))
+        return "\(a)\(b)\(c)"
+    }
+}
+
+// MARK: - Helpers
+
+/// Reads `available_at` for the most-recent PENDING/SLEEPING run of each
+/// task in `taskIDs`, ordered by creation time.
+private func fetchAvailableAt(
+    postgres: PostgresClient,
+    taskIDs: [UUID],
+    logger: Logger
+) async throws -> [UUID: Date] {
+    let stream = try await postgres.query(
+        """
+        SELECT DISTINCT ON (r.task_id) r.task_id, r.available_at
+        FROM strand.runs r
+        WHERE r.task_id = ANY(\(taskIDs))
+        ORDER BY r.task_id, r.attempt DESC
+        """,
+        logger: logger
+    )
+    var result: [UUID: Date] = [:]
+    for try await row in stream {
+        var col = row.makeIterator()
+        let tid = try col.next()!.decode(UUID.self, context: .default)
+        let at  = try col.next()!.decode(Date.self,  context: .default)
+        result[tid] = at
+    }
+    return result
+}
+
+// MARK: - Tests
+
+@Suite("Integration — Rate limiting", .tags(.integration), .serialized)
+struct RateLimitTests {
+
+    // ── 1 ────────────────────────────────────────────────────────────────────────
+    // Enqueuing three standalone activities with the same global key (nil) and a
+    // 1-per-second limit must allocate distinct, consecutive slots:
+    //   run 1 → available_at ≈ NOW        (no delay)
+    //   run 2 → available_at ≈ NOW + 1 s
+    //   run 3 → available_at ≈ NOW + 2 s
+    //
+    // This test inspects the DB directly so it doesn't need to wait for
+    // execution and is fast regardless of worker speed.
+    @Test("global key: three consecutive enqueues get 1-second-apart slots")
+    func globalKeySlotStagger() async throws {
+        try await withTestEnvironment { client in
+            let before = Date.now
+            let e1 = try await client.enqueueActivity(
+                EchoActivity.self, input: .init(value: "x"),
+                options: .init(rateLimit: .init(limit: 1, period: .seconds(1)))
+            )
+            let e2 = try await client.enqueueActivity(
+                EchoActivity.self, input: .init(value: "y"),
+                options: .init(rateLimit: .init(limit: 1, period: .seconds(1)))
+            )
+            let e3 = try await client.enqueueActivity(
+                EchoActivity.self, input: .init(value: "z"),
+                options: .init(rateLimit: .init(limit: 1, period: .seconds(1)))
+            )
+            let after = Date.now
+
+            let dates = try await fetchAvailableAt(
+                postgres: client.postgres,
+                taskIDs: [e1.taskID, e2.taskID, e3.taskID],
+                logger: client.logger
+            )
+
+            let at1 = try #require(dates[e1.taskID])
+            let at2 = try #require(dates[e2.taskID])
+            let at3 = try #require(dates[e3.taskID])
+
+            // Run 1: slot = first available → must be immediately claimable
+            // (≤ 200 ms after enqueue).
+            #expect(at1 <= after.addingTimeInterval(0.2),
+                    "run 1 should be immediately available, got \(at1)")
+
+            // Run 2: slot is 1 s after run 1's slot.
+            let gap12 = at2.timeIntervalSince(at1)
+            #expect(gap12 >= 0.9 && gap12 <= 1.1,
+                    "gap between run 1 and run 2 should be ~1 s, got \(gap12)")
+
+            // Run 3: slot is 1 s after run 2's slot.
+            let gap23 = at3.timeIntervalSince(at2)
+            #expect(gap23 >= 0.9 && gap23 <= 1.1,
+                    "gap between run 2 and run 3 should be ~1 s, got \(gap23)")
+
+            // Sanity: slots are strictly ordered.
+            #expect(at1 < at2 && at2 < at3,
+                    "available_at values must be strictly increasing")
+
+            _ = before  // suppress unused-variable warning
+        }
+    }
+
+    // ── 2 ────────────────────────────────────────────────────────────────────────
+    // Two different entity keys must have INDEPENDENT slot cursors.
+    // Each key's first run is immediately available, even when both are enqueued
+    // back-to-back with a tight rate limit.
+    @Test("per-entity keys have independent slot cursors")
+    func perKeyIndependence() async throws {
+        try await withTestEnvironment { client in
+            // Enqueue two tasks under key "alpha" and two under key "beta".
+            let alpha1 = try await client.enqueueActivity(
+                EchoActivity.self, input: .init(value: "a1"),
+                options: .init(rateLimit: .init(limit: 1, period: .seconds(10), key: "alpha"))
+            )
+            let beta1 = try await client.enqueueActivity(
+                EchoActivity.self, input: .init(value: "b1"),
+                options: .init(rateLimit: .init(limit: 1, period: .seconds(10), key: "beta"))
+            )
+            let alpha2 = try await client.enqueueActivity(
+                EchoActivity.self, input: .init(value: "a2"),
+                options: .init(rateLimit: .init(limit: 1, period: .seconds(10), key: "alpha"))
+            )
+            let beta2 = try await client.enqueueActivity(
+                EchoActivity.self, input: .init(value: "b2"),
+                options: .init(rateLimit: .init(limit: 1, period: .seconds(10), key: "beta"))
+            )
+
+            let dates = try await fetchAvailableAt(
+                postgres: client.postgres,
+                taskIDs: [alpha1.taskID, alpha2.taskID, beta1.taskID, beta2.taskID],
+                logger: client.logger
+            )
+
+            let atA1 = try #require(dates[alpha1.taskID])
+            let atA2 = try #require(dates[alpha2.taskID])
+            let atB1 = try #require(dates[beta1.taskID])
+            let atB2 = try #require(dates[beta2.taskID])
+
+            let now = Date.now
+
+            // First run under each key is immediately available.
+            #expect(atA1 <= now.addingTimeInterval(0.5),
+                    "alpha first run should be immediate, got \(atA1)")
+            #expect(atB1 <= now.addingTimeInterval(0.5),
+                    "beta first run should be immediate, got \(atB1)")
+
+            // Second run under each key is delayed by 10 s.
+            #expect(atA2.timeIntervalSince(atA1) >= 9.0,
+                    "alpha second run should be ~10 s after first, got gap \(atA2.timeIntervalSince(atA1))")
+            #expect(atB2.timeIntervalSince(atB1) >= 9.0,
+                    "beta second run should be ~10 s after first, got gap \(atB2.timeIntervalSince(atB1))")
+
+            // Cross-key: alpha and beta first runs don't block each other.
+            // Both should be near-simultaneous (within 1 s of each other).
+            let crossGap = abs(atA1.timeIntervalSince(atB1))
+            #expect(crossGap < 1.0,
+                    "alpha and beta first runs should be nearly simultaneous, gap=\(crossGap)")
+        }
+    }
+
+    // ── 3 ────────────────────────────────────────────────────────────────────────
+    // After an idle period the slot cursor resets to NOW via GREATEST(cursor, NOW()),
+    // so the next enqueue is IMMEDIATELY available — no artificial backlog.
+    @Test("idle reset: cursor resets after a gap so the next task is immediate")
+    func idleReset() async throws {
+        try await withTestEnvironment { client in
+            let key = "idle-reset-\(UUID().uuidString)"
+
+            // Enqueue one task to seed the cursor.
+            let first = try await client.enqueueActivity(
+                EchoActivity.self, input: .init(value: "seed"),
+                options: .init(rateLimit: .init(limit: 1, period: .seconds(1), key: key))
+            )
+
+            // The cursor is now at NOW + 1 s.  Wait 1.5 s so it falls into the past.
+            try await Task.sleep(for: .milliseconds(1_500))
+
+            // After the idle gap, the next enqueue should be immediately available
+            // (cursor reset by GREATEST(past_cursor, NOW()) = NOW).
+            let second = try await client.enqueueActivity(
+                EchoActivity.self, input: .init(value: "after-idle"),
+                options: .init(rateLimit: .init(limit: 1, period: .seconds(1), key: key))
+            )
+
+            let dates = try await fetchAvailableAt(
+                postgres: client.postgres,
+                taskIDs: [first.taskID, second.taskID],
+                logger: client.logger
+            )
+
+            let atSecond = try #require(dates[second.taskID])
+            let now = Date.now
+
+            // The second task should be immediately available (not 1 s in the future).
+            #expect(atSecond <= now.addingTimeInterval(0.3),
+                    "after idle period, next task should be immediately available, got \(atSecond)")
+        }
+    }
+
+    // ── 4 ────────────────────────────────────────────────────────────────────────
+    // Activities without a rate limit must NOT be delayed — their available_at
+    // should be NOW, regardless of whether a rate-limited activity with the same
+    // name was previously enqueued.
+    @Test("no rateLimit: activity is always immediately available")
+    func noRateLimitIsImmediate() async throws {
+        try await withTestEnvironment { client in
+            let e1 = try await client.enqueueActivity(
+                EchoActivity.self, input: .init(value: "no-limit")
+            )
+            let e2 = try await client.enqueueActivity(
+                EchoActivity.self, input: .init(value: "no-limit-2")
+            )
+            let e3 = try await client.enqueueActivity(
+                EchoActivity.self, input: .init(value: "no-limit-3")
+            )
+
+            let dates = try await fetchAvailableAt(
+                postgres: client.postgres,
+                taskIDs: [e1.taskID, e2.taskID, e3.taskID],
+                logger: client.logger
+            )
+
+            let now = Date.now
+            for (id, at) in dates {
+                #expect(at <= now.addingTimeInterval(0.3),
+                        "task \(id) without rateLimit should be immediately available, got \(at)")
+            }
+        }
+    }
+
+    // ── 5 ────────────────────────────────────────────────────────────────────────
+    // End-to-end: a workflow that schedules three rate-limited activities
+    // (100/s — fast enough for a test) must still complete with the correct
+    // result.  Verifies that rate limiting doesn't break the execution model.
+    @Test("workflow with rate-limited activities completes with correct result")
+    func workflowRateLimitedActivitiesCorrectResult() async throws {
+        try await withTestEnvironment { client in
+            let worker = startWorker(
+                postgres: client.postgres,
+                queueName: client.queueName,
+                logger: client.logger,
+                workflows: [ThreeEchoWorkflow.self],
+                activities: [EchoActivity()]
+            )
+            defer { worker.cancel() }
+
+            let handle = try await client.startWorkflow(
+                ThreeEchoWorkflow.self,
+                options: .init(),
+                input: .done
+            )
+            let result = try await handle.result(timeout: .seconds(15))
+            #expect(result == "ABC")
+        }
+    }
+
+    // ── 6 ────────────────────────────────────────────────────────────────────────
+    // The slot key is "ActivityName:entityKey" when a key is provided.
+    // Two activities with the SAME name but DIFFERENT entity keys must not
+    // interfere with each other (the slotKey includes the key component).
+    @Test("slot key includes entity key — same activity name, different keys are independent")
+    func slotKeyIncludesEntityKey() async throws {
+        try await withTestEnvironment { client in
+            // Enqueue under EchoActivity with key "customer:1" and "customer:2".
+            let c1a = try await client.enqueueActivity(
+                EchoActivity.self, input: .init(value: "c1-first"),
+                options: .init(rateLimit: .init(limit: 1, period: .seconds(5), key: "customer:1"))
+            )
+            let c2a = try await client.enqueueActivity(
+                EchoActivity.self, input: .init(value: "c2-first"),
+                options: .init(rateLimit: .init(limit: 1, period: .seconds(5), key: "customer:2"))
+            )
+            // Second tasks under each key — these should be delayed 5 s each.
+            let c1b = try await client.enqueueActivity(
+                EchoActivity.self, input: .init(value: "c1-second"),
+                options: .init(rateLimit: .init(limit: 1, period: .seconds(5), key: "customer:1"))
+            )
+            let c2b = try await client.enqueueActivity(
+                EchoActivity.self, input: .init(value: "c2-second"),
+                options: .init(rateLimit: .init(limit: 1, period: .seconds(5), key: "customer:2"))
+            )
+
+            let dates = try await fetchAvailableAt(
+                postgres: client.postgres,
+                taskIDs: [c1a.taskID, c1b.taskID, c2a.taskID, c2b.taskID],
+                logger: client.logger
+            )
+
+            let atC1a = try #require(dates[c1a.taskID])
+            let atC1b = try #require(dates[c1b.taskID])
+            let atC2a = try #require(dates[c2a.taskID])
+            let atC2b = try #require(dates[c2b.taskID])
+            let now   = Date.now
+
+            // First tasks for each customer: immediately available.
+            #expect(atC1a <= now.addingTimeInterval(0.5), "c1 first should be immediate")
+            #expect(atC2a <= now.addingTimeInterval(0.5), "c2 first should be immediate")
+
+            // Second tasks: delayed ~5 s within their own key.
+            #expect(atC1b.timeIntervalSince(atC1a) >= 4.5,
+                    "c1 second should be ~5 s after c1 first")
+            #expect(atC2b.timeIntervalSince(atC2a) >= 4.5,
+                    "c2 second should be ~5 s after c2 first")
+        }
+    }
+}

--- a/Tests/StrandTests/VersionTests.swift
+++ b/Tests/StrandTests/VersionTests.swift
@@ -27,8 +27,12 @@ private struct VersionedWorkflow: Workflow {
     typealias Output = String
 
     mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
-        // Sleep briefly so the test window can call markVersion before this point.
-        try await context.sleep(for: .milliseconds(200))
+        // Sleep long enough that the test has a comfortable window to write
+        // markVersion and have it commit well before the timer fires.
+        // 200 ms was too tight: on this machine the worker claims the sleeping
+        // run within ~15 ms of available_at, leaving markVersion's DB write
+        // racing listVersionMarkers on the same connection pool.
+        try await context.sleep(for: .seconds(2))
         let isNew = context.version(changeID: "v2-feature")
         return isNew ? "new-path" : "old-path"
     }
@@ -62,8 +66,8 @@ private struct TwoVersionWorkflow: Workflow {
     typealias Output = String
 
     mutating func run(context: WorkflowContext<Self>, input: String) async throws -> String {
-        // Sleep first so the test can mark version values before they are read.
-        try await context.sleep(for: .milliseconds(200))
+        // Sleep long enough that markVersion writes commit well before the timer fires.
+        try await context.sleep(for: .seconds(2))
         // Both calls use distinct changeIDs — each keyed independently.
         let isV2 = context.version(changeID: "multi-v2")
         let isV3 = context.version(changeID: "multi-v3")

--- a/strand.sql
+++ b/strand.sql
@@ -446,6 +446,13 @@ CREATE INDEX IF NOT EXISTS strand_runs_lease_idx
     ON strand.runs (namespace_id, queue, lease_expires_at)
     WHERE state = 'RUNNING'::text AND lease_expires_at IS NOT NULL;
 
+-- Supports cancelDescendants (run_terminate CTE), resetChildTasks (del_old_runs),
+-- and cancelTasksBatch when cancelling non-terminal runs by task_id.
+-- Without this index those CTEs perform a full sequential scan across all
+-- monthly partitions — observed at 1264 ms on workflows with many descendants.
+CREATE INDEX IF NOT EXISTS strand_runs_task_idx
+    ON strand.runs (task_id);
+
 -- ─────────────────────────────────────────────────────────────────────────────
 -- Checkpoints — sideEffect() / replay cache within a workflow activation.
 -- Keyed by (task_id, seq_num). Read at activation start; bypassed when hit.
@@ -966,6 +973,28 @@ CREATE UNLOGGED TABLE IF NOT EXISTS strand.workers (
 -- Live queue health lookup from the Workers dashboard page.
 CREATE INDEX IF NOT EXISTS strand_workers_ns_queue_idx
     ON strand.workers (namespace_id, queue);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Rate-limit slots — leaky-bucket slot scheduler for per-activity rate limits.
+--
+-- Each row tracks when the NEXT slot is available for a (namespace, queue, key)
+-- bucket.  When an activity with a RateLimit is enqueued, one round-trip
+-- atomically advances next_slot_at by the slot interval and sets the run's
+-- available_at to the allocated slot time.
+--
+-- GREATEST(next_slot_at, NOW()) in the upsert resets stale cursors so tasks
+-- enqueued into an idle queue are never artificially delayed.
+--
+-- No pruning required: stale rows (next_slot_at in the past) are harmless;
+-- the GREATEST guard resets them on next use.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS strand.rate_limit_slots (
+    namespace_id  TEXT        NOT NULL REFERENCES strand.namespaces(id) ON DELETE CASCADE,
+    queue         TEXT        NOT NULL,
+    slot_key      TEXT        NOT NULL,  -- activity name (global) or "ActivityName:entityKey"
+    next_slot_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT strand_rate_limit_slots_pkey PRIMARY KEY (namespace_id, queue, slot_key)
+);
 
 -- ───────────────────────────────────────────────────────────────────────────────
 -- Count estimate — fast approximate row counts for large tables.


### PR DESCRIPTION
## Summary

Adding activity rate limit

## Changes

- Activity rate limit
- Updated the GroundWaterPipeline to use rate limit as demo. This also mean that the pipeline goes from 3 minutes runtime to 15 minutes plus

## Testing

<!-- How did you verify this works? Did you run `swift test`? -->

- [x] `swift test` passes locally

## AI Disclosure

<!--
  REQUIRED if any AI assistance was used — see CONTRIBUTING.md.
  Delete this section entirely if no AI was involved.
-->

- [ ] I used AI assistance while working on this PR

**Tool(s) used:** <!-- e.g. Claude, Copilot, ChatGPT -->

**Extent of use:**
<!-- Describe honestly. Examples:
  - Generated first draft of WorkflowDag.tsx, reviewed and edited manually.
  - Used for commit message suggestions only.
  - Pair-programmed the entire feature; all output was reviewed.
-->

**Was the PR description itself AI-generated?** No
