### PR TITLE
Prevent deadlocks in worker shutdown query

### DIFF
--- a/Sources/Strand/DB/Queries.swift
+++ b/Sources/Strand/DB/Queries.swift
@@ -2810,10 +2810,18 @@ enum Queries {
             WITH expire_runs AS (
                 UPDATE strand.runs
                 SET lease_expires_at = NOW()
-                WHERE worker_id    = \(workerID)
-                  AND namespace_id = \(namespaceID)
-                  AND state        = \(TaskState.running)
-                  AND created_at  >= DATE_TRUNC('month', NOW()) - INTERVAL '1 month'
+                WHERE id = ANY(
+                    -- Subquery with ORDER BY id ensures all concurrent shutdownWorker
+                    -- calls acquire row locks in the same order, preventing deadlocks
+                    -- when multiple workers shut down simultaneously.
+                    SELECT id FROM strand.runs
+                    WHERE  worker_id    = \(workerID)
+                      AND  namespace_id = \(namespaceID)
+                      AND  state        = \(TaskState.running)
+                      AND  created_at  >= DATE_TRUNC('month', NOW()) - INTERVAL '1 month'
+                    ORDER BY id
+                    FOR UPDATE
+                )
             )
             DELETE FROM strand.workers
             WHERE id           = \(workerID)


### PR DESCRIPTION
## Summary

Prevent deadlock on worker shutdown 

## Changes

- Deadlock on worker shutdown

## Testing

<!-- How did you verify this works? Did you run `swift test`? -->

- [x] `swift test` passes locally

## AI Disclosure

<!--
  REQUIRED if any AI assistance was used — see CONTRIBUTING.md.
  Delete this section entirely if no AI was involved.
-->

- [ ] I used AI assistance while working on this PR

**Tool(s) used:** <!-- e.g. Claude, Copilot, ChatGPT -->

**Extent of use:**
<!-- Describe honestly. Examples:
  - Generated first draft of WorkflowDag.tsx, reviewed and edited manually.
  - Used for commit message suggestions only.
  - Pair-programmed the entire feature; all output was reviewed.
-->

**Was the PR description itself AI-generated?** NO
