### PR TITLE
Add run version checks for optimistic concurrency

### DIFF
--- a/Sources/Strand/DB/Queries.swift
+++ b/Sources/Strand/DB/Queries.swift
@@ -3045,7 +3045,7 @@ enum Queries {
             WITH
             ins_completion AS (
                 INSERT INTO strand.task_completions (namespace_id, task_id, state, result)
-                VALUES (\(namespaceID), \(taskID), \(state.rawValue), \(resultBuffer))
+                VALUES (\(namespaceID), \(taskID), \(state), \(resultBuffer))
                 ON CONFLICT (task_id) DO NOTHING
             ),
             flag_running AS (

--- a/Sources/Strand/DB/Queries.swift
+++ b/Sources/Strand/DB/Queries.swift
@@ -1048,11 +1048,28 @@ enum Queries {
         return queues
     }
 
-    /// Marks a run as failed and schedules a retry if attempts remain.
+    /// Transitions a RUNNING run to FAILED, then either schedules the next
+    /// retry attempt (if `maxAttempts` and `deadline_at` allow) or permanently
+    /// marks the task FAILED and signals the parent workflow.
+    ///
+    /// Steps executed inside a single transaction:
+    /// 1. Read the task’s retry policy, attempt counter, and hard deadline.
+    /// 2. CAS the run to FAILED — `AND version = $version` ensures only the
+    ///    worker that claimed this exact execution can fail it. A stale
+    ///    `runTask` whose run was swept back to PENDING and re-claimed by
+    ///    another worker finds 0 rows here and returns silently.
+    /// 3. Delete any dangling `event_waits` rows for this run.
+    /// 4. Update the OTel trace span to FAILED.
+    /// 5. If retries remain and no hard deadline has passed: compute the
+    ///    back-off delay, create a new PENDING run for attempt N+1, and
+    ///    transition the task row to PENDING so it becomes claimable.
+    /// 6. Otherwise: mark the task permanently FAILED and call
+    ///    `emitTaskCompletionSignal` to wake the parent workflow.
     static func failRun(
         on client: PostgresClient,
         namespaceID: String,
         runID: UUID,
+        version: Int,
         reasonBuffer: ByteBuffer,
         logger: Logger
     ) async throws {
@@ -1076,10 +1093,9 @@ enum Queries {
             let retryStrategyBuf = try col.next()!.decode(ByteBuffer?.self, context: .default)
             let deadlineAt = try col.next()!.decode(Date?.self, context: .default)
             let taskKind = try col.next()!.decode(TaskKind.self, context: .default)
-            // Guard: only fail if this run is still running.
-            // If another worker already processed it, bail out silently.
+            // Step 2 — CAS: only transitions the run that this worker claimed.
             let failStream = try await conn.query(
-                "UPDATE strand.runs SET state = \(TaskState.failed), failure_reason = \(reasonBuffer), finished_at = NOW() WHERE id = \(runID) AND state = \(TaskState.running) RETURNING id",
+                "UPDATE strand.runs SET state = \(TaskState.failed), failure_reason = \(reasonBuffer), finished_at = NOW() WHERE id = \(runID) AND state = \(TaskState.running) AND version = \(version) RETURNING id",
                 logger: logger
             )
             guard try await failStream.first(where: { _ in true }) != nil else { return }
@@ -1241,6 +1257,7 @@ enum Queries {
         on client: PostgresClient,
         namespaceID: String,
         runID: UUID,
+        version: Int,
         taskID: UUID,
         wakeAt: Date,
         logger: Logger
@@ -1251,12 +1268,16 @@ enum Queries {
                 UPDATE strand.runs
                 SET state = \(TaskState.sleeping), available_at = \(wakeAt),
                     lease_expires_at = NULL
-                WHERE id = \(runID) AND namespace_id = \(namespaceID)
+                WHERE id        = \(runID)
+                  AND state     = \(TaskState.running)
+                  AND version   = \(version)
+                  AND namespace_id = \(namespaceID)
                   AND created_at >= DATE_TRUNC('month', NOW()) - INTERVAL '1 month'
                 RETURNING id
             )
             UPDATE strand.tasks SET state = \(TaskState.sleeping)
             WHERE id = \(taskID) AND namespace_id = \(namespaceID)
+              AND EXISTS (SELECT 1 FROM r)
             """,
             logger: logger
         )
@@ -1882,6 +1903,7 @@ enum Queries {
         queue: String,
         taskID: UUID,
         runID: UUID,
+        version: Int,
         seqNum: Int,
         eventName: String,
         timeoutSeconds: Int?,
@@ -1925,10 +1947,13 @@ enum Queries {
                         SET state = \(TaskState.sleeping), available_at = \(timeoutAt),
                             wake_event = \(eventName), event_payload = NULL,
                             lease_expires_at = NULL
-                        WHERE id = \(runID)
+                        WHERE id      = \(runID)
+                          AND state   = \(TaskState.running)
+                          AND version = \(version)
                         RETURNING id
                     )
                     UPDATE strand.tasks SET state = \(TaskState.sleeping) WHERE id = \(taskID)
+                      AND EXISTS (SELECT 1 FROM r)
                     """,
                     logger: logger
                 )
@@ -1940,10 +1965,13 @@ enum Queries {
                         SET state = \(TaskState.waiting),
                             wake_event = \(eventName), event_payload = NULL,
                             lease_expires_at = NULL
-                        WHERE id = \(runID)
+                        WHERE id      = \(runID)
+                          AND state   = \(TaskState.running)
+                          AND version = \(version)
                         RETURNING id
                     )
                     UPDATE strand.tasks SET state = \(TaskState.waiting) WHERE id = \(taskID)
+                      AND EXISTS (SELECT 1 FROM r)
                     """,
                     logger: logger
                 )
@@ -2424,6 +2452,7 @@ enum Queries {
                 WHERE worker_id    = \(workerID)
                   AND namespace_id = \(namespaceID)
                   AND state        = \(TaskState.running)
+                  AND created_at  >= DATE_TRUNC('month', NOW()) - INTERVAL '1 month'
             )
             DELETE FROM strand.workers
             WHERE id           = \(workerID)

--- a/Sources/Strand/Internal/WorkflowRegistration.swift
+++ b/Sources/Strand/Internal/WorkflowRegistration.swift
@@ -291,6 +291,7 @@ struct WorkflowRegistration<W: Workflow>: Sendable {
         let activation = _WorkflowActivation<W>(
             taskUUID: claimed.taskID,
             runUUID: claimed.runID,
+            runVersion: claimed.version,
             taskName: claimed.taskName,
             queueName: exec.queue,
             attempt: claimed.attempt,

--- a/Sources/Strand/Internal/WorkflowScheduling.swift
+++ b/Sources/Strand/Internal/WorkflowScheduling.swift
@@ -461,7 +461,9 @@ extension WorkflowRegistration {
                                                    THEN NOW()
                                                    ELSE \(wakeAt) END,
                                 lease_expires_at = NULL
-                            WHERE id = \(claimed.runID)
+                            WHERE id      = \(claimed.runID)
+                              AND state   = \(TaskState.running)
+                              AND version = \(claimed.version)
                             RETURNING state
                         )
                         UPDATE strand.tasks
@@ -617,7 +619,9 @@ extension WorkflowRegistration {
                                                            ELSE \(eventName) END,
                                         event_payload = NULL,
                                         lease_expires_at = NULL
-                                    WHERE id = \(runID)
+                                    WHERE id      = \(runID)
+                                      AND state   = \(TaskState.running)
+                                      AND version = \(claimed.version)
                                     RETURNING state
                                 )
                                 UPDATE strand.tasks

--- a/Sources/Strand/Worker.swift
+++ b/Sources/Strand/Worker.swift
@@ -726,6 +726,7 @@ public struct StrandWorker: Service {
                     on: postgres,
                     namespaceID: namespace,
                     runID: claimed.runID,
+                    version: claimed.version,
                     taskID: claimed.taskID,
                     wakeAt: wakeAt,
                     logger: taskLogger
@@ -1049,6 +1050,7 @@ public struct StrandWorker: Service {
                 on: postgres,
                 namespaceID: namespace,
                 runID: claimed.runID,
+                version: claimed.version,
                 reasonBuffer: reasonBuffer,
                 logger: logger
             )

--- a/Sources/Strand/WorkflowContext.swift
+++ b/Sources/Strand/WorkflowContext.swift
@@ -123,6 +123,10 @@ final class _WorkflowActivation<W: Workflow>: @unchecked Sendable {
 
     let taskUUID: UUID
     let runUUID: UUID
+    /// Optimistic-concurrency version of the run row when this activation was claimed.
+    /// Passed to `scheduleRun` and `awaitEvent` so stale activations cannot transition
+    /// a re-claimed run to the wrong state.
+    let runVersion: Int
     let taskName: String
     let queueName: String
     let attempt: Int
@@ -190,6 +194,7 @@ final class _WorkflowActivation<W: Workflow>: @unchecked Sendable {
     init(
         taskUUID: UUID,
         runUUID: UUID,
+        runVersion: Int,
         taskName: String,
         queueName: String,
         attempt: Int,
@@ -211,6 +216,7 @@ final class _WorkflowActivation<W: Workflow>: @unchecked Sendable {
     ) {
         self.taskUUID = taskUUID
         self.runUUID = runUUID
+        self.runVersion = runVersion
         self.taskName = taskName
         self.queueName = queueName
         self.attempt = attempt
@@ -278,18 +284,6 @@ final class _WorkflowActivation<W: Workflow>: @unchecked Sendable {
             logger: logger
         )
         cacheCheckpoint(seqNum: seqNum, name: name, buffer: buffer)
-    }
-
-    /// Transitions the run to SLEEPING at `wakeAt` via a DB update.
-    func scheduleRun(wakeAt: Date) async throws {
-        try await Queries.scheduleRun(
-            on: postgres,
-            namespaceID: namespace,
-            runID: runUUID,
-            taskID: taskUUID,
-            wakeAt: wakeAt,
-            logger: logger
-        )
     }
 
     /// Extends the worker claim lease by `seconds` seconds.

--- a/Sources/StrandTesting/StrandTesting.swift
+++ b/Sources/StrandTesting/StrandTesting.swift
@@ -154,6 +154,7 @@ public func withTestEnvironment<T: Sendable>(
             DELETE FROM strand.schedules   WHERE queue = q;
             DELETE FROM strand.events      WHERE queue = q;
             DELETE FROM strand.event_waits WHERE queue = q;
+            DELETE FROM strand.runs        WHERE task_id IN (SELECT id FROM strand.tasks WHERE queue = q);
             DELETE FROM strand.tasks       WHERE queue = q;
             DELETE FROM strand.queues      WHERE name  = q;
           END LOOP;
@@ -177,6 +178,13 @@ public func withTestEnvironment<T: Sendable>(
             )
             try await postgres.query(
                 "DELETE FROM strand.event_waits WHERE queue = \(queueName)",
+                logger: logger
+            )
+            // strand.runs has no FK cascade to strand.tasks, so orphaned run rows
+            // accumulate and cause full seq-scans in shutdownWorker. Delete runs
+            // before tasks (tasks deletion order doesn't matter — no FK between them).
+            try await postgres.query(
+                "DELETE FROM strand.runs WHERE task_id IN (SELECT id FROM strand.tasks WHERE queue = \(queueName))",
                 logger: logger
             )
             try await postgres.query(

--- a/Sources/StrandTesting/StrandTesting.swift
+++ b/Sources/StrandTesting/StrandTesting.swift
@@ -403,6 +403,47 @@ public func awaitScheduleRunCount(
     )
 }
 
+// MARK: - awaitAnyTask
+
+/// Polls `listTasks` until at least one task named `taskName` in the client's
+/// queue has reached `state`, or throws ``StrandTestError`` on `timeout`.
+///
+/// Useful when `continueAsNew` creates independent new tasks whose IDs are
+/// unknown at test time — poll by name and target state instead of task ID.
+///
+/// ```swift
+/// // Wait for the terminal ContinueWorkflow generation to complete
+/// try await awaitAnyTask(client: client, taskName: "ContinueWorkflow",
+///                        state: .completed, timeout: .seconds(15))
+/// ```
+public func awaitAnyTask(
+    client: StrandClient,
+    taskName: String,
+    state: TaskState,
+    timeout: Duration = .seconds(10),
+    label: String? = nil
+) async throws {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+        let stream = try await client.postgres.query(
+            """
+            SELECT 1 FROM strand.tasks
+            WHERE namespace_id = \(client.namespaceID)
+              AND queue        = \(client.queueName)
+              AND name         = \(taskName)
+              AND state        = \(state)
+            LIMIT 1
+            """,
+            logger: client.logger
+        )
+        if (try await stream.first(where: { _ in true })) != nil { return }
+        try await Task.sleep(for: .milliseconds(200))
+    }
+    throw StrandTestError(
+        label ?? "no '\(taskName)' task reached state '\(state.rawValue)' within \(timeout)"
+    )
+}
+
 // MARK: - awaitTerminal
 
 /// Polls until `taskID` reaches a terminal state (completed / failed / cancelled)

--- a/Tests/StrandTests/ContinueAsNewTests.swift
+++ b/Tests/StrandTests/ContinueAsNewTests.swift
@@ -72,8 +72,8 @@ struct ContinueAsNewTests {
 
     // ── 1 ───────────────────────────────────────────────────────────────────
     // A workflow that calls continueAsNew once produces a new PENDING task and
-    // marks the old one COMPLETED (or CONTINUED_AS_NEW). The new task is then
-    // claimed by the worker and runs to completion.
+    // marks the old one CONTINUED_AS_NEW. The new task is then claimed by the
+    // worker and runs to completion.
     @Test("continueAsNew enqueues a fresh task that runs to completion")
     func basicContinueAsNew() async throws {
         try await withTestEnvironment { client in
@@ -83,27 +83,27 @@ struct ContinueAsNewTests {
                 logger: client.logger,
                 workflows: [InfiniteWorkflow.self]
             ) {
-                // Start at generation 0 — will continueAsNew to generation 1.
-                // The second run (generation 1) returns 1.
-                // We can't use handle.result() on the original task since it
-                // continuedAsNew; instead we wait for a reasonable time and then
-                // verify via the task state.
                 let handle = try await client.startWorkflow(
                     InfiniteWorkflow.self,
                     options: .init(),
                     input: InfiniteInput(generation: 0)
                 )
 
-                // Allow time for both the original and the continued task to run.
-                try await Task.sleep(for: .seconds(3))
-
-                // The original task should be in a terminal state.
-                if let snap = try await client.fetchTaskResult(id: handle.taskID) {
-                    #expect(
-                        snap.state == .completed || snap.state == .continuedAsNew,
-                        "original task should be terminal, got \(snap.state)"
-                    )
-                }
+                // Wait for the original task to reach a terminal state.
+                // `continueAsNew` transitions it to CONTINUED_AS_NEW, not COMPLETED.
+                // We cannot call handle.result() because the handle points to a
+                // continued task — instead use awaitSnapshot with the full set of
+                // terminal states.
+                let snap = try await awaitSnapshot(
+                    handle,
+                    where: { [.completed, .continuedAsNew, .failed, .cancelled].contains($0.state) },
+                    timeout: .seconds(10),
+                    label: "InfiniteWorkflow generation-0 terminal state"
+                )
+                #expect(
+                    snap.state == .completed || snap.state == .continuedAsNew,
+                    "original task should be COMPLETED or CONTINUED_AS_NEW, got \(snap.state)"
+                )
             }
         }
     }
@@ -126,19 +126,33 @@ struct ContinueAsNewTests {
             ) {
                 // Start the chain: count=0, limit=3.
                 // Generations: 0 (→CAN), 1 (→CAN), 2 (→CAN), 3 (returns 3).
-                _ = try await client.startWorkflow(
+                let handle = try await client.startWorkflow(
                     ContinueWorkflow.self,
                     options: .init(),
                     input: ContinueInput(count: 0, limit: 3)
                 )
 
-                // Give all four generations time to run.
-                try await Task.sleep(for: .seconds(5))
+                // Step 1: wait for generation 0 to become CONTINUED_AS_NEW.
+                // continueAsNew on a root workflow creates an independent new task;
+                // the original handle transitions to CONTINUED_AS_NEW, not COMPLETED.
+                _ = try await awaitSnapshot(
+                    handle,
+                    where: { $0.state == .continuedAsNew || $0.state == .completed },
+                    timeout: .seconds(10),
+                    label: "ContinueWorkflow generation-0 continued"
+                )
 
-                // Verify by checking that at least one task for ContinueWorkflow
-                // is now COMPLETED (the terminal generation).
-                let queues = try await client.listQueues()
-                #expect(queues.contains(client.queueName))
+                // Step 2: wait for the terminal generation (count == 3) to COMPLETE.
+                // continueAsNew creates independent tasks with no parent-child link,
+                // so we don't have a direct handle to the final generation — use
+                // awaitAnyTask to poll by name and state instead.
+                try await awaitAnyTask(
+                    client: client,
+                    taskName: "ContinueWorkflow",
+                    state: .completed,
+                    timeout: .seconds(15),
+                    label: "terminal ContinueWorkflow generation (count == 3)"
+                )
             }
         }
     }

--- a/strand.sql
+++ b/strand.sql
@@ -446,6 +446,14 @@ CREATE INDEX IF NOT EXISTS strand_runs_lease_idx
     ON strand.runs (namespace_id, queue, lease_expires_at)
     WHERE state = 'RUNNING'::text AND lease_expires_at IS NOT NULL;
 
+-- Supports shutdownWorker: UPDATE strand.runs SET lease_expires_at = NOW()
+-- WHERE worker_id = $1 AND namespace_id = $2 AND state = 'RUNNING'.
+-- Without this, shutdown scans the entire partition to find each worker's
+-- in-flight runs — observed at 1+ s on dev DBs with 500k+ historical rows.
+CREATE INDEX IF NOT EXISTS strand_runs_worker_idx
+    ON strand.runs (namespace_id, worker_id)
+    WHERE state = 'RUNNING'::text;
+
 -- Supports cancelDescendants (run_terminate CTE), resetChildTasks (del_old_runs),
 -- and cancelTasksBatch when cancelling non-terminal runs by task_id.
 -- Without this index those CTEs perform a full sequential scan across all


### PR DESCRIPTION
## Summary

Fixed an issue where there could be two instances of a task still running after cancellation was requested

## Changes

- Optimistic concurrency check
- Added Index to runs so that when a worker shutdown it does not do a sequential scan to release any tasks that were in precess

## Testing

<!-- How did you verify this works? Did you run `swift test`? -->

- [x] `swift test` passes locally

## AI Disclosure

<!--
  REQUIRED if any AI assistance was used — see CONTRIBUTING.md.
  Delete this section entirely if no AI was involved.
-->

- [ ] I used AI assistance while working on this PR

**Tool(s) used:** <!-- e.g. Claude, Copilot, ChatGPT -->

**Extent of use:**
<!-- Describe honestly. Examples:
  - Generated first draft of WorkflowDag.tsx, reviewed and edited manually.
  - Used for commit message suggestions only.
  - Pair-programmed the entire feature; all output was reviewed.
-->

**Was the PR description itself AI-generated?** No
