### PR TITLE
Adding retry after error

### DIFF
--- a/Sources/Strand/DB/Queries.swift
+++ b/Sources/Strand/DB/Queries.swift
@@ -940,9 +940,16 @@ enum Queries {
         if taskWasCancelled { throw InternalError.cancelled }
     }
 
-    private struct _NRFlag: Decodable { let non_retryable: Bool? }
+    private struct _NRFlag: Decodable {
+        let nonRetryable: Bool?
+        enum CodingKeys: String, CodingKey { case nonRetryable = "non_retryable" }
+    }
     private struct _ErrorType: Decodable { let name: String? }
     private struct _FailureMessage: Decodable { let message: String? }
+    private struct _NextRetryDelay: Decodable {
+        let nextRetryDelaySeconds: Double?
+        enum CodingKeys: String, CodingKey { case nextRetryDelaySeconds = "next_retry_delay_seconds" }
+    }
 
     /// Recursively processes all non-terminal descendants of `parentTaskID` when the parent
     /// workflow permanently fails.
@@ -1120,7 +1127,7 @@ enum Queries {
             // ── Check 0: non_retryable flag (from NonRetryableError protocol) ──────────
             // Activities whose Failure type conforms to NonRetryableError encode
             // `non_retryable: true` in the failure payload. Skip retry immediately.
-            if (try? JSON.decode(_NRFlag.self, from: reasonBuffer))?.non_retryable == true {
+            if (try? JSON.decode(_NRFlag.self, from: reasonBuffer))?.nonRetryable == true {
                 try await conn.query(
                     "UPDATE strand.tasks SET state = \(TaskState.failed), attempt = \(attempt) WHERE id = \(taskID) AND namespace_id = \(namespaceID)",
                     logger: logger
@@ -1213,7 +1220,13 @@ enum Queries {
                 }
                 return
             }
-            let delay = retryDelay(strategy: retryStrategyBuf, attempt: attempt)
+            // Use a per-error override if the thrown error conforms to RetryAfterError
+            // (e.g. HTTP 429 with a Retry-After header).  Falls back to the configured
+            // RetryStrategy when no override is present.
+            let overrideDelay = (try? JSON.decode(_NextRetryDelay.self, from: reasonBuffer))
+                .flatMap { $0.nextRetryDelaySeconds }
+                .flatMap { $0 > 0 ? $0 : nil }
+            let delay = overrideDelay ?? retryDelay(strategy: retryStrategyBuf, attempt: attempt)
             let wakeAt = Date.now.addingTimeInterval(delay)
             let newState: TaskState = delay > 0 ? .sleeping : .pending
             let newRunID = UUID.v7()

--- a/Sources/Strand/Errors.swift
+++ b/Sources/Strand/Errors.swift
@@ -164,6 +164,69 @@ func strandErrorMessage(_ error: any Error) -> String {
 /// ```
 public protocol NonRetryableError: Error {}
 
+// MARK: - RetryAfterError
+
+/// Conforming errors carry a server-side retry delay that overrides the task's
+/// configured `RetryStrategy` backoff **for the next attempt only**.
+///
+/// Use this when the failure contains authoritative retry guidance — for example,
+/// a `Retry-After` HTTP header from a rate-limited API — that should take
+/// precedence over the local exponential backoff schedule:
+///
+/// ```swift
+/// struct RateLimitError: Error, RetryAfterError {
+///     let retryAfter: Duration
+///     var nextRetryDelay: Duration { retryAfter }
+/// }
+///
+/// // In an activity:
+/// func run(input: Input, context: ActivityContext) async throws -> Output {
+///     let response = try await apiClient.fetch(input.url)
+///     if response.statusCode == 429 {
+///         let seconds = Int(response.headers["Retry-After"] ?? "60") ?? 60
+///         throw RateLimitError(retryAfter: .seconds(seconds))
+///     }
+///     // ...
+/// }
+/// ```
+///
+/// Unlike `NonRetryableError`, conforming does **not** consume the retry budget.
+/// The task is retried on the normal schedule except that `nextRetryDelay`
+/// replaces the backoff computation for the single upcoming retry.
+/// Subsequent retries (if any) return to the configured `RetryStrategy`.
+public protocol RetryAfterError: Error {
+    /// The duration to wait before the next retry attempt.
+    var nextRetryDelay: Duration { get }
+}
+
+/// Ready-made ``RetryAfterError`` for one-liners at the throw site.
+///
+/// Use this when you don't want to define a dedicated error type:
+///
+/// ```swift
+/// if response.statusCode == 429 {
+///     let delay = Int(response.headers["Retry-After"] ?? "60") ?? 60
+///     throw RetryAfterDelay(.seconds(delay), "GitHub rate-limited")
+/// }
+/// ```
+///
+/// For strongly-typed errors (recommended when you need to `catch` the specific
+/// case in a workflow), define your own type that conforms to ``RetryAfterError``
+/// instead.
+public struct RetryAfterDelay: Error, RetryAfterError, CustomStringConvertible, Sendable {
+    public let nextRetryDelay: Duration
+    public let description:    String
+
+    /// - Parameters:
+    ///   - delay:   How long to wait before the next attempt.
+    ///   - message: Human-readable reason stored in the failure record.
+    ///              Defaults to `"Retry after \(delay)"` when omitted.
+    public init(_ delay: Duration, _ message: String? = nil) {
+        self.nextRetryDelay = delay
+        self.description    = message ?? "Retry after \(delay)"
+    }
+}
+
 // MARK: - Internal failure signals
 
 /// Pre-encoded activity failure reason thrown from `Activity._run`.
@@ -182,12 +245,20 @@ struct _TypedActivityFailure: Error, CustomStringConvertible {
     private struct _Payload: Encodable {
         let name: String
         let message: String
-        let non_retryable: Bool?
+        let nonRetryable: Bool?
         let payload: Data?  // synthesised Encodable base64-encodes Data automatically
         let source: _Source?
+        enum CodingKeys: String, CodingKey {
+            case name, message, payload, source
+            case nonRetryable = "non_retryable"
+        }
         struct _Source: Encodable {
-            let file_id: String
+            let fileId: String
             let line: Int
+            enum CodingKeys: String, CodingKey {
+                case fileId = "file_id"
+                case line
+            }
         }
     }
 
@@ -215,9 +286,9 @@ struct _TypedActivityFailure: Error, CustomStringConvertible {
         let p = _Payload(
             name: name,
             message: message,
-            non_retryable: nonRetryable ? true : nil,
+            nonRetryable: nonRetryable ? true : nil,
             payload: payload.map { Data($0.readableBytesView) },
-            source: source.map { _Payload._Source(file_id: $0.fileID, line: $0.line) }
+            source: source.map { _Payload._Source(fileId: $0.fileID, line: $0.line) }
         )
         // If encoding fails (essentially never) fall back to a static safe string.
         // We can't trust arbitrary content in `name` for manual JSON escaping,

--- a/Sources/Strand/Strand.docc/RetryStrategies.md
+++ b/Sources/Strand/Strand.docc/RetryStrategies.md
@@ -114,6 +114,51 @@ options: ActivityOptions(
 )
 ```
 
+## Server-directed retry delay
+
+Some failures carry authoritative retry guidance — for example, an HTTP `429`
+response with a `Retry-After` header specifying exactly how long the server
+needs before it will accept the request again. Hardcoding that into your
+`RetryStrategy` is impractical because the duration changes per response.
+
+Conform your error to ``RetryAfterError`` and Strand will use `nextRetryDelay`
+instead of the configured backoff **for the single upcoming retry**. All
+subsequent retries resume the normal `RetryStrategy`:
+
+```swift
+// Strongly-typed — preferred when you need to catch the specific case:
+struct RateLimitError: Error, RetryAfterError {
+    let retryAfter: Duration
+    var nextRetryDelay: Duration { retryAfter }
+}
+
+func run(input: Input, context: ActivityContext) async throws -> Output {
+    let response = try await apiClient.fetch(input.url)
+    if response.statusCode == 429 {
+        let seconds = Int(response.headers["Retry-After"] ?? "60") ?? 60
+        throw RateLimitError(retryAfter: .seconds(seconds))
+    }
+    return try decode(response.body)
+}
+```
+
+For quick one-liners where a dedicated type isn't needed, use the built-in
+``RetryAfterDelay``:
+
+```swift
+if response.statusCode == 429 {
+    let seconds = Int(response.headers["Retry-After"] ?? "60") ?? 60
+    throw RetryAfterDelay(.seconds(seconds), "GitHub rate-limited")
+}
+```
+
+Both approaches produce a ``SLEEPING`` run that wakes at exactly the
+server-specified time rather than the next backoff step.
+
+> Important: `RetryAfterError` **does not** consume the retry budget. The
+> task is retried as normal — only the delay for the next attempt changes.
+> To stop retrying entirely, additionally conform to ``NonRetryableError``.
+
 ## Worker-level defaults
 
 Set defaults applied to every task claimed by a worker via ``StrandOptions``:

--- a/Sources/Strand/Worker.swift
+++ b/Sources/Strand/Worker.swift
@@ -1117,10 +1117,16 @@ final class FailureReason: Codable, Sendable {
     /// `.maximumAttemptsReached`) or when any `NonRetryableError` propagates uncaught.
     /// Catch the error in the workflow handler and re-throw a plain error to opt out.
     let nonRetryable: Bool?
+    /// Seconds to wait before the next retry, overriding the task's `RetryStrategy`.
+    /// Populated from errors conforming to `RetryAfterError` (e.g. HTTP 429 with a
+    /// `Retry-After` header).  Only the *next* retry is affected; subsequent retries
+    /// return to the configured strategy.
+    let nextRetryDelaySeconds: Double?
 
     enum CodingKeys: String, CodingKey {
         case name, message, cause, source
-        case nonRetryable = "non_retryable"
+        case nonRetryable          = "non_retryable"
+        case nextRetryDelaySeconds = "next_retry_delay_seconds"
     }
 
     struct SourceLocation: Codable, Sendable {
@@ -1160,6 +1166,15 @@ final class FailureReason: Codable, Sendable {
         }
         let root = (error as? CallSiteAnnotatedError)?.underlying ?? error
         nonRetryable = FailureReason.isNonRetryable(root) ? true : nil
+        // Capture a server-specified retry delay if the error carries one.
+        // Consistent with the rest of the codebase: only whole seconds matter
+        // for retry scheduling, attoseconds are irrelevant.
+        if let rae = root as? any RetryAfterError {
+            let secs = Double(rae.nextRetryDelay.components.seconds)
+            nextRetryDelaySeconds = secs > 0 ? secs : nil
+        } else {
+            nextRetryDelaySeconds = nil
+        }
     }
 
     private static func isNonRetryable(_ error: any Error) -> Bool {


### PR DESCRIPTION
## Summary

Adding retry after. A use case for this is when calling external systems and receiving 429 error

## Changes

RetryAfter Error which does not consume an attempt slot

## Testing

<!-- How did you verify this works? Did you run `swift test`? -->

- [x] `swift test` passes locally

## AI Disclosure

<!--
  REQUIRED if any AI assistance was used — see CONTRIBUTING.md.
  Delete this section entirely if no AI was involved.
-->

- [ ] I used AI assistance while working on this PR

**Tool(s) used:** <!-- e.g. Claude, Copilot, ChatGPT -->

**Extent of use:**
<!-- Describe honestly. Examples:
  - Generated first draft of WorkflowDag.tsx, reviewed and edited manually.
  - Used for commit message suggestions only.
  - Pair-programmed the entire feature; all output was reviewed.
-->

**Was the PR description itself AI-generated?** No
